### PR TITLE
Introduce package level `lvalueInit`

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -1901,16 +1901,15 @@ void move(T)(ref T source, ref T target)
         // object in order to avoid double freeing and undue aliasing
         static if (hasElaborateDestructor!T || hasElaborateCopyConstructor!T)
         {
-            static T empty;
             static if (T.tupleof.length > 0 &&
                        T.tupleof[$-1].stringof.endsWith("this"))
             {
                 // If T is nested struct, keep original context pointer
-                memcpy(&source, &empty, T.sizeof - (void*).sizeof);
+                memcpy(&source, &lvalueInit!T, T.sizeof - (void*).sizeof);
             }
             else
             {
-                memcpy(&source, &empty, T.sizeof);
+                memcpy(&source, &lvalueInit!T, T.sizeof);
             }
         }
     }
@@ -1974,6 +1973,22 @@ unittest
     assert(s42.x.n == 1);
 }
 
+unittest
+{
+    static struct S
+    {
+        int i;
+        @disable this();
+        @disable this(this);
+        void opAssign(S){assert(0);}
+        ~this(){}
+    }
+    S a = S.init;
+    S b = void;
+    a.move(b);
+    b.move();
+}
+
 /// Ditto
 T move(T)(ref T source)
 {
@@ -1994,16 +2009,15 @@ T move(T)(ref T source)
         // object in order to avoid double freeing and undue aliasing
         static if (hasElaborateDestructor!T || hasElaborateCopyConstructor!T)
         {
-            static T empty;
             static if (T.tupleof.length > 0 &&
                        T.tupleof[$-1].stringof.endsWith("this"))
             {
                 // If T is nested struct, keep original context pointer
-                memcpy(&source, &empty, T.sizeof - (void*).sizeof);
+                memcpy(&source, &lvalueInit!T, T.sizeof - (void*).sizeof);
             }
             else
             {
-                memcpy(&source, &empty, T.sizeof);
+                memcpy(&source, &lvalueInit!T, T.sizeof);
             }
         }
     }

--- a/std/conv.d
+++ b/std/conv.d
@@ -3975,8 +3975,7 @@ private ref T emplaceInitializer(T)(ref T chunk) @trusted pure nothrow
         chunk = T.init;
     else
     {
-        static immutable T init = T.init;
-        memcpy(&chunk, &init, T.sizeof);
+        memcpy(&chunk, &lvalueInit!T, T.sizeof);
     }
     return chunk;
 }

--- a/std/traits.d
+++ b/std/traits.d
@@ -4543,6 +4543,40 @@ unittest
     static assert(!__traits(compiles, lvalueOf!byte = 128));
 }
 
+/+
+Given a type $(D T), $(D lvalueInit) represents a unique instance of $(D T)
+initialized to $(D T.init). $(D lvalueInit) is always immutable, regardless
+of $(D T)'s qualifiers.
+
+$(D lvalueInit) is useful when one needs a reference the $(D .init) value,
+without creating duplicate static instances, or temporaries that would require
+destruction.
++/
+package template lvalueInit(T)
+{
+    static if (is(T == immutable(T)))
+        static lvalueInit = T.init;
+    else
+        alias lvalueInit = .lvalueInit!(immutable(T));
+}
+
+//
+unittest
+{
+    import core.stdc.string;
+    struct S
+    {
+        this() @disable;
+        this(this) @disable;
+        void opAssign(    S) {assert(0);}
+        void opAssign(ref S) {assert(0);}
+        int i = 777;
+    }
+
+    S s = void;
+    memcpy(&s, &lvalueInit!S, S.sizeof);
+    assert(s.i == 777);
+}
 
 //::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::://
 // SomethingTypeOf

--- a/std/traits.d
+++ b/std/traits.d
@@ -4554,10 +4554,11 @@ destruction.
 +/
 package template lvalueInit(T)
 {
-    static if (is(T == immutable(T)))
-        static lvalueInit = T.init;
-    else
-        alias lvalueInit = .lvalueInit!(immutable(T));
+    //static if (is(T == immutable(T)))
+    //    static lvalueInit = T.init;
+    //else
+    //    alias lvalueInit = .lvalueInit!(immutable(T));
+    static lvalueInit = immutable(T).init;
 }
 
 //


### PR DESCRIPTION
This is a library solution for of my original "WONTFIX" request:
"Make const(T).init and immutable(T).init lvalues"
https://issues.dlang.org/show_bug.cgi?id=11307

It is currently used in 3 places, but I have plans to add it to 2 other places too (`initializeAll` and a `moveOver` required for emplacing rvalues with disabled postblit).

It also fixes a bug where `move` could not be used with elaborate types that have a disabled default initialization.

Overall, it's just a little convenience that avoids bloat.