### PR TITLE
Optimization for put/doPut templates that use outputRanges that should be pass by value

### DIFF
--- a/std/range/constraints.d
+++ b/std/range/constraints.d
@@ -370,7 +370,11 @@ template isInputRange(R)
     static assert(!isInputRange!(char[4]));
     static assert( isInputRange!(inout(int)[])); // bug 7824
 }
-
+/+
+Determines if a type should be passed by value.
+Returns true if $(D T) is a pointer, class, delegate, function etc.  Otherwise, returns false, i.e. when $(D T) is a struct, dynamic array, etc.
++/
+private enum bool isPassByValue(T) = isPointer!T || is( T == class ) || is (T == delegate) || is( T == function );
 /+
 puts the whole raw element $(D e) into $(D r). doPut will not attempt to
 iterate, slice or transcode $(D e) in any way shape or form. It will $(B only)
@@ -381,7 +385,7 @@ This can be important when $(D e) needs to be placed in $(D r) unchanged.
 Furthermore, it can be useful when working with $(D InputRange)s, as doPut
 guarantees that no more than a single element will be placed.
 +/
-private void doPut(R, E)(ref R r, auto ref E e)
+private void doPut(R, E)(R r, auto ref E e) if( isPassByValue!R )
 {
     static if(is(PointerTarget!R == struct))
         enum usingPut = hasMember!(PointerTarget!R, "put");
@@ -391,13 +395,13 @@ private void doPut(R, E)(ref R r, auto ref E e)
     static if (usingPut)
     {
         static assert(is(typeof(r.put(e))),
-            format("Cannot nativaly put a %s into a %s.", E.stringof, R.stringof));
+            format("Cannot natively put a %s into a %s.", E.stringof, R.stringof));
         r.put(e);
     }
     else static if (isInputRange!R)
     {
         static assert(is(typeof(r.front = e)),
-            format("Cannot nativaly put a %s into a %s.", E.stringof, R.stringof));
+            format("Cannot natively put a %s into a %s.", E.stringof, R.stringof));
         r.front = e;
         r.popFront();
     }
@@ -409,7 +413,38 @@ private void doPut(R, E)(ref R r, auto ref E e)
     {
         import std.string;
         static assert (false,
-            format("Cannot nativaly put a %s into a %s.", E.stringof, R.stringof));
+            format("Cannot natively put a %s into a %s.", E.stringof, R.stringof));
+    }
+}
+private void doPut(R, E)(ref R r, auto ref E e) if( !isPassByValue!R )
+{
+    static if(is(PointerTarget!R == struct))
+        enum usingPut = hasMember!(PointerTarget!R, "put");
+    else
+        enum usingPut = hasMember!(R, "put");
+
+    static if (usingPut)
+    {
+        static assert(is(typeof(r.put(e))),
+            format("Cannot natively put a %s into a %s.", E.stringof, R.stringof));
+        r.put(e);
+    }
+    else static if (isInputRange!R)
+    {
+        static assert(is(typeof(r.front = e)),
+            format("Cannot natively put a %s into a %s.", E.stringof, R.stringof));
+        r.front = e;
+        r.popFront();
+    }
+    else static if (is(typeof(r(e))))
+    {
+        r(e);
+    }
+    else
+    {
+        import std.string;
+        static assert (false,
+            format("Cannot natively put a %s into a %s.", E.stringof, R.stringof));
     }
 }
 
@@ -477,7 +512,60 @@ Tip: $(D put) should $(I not) be used "UFCS-style", e.g. $(D r.put(e)).
 Doing this may call $(D R.put) directly, by-passing any transformation
 feature provided by $(D Range.put). $(D put(r, e)) is prefered.
  +/
-void put(R, E)(ref R r, E e)
+void put(R, E)(R r, E e) if( isPassByValue!R )
+{
+    //First level: simply straight up put.
+    static if (is(typeof(doPut(r, e))))
+    {
+        doPut(r, e);
+    }
+    //Optional optimization block for straight up array to array copy.
+    else static if (isDynamicArray!R && !isNarrowString!R && isDynamicArray!E && is(typeof(r[] = e[])))
+    {
+        immutable len = e.length;
+        r[0 .. len] = e[];
+        r = r[len .. $];
+    }
+    //Accepts E[] ?
+    else static if (is(typeof(doPut(r, [e]))) && !isDynamicArray!R)
+    {
+        if (__ctfe)
+            doPut(r, [e]);
+        else
+            doPut(r, (&e)[0..1]);
+    }
+    //special case for char to string.
+    else static if (isSomeChar!E && is(typeof(putChar(r, e))))
+    {
+        putChar(r, e);
+    }
+    //Extract each element from the range
+    //We can use "put" here, so we can recursively test a RoR of E.
+    else static if (isInputRange!E && is(typeof(put(r, e.front))))
+    {
+        //Special optimization: If E is a narrow string, and r accepts characters no-wider than the string's
+        //Then simply feed the characters 1 by 1.
+        static if (isNarrowString!E && (
+            (is(E : const  char[]) && is(typeof(doPut(r,  char.max))) && !is(typeof(doPut(r, dchar.max))) && !is(typeof(doPut(r, wchar.max)))) ||
+            (is(E : const wchar[]) && is(typeof(doPut(r, wchar.max))) && !is(typeof(doPut(r, dchar.max)))) ) )
+        {
+            foreach(c; e)
+                doPut(r, c);
+        }
+        else
+        {
+            for (; !e.empty; e.popFront())
+                put(r, e.front);
+        }
+    }
+    else
+    {
+        import std.string;
+        static assert (false, format("Cannot put a %s into a %s.", E.stringof, R.stringof));
+    }
+}
+/++ ditto +/
+void put(R, E)(ref R r, E e) if( !isPassByValue!R )
 {
     //First level: simply straight up put.
     static if (is(typeof(doPut(r, e))))


### PR DESCRIPTION
The original put/doPut functions pass in the OutputRange by ref, i.e.

```D
package void doPut(R, E)(ref R r, auto ref E e)
void put(R, E)(ref R r, E e)
```

However, some types do not need to be passed by reference such as pointers, dynamic arrays, classes, delegates...

To better optimize these output ranges I added overloads for the put/doPut functions that pass the OutputRange by value instead of by reference (See code).

Now that each overload handles a different set of types, some of the logic can be removed from each function, but I just duplicated the logic twice to minimize the potential amount of turmoil (I don't want to mess anything up).  If anyone knows "for sure" what logic can be removed I'm willing to do that, but, most of the logic is compile time so the only gain will be slightly faster compile times (not necessarily smaller/leaner functions).  Also feel free to make any modifications to my code:)