### PR TITLE
Add CopyStorageClasses template and allow access to ConstOf and others.

### DIFF
--- a/std/string.d
+++ b/std/string.d
@@ -2039,7 +2039,7 @@ auto representation(Char)(Char[] s) @safe pure nothrow @nogc
     if (isSomeChar!Char)
 {
     alias ToRepType(T) = TypeTuple!(ubyte, ushort, uint)[T.sizeof / 2];
-    return cast(ModifyTypePreservingSTC!(ToRepType, Char)[])s;
+    return cast(ModifyTypePreservingTQ!(ToRepType, Char)[])s;
 }
 
 ///
@@ -6182,7 +6182,7 @@ auto assumeUTF(T)(T[] arr) pure
 {
     import std.utf : validate;
     alias ToUTFType(U) = TypeTuple!(char, wchar, dchar)[U.sizeof / 2];
-    auto asUTF = cast(ModifyTypePreservingSTC!(ToUTFType, T)[])arr;
+    auto asUTF = cast(ModifyTypePreservingTQ!(ToUTFType, T)[])arr;
     debug validate(asUTF);
     return asUTF;
 }


### PR DESCRIPTION
Please see https://github.com/D-Programming-Language/phobos/pull/2562 for context.

This change adds a CopyStorageClasses template based on the existing ModifyTypePreservingSTC template. It also makes MutableOf, InoutOf, etc. public so that they can be used in user code.