### PR TITLE
Move std.typetuple to std.meta.list

### DIFF
--- a/index.d
+++ b/index.d
@@ -149,7 +149,7 @@ $(BOOKTABLE ,
         $(TD 
             $(LINK2 std_traits.html, std.traits)$(BR)
             $(LINK2 std_typecons.html, std.typecons)$(BR)
-            $(LINK2 std_typetuple.html, std.typetuple)$(BR)
+            $(LINK2 std_meta_list.html, std.meta.list)$(BR)
             $(LINK2 core_demangle.html, core.demangle)
         )
         $(TD

--- a/posix.mak
+++ b/posix.mak
@@ -91,7 +91,7 @@ DOCSRC = ../dlang.org
 WEBSITE_DIR = ../web
 DOC_OUTPUT_DIR = $(WEBSITE_DIR)/phobos-prerelease
 BIGDOC_OUTPUT_DIR = /tmp
-SRC_DOCUMENTABLES = index.d $(addsuffix .d,$(STD_MODULES) $(STD_NET_MODULES) $(STD_DIGEST_MODULES) $(STD_CONTAINER_MODULES) $(STD_RANGE_MODULES) $(STD_ALGO_MODULES) std/regex/package $(EXTRA_DOCUMENTABLES) $(STD_LOGGER_MODULES))
+SRC_DOCUMENTABLES = index.d $(addsuffix .d,$(STD_MODULES) $(STD_NET_MODULES) $(STD_DIGEST_MODULES) $(STD_CONTAINER_MODULES) $(STD_META_MODULES) $(STD_RANGE_MODULES) $(STD_ALGO_MODULES) std/regex/package $(EXTRA_DOCUMENTABLES) $(STD_LOGGER_MODULES))
 STDDOC = $(DOCSRC)/html.ddoc $(DOCSRC)/dlang.org.ddoc $(DOCSRC)/std_navbar-prerelease.ddoc $(DOCSRC)/std.ddoc $(DOCSRC)/macros.ddoc
 BIGSTDDOC = $(DOCSRC)/std_consolidated.ddoc $(DOCSRC)/macros.ddoc
 # Set DDOC, the documentation generator
@@ -209,6 +209,8 @@ STD_DIGEST_MODULES = $(addprefix std/digest/, digest crc md ripemd sha)
 STD_CONTAINER_MODULES = $(addprefix std/container/, package array \
 		binaryheap dlist rbtree slist util)
 
+STD_META_MODULES = $(addprefix std/meta/, list)
+
 # OS-specific D modules
 EXTRA_MODULES_LINUX := $(addprefix std/c/linux/, linux socket)
 EXTRA_MODULES_OSX := $(addprefix std/c/osx/, socket)
@@ -235,7 +237,7 @@ EXTRA_MODULES += $(EXTRA_DOCUMENTABLES) $(addprefix			\
 
 # Aggregate all D modules relevant to this build
 D_MODULES = $(STD_MODULES) $(EXTRA_MODULES) $(STD_NET_MODULES) \
-	$(STD_DIGEST_MODULES) $(STD_CONTAINER_MODULES) $(STD_REGEX_MODULES) \
+	$(STD_DIGEST_MODULES) $(STD_CONTAINER_MODULES) $(STD_META_MODULES) $(STD_REGEX_MODULES) \
 	$(STD_RANGE_MODULES) $(STD_ALGO_MODULES) $(STD_LOGGER_MODULES)
 
 # Add the .d suffix to the module names
@@ -443,6 +445,9 @@ $(DOC_OUTPUT_DIR)/std_range_%.html : std/range/%.d $(STDDOC)
 	$(DDOC) project.ddoc $(STDDOC) -Df$@ $<
 
 $(DOC_OUTPUT_DIR)/std_regex_%.html : std/regex/%.d $(STDDOC)
+	$(DDOC) project.ddoc $(STDDOC) -Df$@ $<
+
+$(DOC_OUTPUT_DIR)/std_meta_%.html : std/meta/%.d $(STDDOC)
 	$(DDOC) project.ddoc $(STDDOC) -Df$@ $<
 
 $(DOC_OUTPUT_DIR)/std_net_%.html : std/net/%.d $(STDDOC)

--- a/std/meta/list.d
+++ b/std/meta/list.d
@@ -1,14 +1,16 @@
 // Written in the D programming language.
 
 /**
- * Templates with which to manipulate type tuples (also known as type lists).
+ * Templates with which to manipulate
+ * $(LINK2 ../template.html#TemplateArgumentList, $(I TemplateArgumentList))s.
+ * Such lists are known as type lists when they only contain types.
  *
- * Some operations on type tuples are built in to the language,
- * such as TL[$(I n)] which gets the $(I n)th type from the
- * type tuple. TL[$(I lwr) .. $(I upr)] returns a new type
- * list that is a slice of the old one.
+ * Some operations on template argument lists are built in to the language,
+ * such as $(D Args[$(I n)]) which gets the $(I n)th element from the
+ * _list. $(D Args[$(I lwr) .. $(I upr)]) returns a new
+ * _list that is a slice of the old one. This is analogous to array slicing syntax.
  *
- * Several templates in this module use or operate on eponymous templates that
+ * Several templates in this module use or operate on enum templates that
  * take a single argument and evaluate to a boolean constant. Such templates
  * are referred to as $(I template predicates).
  *
@@ -18,29 +20,26 @@
  *      Modern C++ Design),
  *   Andrei Alexandrescu (Addison-Wesley Professional, 2001)
  * Macros:
- *  WIKI = Phobos/StdTypeTuple
+ *  WIKI = Phobos/StdMeta
  *
  * Copyright: Copyright Digital Mars 2005 - 2009.
  * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:
  *     $(WEB digitalmars.com, Walter Bright),
  *     $(WEB klickverbot.at, David Nadlinger)
- * Source:    $(PHOBOSSRC std/_typetuple.d)
+ * Source:    $(PHOBOSSRC std/meta/_list.d)
  */
 /*          Copyright Digital Mars 2005 - 2009.
  * Distributed under the Boost Software License, Version 1.0.
  *    (See accompanying file LICENSE_1_0.txt or copy at
  *          http://www.boost.org/LICENSE_1_0.txt)
  */
-module std.typetuple;
+module std.meta.list;
 
 /**
- * Creates a typetuple out of a sequence of zero or more types.
+ * Aliases the given compile-time list of template arguments.
  */
-template TypeTuple(TList...)
-{
-    alias TypeTuple = TList;
-}
+alias TypeTuple(Args...) = Args;
 
 ///
 unittest
@@ -52,9 +51,19 @@ unittest
     {
         return td[0] + cast(int)td[1];
     }
+    assert(foo(2, 3.5) == 5);
 }
 
 ///
+unittest
+{
+    alias numbers = TypeTuple!(1, 2, 3);
+    static int[3] arr = [numbers];
+    
+    assert(arr == [1, 2, 3]);
+}
+
+/// Lists do not nest:
 unittest
 {
     alias TL = TypeTuple!(int, double);
@@ -64,8 +73,8 @@ unittest
 }
 
 /**
- * Returns the index of the first occurrence of type T in the
- * sequence of zero or more types TList.
+ * Returns the index of the first occurrence of T in the
+ * sequence of zero or more elements TList.
  * If not found, -1 is returned.
  */
 template staticIndexOf(T, TList...)
@@ -82,7 +91,7 @@ template staticIndexOf(alias T, TList...)
 ///
 unittest
 {
-    import std.typetuple;
+    import std.meta.list;
     import std.stdio;
 
     void foo()
@@ -147,7 +156,7 @@ unittest
 alias IndexOf = staticIndexOf;
 
 /**
- * Returns a typetuple created from TList with the first occurrence,
+ * Returns a list created from TList with the first occurrence,
  * if any, of T removed.
  */
 template Erase(T, TList...)
@@ -205,7 +214,7 @@ unittest
 
 
 /**
- * Returns a typetuple created from TList with the all occurrences,
+ * Returns a list created from TList with all occurrences,
  * if any, of T removed.
  */
 template EraseAll(T, TList...)
@@ -265,8 +274,8 @@ unittest
 
 
 /**
- * Returns a typetuple created from TList with the all duplicate
- * types removed.
+ * Returns a list created from TList with all duplicate
+ * elements removed.
  */
 template NoDuplicates(TList...)
 {
@@ -296,8 +305,8 @@ unittest
 
 
 /**
- * Returns a typetuple created from TList with the first occurrence
- * of type T, if found, replaced with type U.
+ * Returns a list created from TList with the first occurrence
+ * of T, if found, replaced with U.
  */
 template Replace(T, U, TList...)
 {
@@ -376,8 +385,8 @@ unittest
 }
 
 /**
- * Returns a typetuple created from TList with all occurrences
- * of type T, if found, replaced with type U.
+ * Returns a list created from TList with each occurrence
+ * of T, if found, replaced with U.
  */
 template ReplaceAll(T, U, TList...)
 {
@@ -456,7 +465,7 @@ unittest
 }
 
 /**
- * Returns a typetuple created from TList with the order reversed.
+ * Returns a list created from TList with the order reversed.
  */
 template Reverse(TList...)
 {
@@ -509,7 +518,7 @@ unittest
 }
 
 /**
- * Returns the typetuple TList with the types sorted so that the most
+ * Returns the list TList with the types sorted so that the most
  * derived types come first.
  */
 template DerivedToFront(TList...)
@@ -652,8 +661,8 @@ unittest
 
 
 /**
- * Filters a $(D TypeTuple) using a template predicate. Returns a
- * $(D TypeTuple) of the elements which satisfy the predicate.
+ * Filters a list using a template predicate. Returns a
+ * list of the elements which satisfy the predicate.
  */
 template Filter(alias pred, TList...)
 {

--- a/std/meta/list.d
+++ b/std/meta/list.d
@@ -145,9 +145,6 @@ unittest
     static assert(staticIndexOf!("void", 0, void, "void") == 2);
 }
 
-/// Kept for backwards compatibility.
-alias IndexOf = staticIndexOf;
-
 /**
  * Returns a list created from TList with the first occurrence,
  * if any, of T removed.

--- a/std/meta/list.d
+++ b/std/meta/list.d
@@ -538,22 +538,22 @@ unittest
 /**
 Evaluates to $(D TypeTuple!(F!(T[0]), F!(T[1]), ..., F!(T[$ - 1]))).
  */
-template staticMap(alias F, T...)
+template Map(alias F, T...)
 {
     static if (T.length == 0)
     {
-        alias staticMap = TypeTuple!();
+        alias Map = TypeTuple!();
     }
     else static if (T.length == 1)
     {
-        alias staticMap = TypeTuple!(F!(T[0]));
+        alias Map = TypeTuple!(F!(T[0]));
     }
     else
     {
-        alias staticMap =
+        alias Map =
             TypeTuple!(
-                staticMap!(F, T[ 0  .. $/2]),
-                staticMap!(F, T[$/2 ..  $ ]));
+                Map!(F, T[ 0  .. $/2]),
+                Map!(F, T[$/2 ..  $ ]));
     }
 }
 
@@ -561,7 +561,7 @@ template staticMap(alias F, T...)
 unittest
 {
     import std.traits : Unqual;
-    alias TL = staticMap!(Unqual, int, const int, immutable int);
+    alias TL = Map!(Unqual, int, const int, immutable int);
     static assert(is(TL == TypeTuple!(int, int, int)));
 }
 
@@ -570,14 +570,14 @@ unittest
     import std.traits : Unqual;
 
     // empty
-    alias Empty = staticMap!(Unqual);
+    alias Empty = Map!(Unqual);
     static assert(Empty.length == 0);
 
     // single
-    alias Single = staticMap!(Unqual, const int);
+    alias Single = Map!(Unqual, const int);
     static assert(is(Single == TypeTuple!int));
 
-    alias T = staticMap!(Unqual, int, const int, immutable int);
+    alias T = Map!(Unqual, int, const int, immutable int);
     static assert(is(T == TypeTuple!(int, int, int)));
 }
 
@@ -739,7 +739,7 @@ unittest
 
 unittest
 {
-    foreach (T; TypeTuple!(int, staticMap, 42))
+    foreach (T; TypeTuple!(int, Map, 42))
     {
         static assert(!Instantiate!(templateNot!testAlways, T));
         static assert(Instantiate!(templateNot!testNever, T));
@@ -790,7 +790,7 @@ unittest
 
 unittest
 {
-    foreach (T; TypeTuple!(int, staticMap, 42))
+    foreach (T; TypeTuple!(int, Map, 42))
     {
         static assert( Instantiate!(templateAnd!(), T));
         static assert( Instantiate!(templateAnd!(testAlways), T));
@@ -848,7 +848,7 @@ unittest
 
 unittest
 {
-    foreach (T; TypeTuple!(int, staticMap, 42))
+    foreach (T; TypeTuple!(int, Map, 42))
     {
         static assert( Instantiate!(templateOr!(testAlways), T));
         static assert( Instantiate!(templateOr!(testAlways, testAlways), T));

--- a/std/meta/list.d
+++ b/std/meta/list.d
@@ -44,7 +44,7 @@ alias TypeTuple(Args...) = Args;
 ///
 unittest
 {
-    import std.typetuple;
+    import std.meta.list;
     alias TL = TypeTuple!(int, double);
 
     int foo(TL td)  // same as int foo(int, double);
@@ -91,15 +91,8 @@ template staticIndexOf(alias T, TList...)
 ///
 unittest
 {
-    import std.meta.list;
-    import std.stdio;
-
-    void foo()
-    {
-        writefln("The index of long is %s",
-                 staticIndexOf!(long, TypeTuple!(int, long, double)));
-        // prints: The index of long is 1
-    }
+    alias Types = TypeTuple!(int, long, double);
+    static assert(staticIndexOf!(long, Types) == 1);
 }
 
 // [internal]
@@ -152,7 +145,7 @@ unittest
     static assert(staticIndexOf!("void", 0, void, "void") == 2);
 }
 
-/// Kept for backwards compatibility
+/// Kept for backwards compatibility.
 alias IndexOf = staticIndexOf;
 
 /**

--- a/std/meta/list.d
+++ b/std/meta/list.d
@@ -39,13 +39,13 @@ module std.meta.list;
 /**
  * Aliases the given compile-time list of template arguments.
  */
-alias TypeTuple(Args...) = Args;
+alias MetaList(Args...) = Args;
 
 ///
 unittest
 {
     import std.meta.list;
-    alias TL = TypeTuple!(int, double);
+    alias TL = MetaList!(int, double);
 
     int foo(TL td)  // same as int foo(int, double);
     {
@@ -57,7 +57,7 @@ unittest
 ///
 unittest
 {
-    alias numbers = TypeTuple!(1, 2, 3);
+    alias numbers = MetaList!(1, 2, 3);
     static int[3] arr = [numbers];
     
     assert(arr == [1, 2, 3]);
@@ -66,10 +66,10 @@ unittest
 /// Lists do not nest:
 unittest
 {
-    alias TL = TypeTuple!(int, double);
+    alias TL = MetaList!(int, double);
 
-    alias Types = TypeTuple!(TL, char);
-    static assert(is(Types == TypeTuple!(int, double, char)));
+    alias Types = MetaList!(TL, char);
+    static assert(is(Types == MetaList!(int, double, char)));
 }
 
 /**
@@ -91,7 +91,7 @@ template staticIndexOf(alias T, TList...)
 ///
 unittest
 {
-    alias Types = TypeTuple!(int, long, double);
+    alias Types = MetaList!(int, long, double);
     static assert(staticIndexOf!(long, Types) == 1);
 }
 
@@ -163,9 +163,9 @@ template Erase(alias T, TList...)
 ///
 unittest
 {
-    alias Types = TypeTuple!(int, long, double, char);
+    alias Types = MetaList!(int, long, double, char);
     alias TL = Erase!(long, Types);
-    static assert(is(TL == TypeTuple!(int, double, char)));
+    static assert(is(TL == MetaList!(int, double, char)));
 }
 
 // [internal]
@@ -183,11 +183,11 @@ private template GenericErase(args...)
         static if (isSame!(e, head))
             alias result = tail;
         else
-            alias result = TypeTuple!(head, GenericErase!(e, tail).result);
+            alias result = MetaList!(head, GenericErase!(e, tail).result);
     }
     else
     {
-        alias result = TypeTuple!();
+        alias result = MetaList!();
     }
 }
 
@@ -221,10 +221,10 @@ template EraseAll(alias T, TList...)
 ///
 unittest
 {
-    alias Types = TypeTuple!(int, long, long, int);
+    alias Types = MetaList!(int, long, long, int);
 
     alias TL = EraseAll!(long, Types);
-    static assert(is(TL == TypeTuple!(int, int)));
+    static assert(is(TL == MetaList!(int, int)));
 }
 
 // [internal]
@@ -243,11 +243,11 @@ private template GenericEraseAll(args...)
         static if (isSame!(e, head))
             alias result = next;
         else
-            alias result = TypeTuple!(head, next);
+            alias result = MetaList!(head, next);
     }
     else
     {
-        alias result = TypeTuple!();
+        alias result = MetaList!();
     }
 }
 
@@ -273,16 +273,16 @@ template NoDuplicates(TList...)
         alias NoDuplicates = TList;
     else
         alias NoDuplicates =
-            TypeTuple!(TList[0], NoDuplicates!(EraseAll!(TList[0], TList[1 .. $])));
+            MetaList!(TList[0], NoDuplicates!(EraseAll!(TList[0], TList[1 .. $])));
 }
 
 ///
 unittest
 {
-    alias Types = TypeTuple!(int, long, long, int, float);
+    alias Types = MetaList!(int, long, long, int, float);
 
     alias TL = NoDuplicates!(Types);
-    static assert(is(TL == TypeTuple!(int, long, float)));
+    static assert(is(TL == MetaList!(int, long, float)));
 }
 
 unittest
@@ -324,10 +324,10 @@ template Replace(alias T, alias U, TList...)
 ///
 unittest
 {
-    alias Types = TypeTuple!(int, long, long, int, float);
+    alias Types = MetaList!(int, long, long, int, float);
 
     alias TL = Replace!(long, char, Types);
-    static assert(is(TL == TypeTuple!(int, char, long, int, float)));
+    static assert(is(TL == MetaList!(int, char, long, int, float)));
 }
 
 // [internal]
@@ -344,14 +344,14 @@ private template GenericReplace(args...)
         alias tail = tuple[1 .. $];
 
         static if (isSame!(from, head))
-            alias result = TypeTuple!(to, tail);
+            alias result = MetaList!(to, tail);
         else
-            alias result = TypeTuple!(head,
+            alias result = MetaList!(head,
                 GenericReplace!(from, to, tail).result);
     }
     else
     {
-        alias result = TypeTuple!();
+        alias result = MetaList!();
     }
  }
 
@@ -404,10 +404,10 @@ template ReplaceAll(alias T, alias U, TList...)
 ///
 unittest
 {
-    alias Types = TypeTuple!(int, long, long, int, float);
+    alias Types = MetaList!(int, long, long, int, float);
 
     alias TL = ReplaceAll!(long, char, Types);
-    static assert(is(TL == TypeTuple!(int, char, char, int, float)));
+    static assert(is(TL == MetaList!(int, char, char, int, float)));
 }
 
 // [internal]
@@ -425,13 +425,13 @@ private template GenericReplaceAll(args...)
         alias next = GenericReplaceAll!(from, to, tail).result;
 
         static if (isSame!(from, head))
-            alias result = TypeTuple!(to, next);
+            alias result = MetaList!(to, next);
         else
-            alias result = TypeTuple!(head, next);
+            alias result = MetaList!(head, next);
     }
     else
     {
-        alias result = TypeTuple!();
+        alias result = MetaList!();
     }
 }
 
@@ -466,7 +466,7 @@ template Reverse(TList...)
     else
     {
         alias Reverse =
-            TypeTuple!(
+            MetaList!(
                 Reverse!(TList[$/2 ..  $ ]),
                 Reverse!(TList[ 0  .. $/2]));
     }
@@ -475,10 +475,10 @@ template Reverse(TList...)
 ///
 unittest
 {
-    alias Types = TypeTuple!(int, long, long, int, float);
+    alias Types = MetaList!(int, long, long, int, float);
 
     alias TL = Reverse!(Types);
-    static assert(is(TL == TypeTuple!(float, int, long, long, int)));
+    static assert(is(TL == MetaList!(float, int, long, long, int)));
 }
 
 /**
@@ -501,7 +501,7 @@ unittest
     class A { }
     class B : A { }
     class C : B { }
-    alias Types = TypeTuple!(A, C, B);
+    alias Types = MetaList!(A, C, B);
 
     MostDerived!(Object, Types) x;  // x is declared as type C
     static assert(is(typeof(x) == C));
@@ -517,7 +517,7 @@ template DerivedToFront(TList...)
         alias DerivedToFront = TList;
     else
         alias DerivedToFront =
-            TypeTuple!(MostDerived!(TList[0], TList[1 .. $]),
+            MetaList!(MostDerived!(TList[0], TList[1 .. $]),
                        DerivedToFront!(ReplaceAll!(MostDerived!(TList[0], TList[1 .. $]),
                                 TList[0],
                                 TList[1 .. $])));
@@ -529,29 +529,29 @@ unittest
     class A { }
     class B : A { }
     class C : B { }
-    alias Types = TypeTuple!(A, C, B);
+    alias Types = MetaList!(A, C, B);
 
     alias TL = DerivedToFront!(Types);
-    static assert(is(TL == TypeTuple!(C, B, A)));
+    static assert(is(TL == MetaList!(C, B, A)));
 }
 
 /**
-Evaluates to $(D TypeTuple!(F!(T[0]), F!(T[1]), ..., F!(T[$ - 1]))).
+Evaluates to $(D MetaList!(F!(T[0]), F!(T[1]), ..., F!(T[$ - 1]))).
  */
 template Map(alias F, T...)
 {
     static if (T.length == 0)
     {
-        alias Map = TypeTuple!();
+        alias Map = MetaList!();
     }
     else static if (T.length == 1)
     {
-        alias Map = TypeTuple!(F!(T[0]));
+        alias Map = MetaList!(F!(T[0]));
     }
     else
     {
         alias Map =
-            TypeTuple!(
+            MetaList!(
                 Map!(F, T[ 0  .. $/2]),
                 Map!(F, T[$/2 ..  $ ]));
     }
@@ -562,7 +562,7 @@ unittest
 {
     import std.traits : Unqual;
     alias TL = Map!(Unqual, int, const int, immutable int);
-    static assert(is(TL == TypeTuple!(int, int, int)));
+    static assert(is(TL == MetaList!(int, int, int)));
 }
 
 unittest
@@ -575,10 +575,10 @@ unittest
 
     // single
     alias Single = Map!(Unqual, const int);
-    static assert(is(Single == TypeTuple!int));
+    static assert(is(Single == MetaList!int));
 
     alias T = Map!(Unqual, int, const int, immutable int);
-    static assert(is(T == TypeTuple!(int, int, int)));
+    static assert(is(T == MetaList!(int, int, int)));
 }
 
 /**
@@ -658,19 +658,19 @@ template Filter(alias pred, TList...)
 {
     static if (TList.length == 0)
     {
-        alias Filter = TypeTuple!();
+        alias Filter = MetaList!();
     }
     else static if (TList.length == 1)
     {
         static if (pred!(TList[0]))
-            alias Filter = TypeTuple!(TList[0]);
+            alias Filter = MetaList!(TList[0]);
         else
-            alias Filter = TypeTuple!();
+            alias Filter = MetaList!();
     }
     else
     {
         alias Filter =
-            TypeTuple!(
+            MetaList!(
                 Filter!(pred, TList[ 0  .. $/2]),
                 Filter!(pred, TList[$/2 ..  $ ]));
     }
@@ -681,21 +681,21 @@ unittest
 {
     import std.traits : isNarrowString, isUnsigned;
 
-    alias Types1 = TypeTuple!(string, wstring, dchar[], char[], dstring, int);
+    alias Types1 = MetaList!(string, wstring, dchar[], char[], dstring, int);
     alias TL1 = Filter!(isNarrowString, Types1);
-    static assert(is(TL1 == TypeTuple!(string, wstring, char[])));
+    static assert(is(TL1 == MetaList!(string, wstring, char[])));
 
-    alias Types2 = TypeTuple!(int, byte, ubyte, dstring, dchar, uint, ulong);
+    alias Types2 = MetaList!(int, byte, ubyte, dstring, dchar, uint, ulong);
     alias TL2 = Filter!(isUnsigned, Types2);
-    static assert(is(TL2 == TypeTuple!(ubyte, uint, ulong)));
+    static assert(is(TL2 == MetaList!(ubyte, uint, ulong)));
 }
 
 unittest
 {
     import std.traits : isPointer;
 
-    static assert(is(Filter!(isPointer, int, void*, char[], int*) == TypeTuple!(void*, int*)));
-    static assert(is(Filter!isPointer == TypeTuple!()));
+    static assert(is(Filter!(isPointer, int, void*, char[], int*) == MetaList!(void*, int*)));
+    static assert(is(Filter!isPointer == MetaList!()));
 }
 
 
@@ -739,7 +739,7 @@ unittest
 
 unittest
 {
-    foreach (T; TypeTuple!(int, Map, 42))
+    foreach (T; MetaList!(int, Map, 42))
     {
         static assert(!Instantiate!(templateNot!testAlways, T));
         static assert(Instantiate!(templateNot!testNever, T));
@@ -790,7 +790,7 @@ unittest
 
 unittest
 {
-    foreach (T; TypeTuple!(int, Map, 42))
+    foreach (T; MetaList!(int, Map, 42))
     {
         static assert( Instantiate!(templateAnd!(), T));
         static assert( Instantiate!(templateAnd!(testAlways), T));
@@ -848,7 +848,7 @@ unittest
 
 unittest
 {
-    foreach (T; TypeTuple!(int, Map, 42))
+    foreach (T; MetaList!(int, Map, 42))
     {
         static assert( Instantiate!(templateOr!(testAlways), T));
         static assert( Instantiate!(templateOr!(testAlways, testAlways), T));

--- a/std/meta/list.d
+++ b/std/meta/list.d
@@ -1,9 +1,6 @@
 // Written in the D programming language.
 
 /**
- * $(RED Deprecated. This module will be delisted in March 2017.
- * Please use $(LINK2 std_meta_list.html, std.meta.list) instead).
- * 
  * Templates with which to manipulate type tuples (also known as type lists).
  *
  * Some operations on type tuples are built in to the language,
@@ -35,7 +32,6 @@
  *    (See accompanying file LICENSE_1_0.txt or copy at
  *          http://www.boost.org/LICENSE_1_0.txt)
  */
-deprecated("Please use std.meta.list instead.")
 module std.typetuple;
 
 /**

--- a/std/meta/list.d
+++ b/std/meta/list.d
@@ -588,21 +588,21 @@ $(D F!(T[0]) && F!(T[1]) && ... && F!(T[$ - 1])).
 Evaluation is $(I not) short-circuited if a false result is encountered; the
 template predicate must be instantiable with all the given items.
  */
-template allSatisfy(alias F, T...)
+template metaAll(alias F, T...)
 {
     static if (T.length == 0)
     {
-        enum allSatisfy = true;
+        enum metaAll = true;
     }
     else static if (T.length == 1)
     {
-        enum allSatisfy = F!(T[0]);
+        enum metaAll = F!(T[0]);
     }
     else
     {
-        enum allSatisfy =
-            allSatisfy!(F, T[ 0  .. $/2]) &&
-            allSatisfy!(F, T[$/2 ..  $ ]);
+        enum metaAll =
+            metaAll!(F, T[ 0  .. $/2]) &&
+            metaAll!(F, T[$/2 ..  $ ]);
     }
 }
 
@@ -611,8 +611,8 @@ unittest
 {
     import std.traits : isIntegral;
 
-    static assert(!allSatisfy!(isIntegral, int, double));
-    static assert( allSatisfy!(isIntegral, int, long));
+    static assert(!metaAll!(isIntegral, int, double));
+    static assert( metaAll!(isIntegral, int, long));
 }
 
 /**
@@ -622,21 +622,21 @@ $(D F!(T[0]) || F!(T[1]) || ... || F!(T[$ - 1])).
 Evaluation is $(I not) short-circuited if a true result is encountered; the
 template predicate must be instantiable with all the given items.
  */
-template anySatisfy(alias F, T...)
+template metaAny(alias F, T...)
 {
     static if(T.length == 0)
     {
-        enum anySatisfy = false;
+        enum metaAny = false;
     }
     else static if (T.length == 1)
     {
-        enum anySatisfy = F!(T[0]);
+        enum metaAny = F!(T[0]);
     }
     else
     {
-        enum anySatisfy =
-            anySatisfy!(F, T[ 0  .. $/2]) ||
-            anySatisfy!(F, T[$/2 ..  $ ]);
+        enum metaAny =
+            metaAny!(F, T[ 0  .. $/2]) ||
+            metaAny!(F, T[$/2 ..  $ ]);
     }
 }
 
@@ -645,8 +645,8 @@ unittest
 {
     import std.traits : isIntegral;
 
-    static assert(!anySatisfy!(isIntegral, string, double));
-    static assert( anySatisfy!(isIntegral, int, double));
+    static assert(!metaAny!(isIntegral, string, double));
+    static assert( metaAny!(isIntegral, int, double));
 }
 
 
@@ -734,7 +734,7 @@ unittest
 
     alias isNoPointer = templateNot!isPointer;
     static assert(!isNoPointer!(int*));
-    static assert(allSatisfy!(isNoPointer, string, char, float));
+    static assert(metaAll!(isNoPointer, string, char, float));
 }
 
 unittest

--- a/std/meta/list.d
+++ b/std/meta/list.d
@@ -77,22 +77,22 @@ unittest
  * sequence of zero or more elements TList.
  * If not found, -1 is returned.
  */
-template staticIndexOf(T, TList...)
+template metaIndexOf(T, TList...)
 {
-    enum staticIndexOf = genericIndexOf!(T, TList).index;
+    enum metaIndexOf = genericIndexOf!(T, TList).index;
 }
 
 /// Ditto
-template staticIndexOf(alias T, TList...)
+template metaIndexOf(alias T, TList...)
 {
-    enum staticIndexOf = genericIndexOf!(T, TList).index;
+    enum metaIndexOf = genericIndexOf!(T, TList).index;
 }
 
 ///
 unittest
 {
     alias Types = MetaList!(int, long, double);
-    static assert(staticIndexOf!(long, Types) == 1);
+    static assert(metaIndexOf!(long, Types) == 1);
 }
 
 // [internal]
@@ -125,24 +125,24 @@ private template genericIndexOf(args...)
 
 unittest
 {
-    static assert(staticIndexOf!( byte, byte, short, int, long) ==  0);
-    static assert(staticIndexOf!(short, byte, short, int, long) ==  1);
-    static assert(staticIndexOf!(  int, byte, short, int, long) ==  2);
-    static assert(staticIndexOf!( long, byte, short, int, long) ==  3);
-    static assert(staticIndexOf!( char, byte, short, int, long) == -1);
-    static assert(staticIndexOf!(   -1, byte, short, int, long) == -1);
-    static assert(staticIndexOf!(void) == -1);
+    static assert(metaIndexOf!( byte, byte, short, int, long) ==  0);
+    static assert(metaIndexOf!(short, byte, short, int, long) ==  1);
+    static assert(metaIndexOf!(  int, byte, short, int, long) ==  2);
+    static assert(metaIndexOf!( long, byte, short, int, long) ==  3);
+    static assert(metaIndexOf!( char, byte, short, int, long) == -1);
+    static assert(metaIndexOf!(   -1, byte, short, int, long) == -1);
+    static assert(metaIndexOf!(void) == -1);
 
-    static assert(staticIndexOf!("abc", "abc", "def", "ghi", "jkl") ==  0);
-    static assert(staticIndexOf!("def", "abc", "def", "ghi", "jkl") ==  1);
-    static assert(staticIndexOf!("ghi", "abc", "def", "ghi", "jkl") ==  2);
-    static assert(staticIndexOf!("jkl", "abc", "def", "ghi", "jkl") ==  3);
-    static assert(staticIndexOf!("mno", "abc", "def", "ghi", "jkl") == -1);
-    static assert(staticIndexOf!( void, "abc", "def", "ghi", "jkl") == -1);
-    static assert(staticIndexOf!(42) == -1);
+    static assert(metaIndexOf!("abc", "abc", "def", "ghi", "jkl") ==  0);
+    static assert(metaIndexOf!("def", "abc", "def", "ghi", "jkl") ==  1);
+    static assert(metaIndexOf!("ghi", "abc", "def", "ghi", "jkl") ==  2);
+    static assert(metaIndexOf!("jkl", "abc", "def", "ghi", "jkl") ==  3);
+    static assert(metaIndexOf!("mno", "abc", "def", "ghi", "jkl") == -1);
+    static assert(metaIndexOf!( void, "abc", "def", "ghi", "jkl") == -1);
+    static assert(metaIndexOf!(42) == -1);
 
-    static assert(staticIndexOf!(void, 0, "void", void) == 2);
-    static assert(staticIndexOf!("void", 0, void, "void") == 2);
+    static assert(metaIndexOf!(void, 0, "void", void) == 2);
+    static assert(metaIndexOf!("void", 0, void, "void") == 2);
 }
 
 /**

--- a/std/typelist.d
+++ b/std/typelist.d
@@ -40,7 +40,7 @@
  *    (See accompanying file LICENSE_1_0.txt or copy at
  *          http://www.boost.org/LICENSE_1_0.txt)
  */
-deprecated("Please use std.typecons instead. This module will be removed in March 2015.")
+deprecated("Please use std.typetuple instead. This module will be removed in March 2015.")
 module std.typelist;
 version(unittest) {
     import std.typetuple;

--- a/std/typelist.d
+++ b/std/typelist.d
@@ -54,7 +54,7 @@ version(unittest) {
  * $(D TypeList)s are passed to other templates as alias parameters
  * To create an empty list use $(D TypeList!())
  *
- * $(D TypeList) efines several "methods":
+ * $(D TypeList) defines several "methods":
  *
  * $(D_PARAM toTuple), $(D_PARAM head), $(D_PARAM tail), $(D_PARAM length), $(D_PARAM isEmpty)
  *

--- a/unittest.d
+++ b/unittest.d
@@ -27,6 +27,7 @@ public import std.format;
 public import std.getopt;
 public import std.math;
 public import std.mathspecial;
+public import std.meta.list;
 public import std.mmfile;
 public import std.outbuffer;
 public import std.parallelism;

--- a/win32.mak
+++ b/win32.mak
@@ -115,7 +115,7 @@ SRC_STD_3= std\csv.d std\math.d std\complex.d std\numeric.d std\bigint.d \
 	std\uni.d std\base64.d std\ascii.d \
 	std\demangle.d std\uri.d std\metastrings.d std\mmfile.d std\getopt.d
 
-SRC_STD_3a= std\signals.d std\typetuple.d std\traits.d \
+SRC_STD_3a= std\signals.d std\typetuple.d std\meta\list.d std\traits.d \
 	std\encoding.d std\xml.d \
 	std\random.d \
 	std\exception.d \
@@ -163,7 +163,7 @@ SRC_STD= std\zlib.d std\zip.d std\stdint.d std\conv.d std\utf.d std\uri.d \
 	std\math.d std\string.d std\path.d std\datetime.d \
 	std\csv.d std\file.d std\compiler.d std\system.d \
 	std\outbuffer.d std\base64.d \
-	std\metastrings.d std\mmfile.d \
+	std\meta\list.d std\metastrings.d std\mmfile.d \
 	std\syserror.d \
 	std\random.d std\stream.d std\process.d \
 	std\socket.d std\socketstream.d std\format.d \
@@ -190,7 +190,7 @@ SRC_STD_NET= std\net\isemail.d std\net\curl.d
 SRC_STD_LOGGER= std\experimental\logger\core.d std\experimental\logger\filelogger.d \
 	std\experimental\logger\multilogger.d std\experimental\logger\nulllogger.d \
 	std\experimental\logger\package.d
-    
+
 SRC_STD_C= std\c\process.d std\c\stdlib.d std\c\time.d std\c\stdio.d \
 	std\c\math.d std\c\stdarg.d std\c\stddef.d std\c\fenv.d std\c\string.d \
 	std\c\locale.d std\c\wcharh.d
@@ -341,6 +341,7 @@ DOCS=	$(DOC)\object.html \
 	$(DOC)\std_json.html \
 	$(DOC)\std_math.html \
 	$(DOC)\std_mathspecial.html \
+	$(DOC)\std_meta_list.html \
 	$(DOC)\std_mmfile.html \
 	$(DOC)\std_numeric.html \
 	$(DOC)\std_outbuffer.html \
@@ -468,6 +469,7 @@ cov : $(SRC_TO_COMPILE) $(LIB)
 	$(DMD) -conf= -cov=95 -unittest -main -run std\getopt.d
 	$(DMD) -conf= -cov=92 -unittest -main -run std\signals.d
 	$(DMD) -conf= -cov=100 -unittest -main -run std\typetuple.d
+	$(DMD) -conf= -cov=100 -unittest -main -run std\meta\list.d
 	$(DMD) -conf= -cov=85 -unittest -main -run std\traits.d
 	$(DMD) -conf= -cov=62 -unittest -main -run std\encoding.d
 	$(DMD) -conf= -cov=61 -unittest -main -run std\xml.d
@@ -701,6 +703,9 @@ $(DOC)\std_math.html : $(STDDOC) std\math.d
 
 $(DOC)\std_mathspecial.html : $(STDDOC) std\mathspecial.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_mathspecial.html $(STDDOC) std\mathspecial.d
+
+$(DOC)\std_meta_list.html : $(STDDOC) std\meta\list.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_meta_list.html $(STDDOC) std\meta\list.d
 
 $(DOC)\std_mmfile.html : $(STDDOC) std\mmfile.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_mmfile.html $(STDDOC) std\mmfile.d

--- a/win64.mak
+++ b/win64.mak
@@ -117,7 +117,7 @@ SRC_STD_3c= std\datetime.d std\bitmanip.d std\typecons.d
 SRC_STD_3a= std\uni.d std\base64.d std\ascii.d \
 	std\demangle.d std\uri.d std\metastrings.d std\mmfile.d std\getopt.d
 
-SRC_STD_3b= std\signals.d std\typetuple.d std\traits.d \
+SRC_STD_3b= std\signals.d std\typetuple.d std\meta\list.d std\traits.d \
 	std\encoding.d std\xml.d \
 	std\random.d \
 	std\exception.d \
@@ -180,7 +180,7 @@ SRC_STD= std\zlib.d std\zip.d std\stdint.d std\conv.d std\utf.d std\uri.d \
 	std\math.d std\string.d std\path.d std\datetime.d \
 	std\csv.d std\file.d std\compiler.d std\system.d \
 	std\outbuffer.d std\base64.d \
-	std\metastrings.d std\mmfile.d \
+	std\meta\list.d std\metastrings.d std\mmfile.d \
 	std\syserror.d \
 	std\random.d std\stream.d std\process.d \
 	std\socket.d std\socketstream.d std\format.d \
@@ -358,6 +358,7 @@ DOCS=	$(DOC)\object.html \
 	$(DOC)\std_json.html \
 	$(DOC)\std_math.html \
 	$(DOC)\std_mathspecial.html \
+	$(DOC)\std_meta_list.html \
 	$(DOC)\std_mmfile.html \
 	$(DOC)\std_numeric.html \
 	$(DOC)\std_outbuffer.html \
@@ -659,6 +660,9 @@ $(DOC)\std_math.html : $(STDDOC) std\math.d
 
 $(DOC)\std_mathspecial.html : $(STDDOC) std\mathspecial.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_mathspecial.html $(STDDOC) std\mathspecial.d
+
+$(DOC)\std_meta_list.html : $(STDDOC) std\meta\list.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_meta_list.html $(STDDOC) std\meta\list.d
 
 $(DOC)\std_mmfile.html : $(STDDOC) std\mmfile.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_mmfile.html $(STDDOC) std\mmfile.d


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=4113

Part of [DIP 54](http://wiki.dlang.org/DIP54).

My plan of attack is to create `std.meta.list` as described in the DIP, then work on updating dlang.org and remaining Phobos modules not to use *tuple* for template argument lists. I don't intend to work on `std.meta.pack` as that seems additional functionality best done by someone else.

BTW I think the DIP also needs to mention what happens to `.tupleof` - copying @Dicebot.

For the documented new symbol name for *TypeTuple*, *TemplateArgumentList*, I think the 'Template' word is redundant because there's always a '!' after the symbol, e.g. TemplateArgumentList!int, so the reader knows it's a template. I suggest we use just ArgumentList ~~or ArgList~~. It's still descriptive, and we need a short name (e.g. for easy use in unittests) otherwise everyone will just alias it differently. But I will change this if necessary.

* Rename `std.typetuple` to `std.meta.list`.
* Deprecate `std.typetuple`.
* Rename TypeTuple -> List, recommend `import meta = std.meta.list` (as discussed below).
* Update `std.meta.list` docs to mention *template argument list* or just list instead of tuple.
* Update makefiles.
* Fix remaining uses of `std.typetuple`, `TypeTuple` in Phobos.
* Rename some symbols for consistency (see discussion below & commits).