### PR TITLE
Make std.file.ensureDirExists safe

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -1508,17 +1508,25 @@ void mkdir(in char[] pathname)
 // Same as mkdir but ignores "already exists" errors.
 // Returns: "true" if the directory was created,
 //   "false" if it already existed.
-private bool ensureDirExists(in char[] pathname)
+private bool ensureDirExists(in char[] pathname) @safe
 {
     version(Windows)
     {
-        if (CreateDirectoryW(pathname.tempCStringW(), null))
+        static auto trustedCreateDirectoryW(in char[] path) @trusted
+        {
+            return CreateDirectoryW(path.tempCStringW(), null);
+        }
+        if (trustedCreateDirectoryW(pathname))
             return true;
-        cenforce(GetLastError() == ERROR_ALREADY_EXISTS, pathname.idup);
+        wenforce(GetLastError() == ERROR_ALREADY_EXISTS, pathname);
     }
     else version(Posix)
     {
-        if (core.sys.posix.sys.stat.mkdir(pathname.tempCString(), octal!777) == 0)
+        static auto trustedMkdir(in char[] path, mode_t mode) @trusted
+        {
+            return core.sys.posix.sys.stat.mkdir(path.tempCString(), mode);
+        }
+        if (trustedMkdir(pathname, octal!777) == 0)
             return true;
         cenforce(errno == EEXIST, pathname);
     }


### PR DESCRIPTION
It contains the following unsafe operations but we can verify that they can be trusted.

On Windows systems:
  - use of unsafe functions `core.sys.windows.windows.CreateDirectoryW` and `std.internal.cstring.tempCStringW`

On Posix systems:
  - use of unsafe functions `core.sys.posix.sys.stat.mkdir` and `std.internal.cstring.tempCString`

Additionally, I replaced `cenforce` with `wenforce` on Windows systems.
