### PR TITLE
Make std.file.rmdir safe

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -1592,19 +1592,26 @@ unittest
 /****************************************************
 Remove directory $(D pathname).
 
-Throws: $(D FileException) on error.
- */
-void rmdir(in char[] pathname)
+Throws: $(D FileException) on Posix or $(D WindowsException) on Windows
+        if an error occured.
+  */
+void rmdir(in char[] pathname) @safe
 {
     version(Windows)
     {
-        cenforce(RemoveDirectoryW(pathname.tempCStringW()),
-                pathname);
+        static auto trustedRemoveDirectoryW(in char[] path) @trusted
+        {
+            return RemoveDirectoryW(path.tempCStringW());
+        }
+        wenforce(trustedRemoveDirectoryW(pathname), pathname);
     }
     else version(Posix)
     {
-        cenforce(core.sys.posix.unistd.rmdir(pathname.tempCString()) == 0,
-                pathname);
+        static auto trustedRmdir(in char[] path) @trusted
+        {
+            return core.sys.posix.unistd.rmdir(path.tempCString());
+        }
+        cenforce(trustedRmdir(pathname) == 0, pathname);
     }
 }
 


### PR DESCRIPTION
It contains the following unsafe operations but we can verify that they can be trusted.

On Windows systems:
 - use of unsafe functions `core.sys.windows.windows.RemoveDirectoryW` and `std.internal.cstring.tempCStringW`

On Posix systems:
- use of unsafe functions `core.sys.posix.unistd.rmdir` and `std.internal.cstring.tempCString`

Additionally, I replaced `cenforce` with `wenforce` on Windows systems and changed the `Throws` section in the document.
