### PR TITLE
Separate linux kernel, glibc, and bionic APIs where appropriate

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -2978,7 +2978,7 @@ unittest
     {
         version (CRuntime_Microsoft)
             ld1 = 0x1.FFFFFFFFFFFFFFFEp-16382L; // strtold currently mapped to strtod
-        else version (Android)
+        else version (CRuntime_Bionic)
             ld1 = 0x1.FFFFFFFFFFFFFFFEp-16382L; // strtold currently mapped to strtod
         else
             ld1 = strtold(s.ptr, null);

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -26533,7 +26533,6 @@ auto tz = TimeZone.getTimeZone("America/Los_Angeles");
             version(FreeBSD)      enum utcZone = "Etc/UTC";
             else version(linux)   enum utcZone = "UTC";
             else version(OSX)     enum utcZone = "UTC";
-            else version(Android) enum utcZone = "UTC";
             else static assert(0, "The location of the UTC timezone file on this Posix platform must be set.");
 
             auto tzs = [testTZ("America/Los_Angeles", "PST", "PDT", dur!"hours"(-8), dur!"hours"(1)),

--- a/std/exception.d
+++ b/std/exception.d
@@ -1418,7 +1418,7 @@ class ErrnoException : Exception
     this(string msg, string file = null, size_t line = 0) @trusted
     {
         _errno = .errno;
-        version (linux)
+        version (CRuntime_Glibc)
         {
             char[1024] buf = void;
             auto s = core.stdc.string.strerror_r(errno, buf.ptr, buf.length);

--- a/std/file.d
+++ b/std/file.d
@@ -1896,10 +1896,6 @@ else version (FreeBSD)
         // Only Solaris 10 and later
         return readLink(format("/proc/%d/path/a.out", getpid()));
     }
-    else version (Android)
-    {
-        return readLink("/proc/self/exe");
-    }
     else
         static assert(0, "thisExePath is not supported on this platform");
 }

--- a/std/format.d
+++ b/std/format.d
@@ -1805,7 +1805,7 @@ unittest
         formatTest( to!(immutable T)(5.5), "5.5" );
 
         // bionic doesn't support lower-case string formatting of nan yet
-        version(Android) { formatTest( T.nan, "NaN" ); }
+        version(CRuntime_Bionic) { formatTest( T.nan, "NaN" ); }
         else { formatTest( T.nan, "nan" ); }
     }
 }
@@ -3711,7 +3711,7 @@ unittest
     * specify what the hex digit before the decimal point is for
     * %A.  */
 
-    version (linux)
+    version (CRuntime_Glibc)
     {
         assert(stream.data == "1.67 -0X1.47AE147AE147BP+0 nan",
                 stream.data);
@@ -3732,7 +3732,7 @@ unittest
             || stream.data == "1.67 -0X1.47AE147AE147BP+0 nan", // MSVCRT 14+ (VS 2015)
                 stream.data);
     }
-    else version (Android)
+    else version (CRuntime_Bionic)
     {
         // bionic doesn't support hex formatting of floating point numbers
         // or lower-case string formatting of nan yet, but it was committed
@@ -3767,7 +3767,7 @@ unittest
     version (CRuntime_Microsoft)
         assert(stream.data == "0x1.51eb85p+0 0X1.B1EB86P+2"
             || stream.data == "0x1.51eb851eb851fp+0 0X1.B1EB860000000P+2"); // MSVCRT 14+ (VS 2015)
-    else version (Android)
+    else version (CRuntime_Bionic)
     {
         // bionic doesn't support hex formatting of floating point numbers,
         // but it was committed recently (April 2014):
@@ -6250,7 +6250,7 @@ unittest
     else version (CRuntime_Microsoft)
         assert(s == "1.67 -0X1.47AE14P+0 nan"
             || s == "1.67 -0X1.47AE147AE147BP+0 nan", s); // MSVCRT 14+ (VS 2015)
-    else version (Android)
+    else version (CRuntime_Bionic)
     {
         // bionic doesn't support hex formatting of floating point numbers
         // or lower-case string formatting of nan yet, but it was committed

--- a/std/math.d
+++ b/std/math.d
@@ -6633,34 +6633,6 @@ private real polyImpl(real x, in real[] A) @trusted pure nothrow @nogc
                 ;
             }
         }
-        else version (Android)
-        {
-            asm pure nothrow @nogc // assembler by W. Bright
-            {
-                // EDX = (A.length - 1) * real.sizeof
-                mov     ECX,A[EBP]              ; // ECX = A.length
-                dec     ECX                     ;
-                lea     EDX,[ECX*8]             ;
-                lea     EDX,[EDX][ECX*4]        ;
-                add     EDX,A+4[EBP]            ;
-                fld     real ptr [EDX]          ; // ST0 = coeff[ECX]
-                jecxz   return_ST               ;
-                fld     x[EBP]                  ; // ST0 = x
-                fxch    ST(1)                   ; // ST1 = x, ST0 = r
-                align   4                       ;
-        L2:     fmul    ST,ST(1)                ; // r *= x
-                fld     real ptr -12[EDX]       ;
-                sub     EDX,12                  ; // deg--
-                faddp   ST(1),ST                ;
-                dec     ECX                     ;
-                jne     L2                      ;
-                fxch    ST(1)                   ; // ST1 = r, ST0 = x
-                fstp    ST(0)                   ; // dump x
-                align   4                       ;
-        return_ST:                              ;
-                ;
-            }
-        }
         else
         {
             static assert(0);

--- a/std/mmfile.d
+++ b/std/mmfile.d
@@ -328,7 +328,7 @@ class MmFile
             else
             {
                 fd = -1;
-                version(linux) import core.sys.linux.sys.mman : MAP_ANON;
+                version(CRuntime_Glibc) import core.sys.linux.sys.mman : MAP_ANON;
                 flags |= MAP_ANON;
             }
             this.size = size;

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -156,15 +156,6 @@ else version(Solaris)
         totalCPUs = cast(uint) sysconf(_SC_NPROCESSORS_ONLN);
     }
 }
-else version(Android)
-{
-    import core.sys.posix.unistd;
-
-    shared static this()
-    {
-        totalCPUs = cast(uint) sysconf(_SC_NPROCESSORS_ONLN);
-    }
-}
 else version(useSysctlbyname)
 {
     extern(C) int sysctlbyname(

--- a/std/path.d
+++ b/std/path.d
@@ -3059,7 +3059,6 @@ string expandTilde(string inputPath) nothrow
         import core.stdc.string : strlen;
         import core.stdc.stdlib : getenv, malloc, free, realloc;
         import core.exception : onOutOfMemoryError;
-        import core.sys.posix.pwd : passwd, getpwnam_r;
         import core.stdc.errno : errno, ERANGE;
 
         /*  Joins a path from a C string to the remainder of path.
@@ -3110,14 +3109,15 @@ string expandTilde(string inputPath) nothrow
         // Replaces the tilde from path with the path from the user database.
         static string expandFromDatabase(string path) nothrow
         {
-            // Android doesn't really support this, as getpwnam_r
+            // bionic doesn't really support this, as getpwnam_r
             // isn't provided and getpwnam is basically just a stub
-            version(Android)
+            version(CRuntime_Bionic)
             {
                 return path;
             }
             else
             {
+                import core.sys.posix.pwd : passwd, getpwnam_r;
                 import std.string : indexOf;
 
                 assert(path.length > 2 || (path.length == 2 && !isDirSeparator(path[1])));

--- a/std/process.d
+++ b/std/process.d
@@ -2181,7 +2181,7 @@ class ProcessException : Exception
     {
         import core.stdc.errno;
         import core.stdc.string;
-        version (linux)
+        version (CRuntime_Glibc)
         {
             char[1024] buf;
             auto errnoMsg = to!string(

--- a/std/socket.d
+++ b/std/socket.d
@@ -169,7 +169,7 @@ string formatSocketError(int err) @trusted
     {
         char[80] buf;
         const(char)* cs;
-        version (linux)
+        version (CRuntime_Glibc)
         {
             cs = strerror_r(err, buf.ptr, buf.length);
         }
@@ -197,7 +197,7 @@ string formatSocketError(int err) @trusted
             else
                 return "Socket error " ~ to!string(err);
         }
-        else version (Android)
+        else version (CRuntime_Bionic)
         {
             auto errs = strerror_r(err, buf.ptr, buf.length);
             if (errs == 0)
@@ -403,37 +403,18 @@ enum SocketType: int
 /**
  * Protocol
  */
-version(Android)
+enum ProtocolType: int
 {
-    // no GGP on Android
-    enum ProtocolType: int
-    {
-        IP =    IPPROTO_IP,         /// Internet Protocol version 4
-        ICMP =  IPPROTO_ICMP,       /// Internet Control Message Protocol
-        IGMP =  IPPROTO_IGMP,       /// Internet Group Management Protocol
-        TCP =   IPPROTO_TCP,        /// Transmission Control Protocol
-        PUP =   IPPROTO_PUP,        /// PARC Universal Packet Protocol
-        UDP =   IPPROTO_UDP,        /// User Datagram Protocol
-        IDP =   IPPROTO_IDP,        /// Xerox NS protocol
-        RAW =   IPPROTO_RAW,        /// Raw IP packets
-        IPV6 =  IPPROTO_IPV6,       /// Internet Protocol version 6
-    }
-}
-else
-{
-    enum ProtocolType: int
-    {
-        IP =    IPPROTO_IP,         /// Internet Protocol version 4
-        ICMP =  IPPROTO_ICMP,       /// Internet Control Message Protocol
-        IGMP =  IPPROTO_IGMP,       /// Internet Group Management Protocol
-        GGP =   IPPROTO_GGP,        /// Gateway to Gateway Protocol
-        TCP =   IPPROTO_TCP,        /// Transmission Control Protocol
-        PUP =   IPPROTO_PUP,        /// PARC Universal Packet Protocol
-        UDP =   IPPROTO_UDP,        /// User Datagram Protocol
-        IDP =   IPPROTO_IDP,        /// Xerox NS protocol
-        RAW =   IPPROTO_RAW,        /// Raw IP packets
-        IPV6 =  IPPROTO_IPV6,       /// Internet Protocol version 6
-    }
+    IP =    IPPROTO_IP,         /// Internet Protocol version 4
+    ICMP =  IPPROTO_ICMP,       /// Internet Control Message Protocol
+    IGMP =  IPPROTO_IGMP,       /// Internet Group Management Protocol
+    GGP =   IPPROTO_GGP,        /// Gateway to Gateway Protocol
+    TCP =   IPPROTO_TCP,        /// Transmission Control Protocol
+    PUP =   IPPROTO_PUP,        /// PARC Universal Packet Protocol
+    UDP =   IPPROTO_UDP,        /// User Datagram Protocol
+    IDP =   IPPROTO_IDP,        /// Xerox NS protocol
+    RAW =   IPPROTO_RAW,        /// Raw IP packets
+    IPV6 =  IPPROTO_IPV6,       /// Internet Protocol version 6
 }
 
 
@@ -517,7 +498,7 @@ class Protocol
 
 unittest
 {
-    // getprotobyname,number are unimplemented on Android
+    // getprotobyname,number are unimplemented in bionic
     softUnittest({
         Protocol proto = new Protocol;
         assert(proto.getProtocolByType(ProtocolType.TCP));
@@ -2454,39 +2435,19 @@ unittest // Issue 14012, 14013
 }
 
 /// The level at which a socket option is defined:
-version(Android)
+enum SocketOptionLevel: int
 {
-    // no GGP on Android
-    enum SocketOptionLevel: int
-    {
-        SOCKET =  SOL_SOCKET,               /// Socket level
-        IP =      ProtocolType.IP,          /// Internet Protocol version 4 level
-        ICMP =    ProtocolType.ICMP,        /// Internet Control Message Protocol level
-        IGMP =    ProtocolType.IGMP,        /// Internet Group Management Protocol level
-        TCP =     ProtocolType.TCP,         /// Transmission Control Protocol level
-        PUP =     ProtocolType.PUP,         /// PARC Universal Packet Protocol level
-        UDP =     ProtocolType.UDP,         /// User Datagram Protocol level
-        IDP =     ProtocolType.IDP,         /// Xerox NS protocol level
-        RAW =     ProtocolType.RAW,         /// Raw IP packet level
-        IPV6 =    ProtocolType.IPV6,        /// Internet Protocol version 6 level
-    }
-}
-else
-{
-    enum SocketOptionLevel: int
-    {
-        SOCKET =  SOL_SOCKET,               /// Socket level
-        IP =      ProtocolType.IP,          /// Internet Protocol version 4 level
-        ICMP =    ProtocolType.ICMP,        /// Internet Control Message Protocol level
-        IGMP =    ProtocolType.IGMP,        /// Internet Group Management Protocol level
-        GGP =     ProtocolType.GGP,         /// Gateway to Gateway Protocol level
-        TCP =     ProtocolType.TCP,         /// Transmission Control Protocol level
-        PUP =     ProtocolType.PUP,         /// PARC Universal Packet Protocol level
-        UDP =     ProtocolType.UDP,         /// User Datagram Protocol level
-        IDP =     ProtocolType.IDP,         /// Xerox NS protocol level
-        RAW =     ProtocolType.RAW,         /// Raw IP packet level
-        IPV6 =    ProtocolType.IPV6,        /// Internet Protocol version 6 level
-    }
+    SOCKET =  SOL_SOCKET,               /// Socket level
+    IP =      ProtocolType.IP,          /// Internet Protocol version 4 level
+    ICMP =    ProtocolType.ICMP,        /// Internet Control Message Protocol level
+    IGMP =    ProtocolType.IGMP,        /// Internet Group Management Protocol level
+    GGP =     ProtocolType.GGP,         /// Gateway to Gateway Protocol level
+    TCP =     ProtocolType.TCP,         /// Transmission Control Protocol level
+    PUP =     ProtocolType.PUP,         /// PARC Universal Packet Protocol level
+    UDP =     ProtocolType.UDP,         /// User Datagram Protocol level
+    IDP =     ProtocolType.IDP,         /// Xerox NS protocol level
+    RAW =     ProtocolType.RAW,         /// Raw IP packet level
+    IPV6 =    ProtocolType.IPV6,        /// Internet Protocol version 6 level
 }
 
 /// _Linger information for use with SocketOption.LINGER.

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -40,7 +40,7 @@ else version (CRuntime_DigitalMars)
     version = DIGITAL_MARS_STDIO;
 }
 
-version (linux)
+version (CRuntime_Glibc)
 {
     // Specific to the way Gnu C does stdio
     version = GCC_IO;
@@ -65,7 +65,7 @@ version (Solaris)
     version = NO_GETDELIM;
 }
 
-version (Android)
+version (CRuntime_Bionic)
 {
     version = GENERIC_IO;
     version = NO_GETDELIM;
@@ -882,7 +882,7 @@ Throws: $(D Exception) if the file is not opened.
         {
             import std.conv : text;
 
-            version (Android)
+            version (CRuntime_Bionic)
                 auto bigOffset = int.max - 100;
             else
                 auto bigOffset = cast(ulong) int.max + 100;
@@ -2042,7 +2042,7 @@ $(XREF file,readText)
             auto file = File(deleteme, "w+");
             scope(success) std.file.remove(deleteme);
         }
-        else version(Android)
+        else version(CRuntime_Bionic)
         {
             static import std.file;
 
@@ -3816,7 +3816,7 @@ Initialize with a message and an error code.
             import core.stdc.string : strerror_r;
 
             char[256] buf = void;
-            version (linux)
+            version (CRuntime_Glibc)
             {
                 auto s = core.stdc.string.strerror_r(errno, buf.ptr, buf.length);
             }

--- a/std/system.d
+++ b/std/system.d
@@ -42,10 +42,10 @@ immutable
     /// The OS that the program was compiled for.
     version(Win32)        OS os = OS.win32;
     else version(Win64)   OS os = OS.win64;
+    else version(Android) OS os = OS.android;
     else version(linux)   OS os = OS.linux;
     else version(OSX)     OS os = OS.osx;
     else version(FreeBSD) OS os = OS.freeBSD;
-    else version(Android) OS os = OS.android;
     else version(Posix)   OS os = OS.otherPosix;
     else static assert(0, "Unknown OS.");
 


### PR DESCRIPTION
Building on submitted dmd pulls [#4111](https://github.com/D-Programming-Language/dmd/pull/4111) and [#3643](https://github.com/D-Programming-Language/dmd/pull/3643) and druntime pull [#1010](https://github.com/D-Programming-Language/druntime/pull/1010), this pull substitutes the new `CRuntime_Glibc` and `CRuntime_Bionic` predefined global versions where appropriate.  After those dmd pulls are merged, `linux` will be defined for both desktop/server linux and Android, as opposed to the current situation where either `linux` or `Android` alone is expected to be defined (which is why I had to change the order in `std.system`).  dmd #4111 will have to be merged before this pull will compile and pass tests.