### PR TITLE
Fix a bug with FiberScheduler

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -1342,7 +1342,10 @@ private:
 
         override void wait()
         {
-            switchContext();
+            scope(exit) notified = false;
+
+            while( !notified )
+                switchContext();
         }
 
         override bool wait( Duration period )


### PR DESCRIPTION
FiberScheduler wasn't resetting notified state when Condition.wait completed.