### PR TITLE
FixedArray & Sorted

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -201,7 +201,7 @@ STD_RANGE_MODULES = $(addprefix std/range/, package primitives interfaces)
 STD_DIGEST_MODULES = $(addprefix std/digest/, digest crc md ripemd sha)
 
 STD_CONTAINER_MODULES = $(addprefix std/container/, package array \
-		binaryheap dlist rbtree slist util)
+		binaryheap dlist rbtree slist util fixedarray sorted)
 
 # OS-specific D modules
 EXTRA_MODULES_LINUX := $(addprefix std/c/linux/, linux socket)

--- a/std/container/fixedarray.d
+++ b/std/container/fixedarray.d
@@ -11,7 +11,7 @@ Array type that uses a random access range as fixed storage location.
 No memory is ever allocated. Throws if not enough space is left
 for an operation to succeed. */
 struct FixedArray(Store)
-    if(isRandomAccessRange!Store)
+    if(isRandomAccessRange!Store && hasLength!Store)
 {
 
 /**

--- a/std/container/fixedarray.d
+++ b/std/container/fixedarray.d
@@ -11,6 +11,7 @@ Array type that uses a random access range as fixed storage location.
 No memory is ever allocated. Throws if not enough space is left
 for an operation to succeed. */
 struct FixedArray(Store)
+    if(isRandomAccessRange!Store)
 {
 
 /**

--- a/std/container/fixedarray.d
+++ b/std/container/fixedarray.d
@@ -259,7 +259,7 @@ Complexity: $(BIGOH log(n)).
      */
     T removeAny()
     {
-        auto result = back;
+        auto result = move(back);
         removeBack();
         return result;
     }

--- a/std/container/fixedarray.d
+++ b/std/container/fixedarray.d
@@ -1,0 +1,410 @@
+module std.container.fixedarray;
+
+import core.exception,
+  std.algorithm, std.conv, std.exception, std.range,
+  std.traits, std.typecons;
+
+public import std.container.util;
+version(unittest) import std.stdio;
+
+/**
+Array type that uses a random access range as fixed storage location. 
+No memory is ever allocated. Throws if not enough space is left
+for an operation to succeed. */
+struct FixedArray(Store)
+{
+    alias Range = Store;
+    alias T = ElementType!Range;
+    private {
+         Store _store;
+         size_t _length;
+    }
+
+/**
+Constructor taking a random access range
+     */
+    this(Store s, size_t initialLength = size_t.max)
+    {
+        _store = s;
+        _length = min(initialLength, _store.length);
+    }
+
+
+/**
+Comparison for equality.
+     */
+    bool opEquals(const FixedArray rhs) const
+    {
+        return opEquals(rhs);
+    }
+
+    /// ditto
+    bool opEquals(ref const FixedArray rhs) const
+    {
+        if(length != rhs.length)
+            return false;
+        return equal(_store[0 .. _length], rhs._store[0 .. _length]);
+    }
+
+/**
+Duplicates the container. The elements themselves are not transitively
+duplicated.
+
+Complexity: $(BIGOH n).
+     */
+    @property FixedArray dup()
+    {
+        return FixedArray(_store.dup, _length);
+    }
+
+/**
+Property returning $(D true) if and only if the container has no
+elements.
+
+Complexity: $(BIGOH 1)
+     */
+    @property bool empty() const
+    {
+        return _length == 0;
+    }
+
+/**
+Returns the number of elements in the container.
+
+Complexity: $(BIGOH 1).
+     */
+    @property size_t length() const
+    {
+        return _length;
+    }
+
+    /// ditto
+    size_t opDollar() const
+    {
+        return length;
+    }
+
+/**
+Set length.
+
+Precondition: $(D 0 <= nlength && nlength <= capacity)
+
+Complexity: $(BIGOH 1).
+     */
+
+    @property void length(size_t nlength) 
+    {
+        enforce(0 <= nlength && nlength <= capacity);
+        _length = nlength;
+    }
+/**
+Returns the maximum number of elements the container can store 
+
+Complexity: $(BIGOH 1)
+     */
+    @property size_t capacity()
+    {
+        return _store.length;
+    }
+
+/**
+Returns a range that iterates over elements of the container, in
+forward order.
+
+Complexity: $(BIGOH 1)
+     */
+    Range opIndex()
+    {
+        return _store[0 .. length];
+    }
+
+/**
+Returns a range that iterates over elements of the container from
+index $(D a) up to (excluding) index $(D b).
+
+Precondition: $(D a <= b && b <= length)
+
+Complexity: $(BIGOH 1)
+     */
+    Range opSlice(size_t i, size_t j)
+    {
+        version (assert) if (i > j || j > length) throw new RangeError();
+        return _store[i .. j];
+    }
+
+
+/**
+Forward to $(D opSlice().front) and $(D opSlice().back), respectively.
+
+Precondition: $(D !empty)
+
+Complexity: $(BIGOH 1)
+     */
+    @property ref T front()
+    {
+        version (assert) if (empty) throw new RangeError();
+        return _store[0];
+    }
+
+    /// ditto
+    @property ref T back()
+    {
+        version (assert) if (empty) throw new RangeError();
+        return _store[length - 1];
+    }
+
+/**
+Indexing operators yield or modify the value at a specified index.
+
+Precondition: $(D i < length)
+
+Complexity: $(BIGOH 1)
+     */
+    ref T opIndex(size_t i)
+    {
+        version (assert) if (i >= _length) throw new RangeError();
+        return _store[i];
+    }
+
+/**
+Slicing operations execute an operation on an entire slice.
+
+Forwards everything to the underlying range.
+
+Precondition: $(D i < j && j < length)
+
+Complexity: $(BIGOH slice.length)
+     */
+    void opSliceAssign(T value)
+    {
+        _store[] = value;
+    }
+
+    /// ditto
+    void opSliceAssign(T value, size_t i, size_t j)
+    {
+        _store[i .. j] = value;
+    }
+
+    /// ditto
+    void opSliceUnary(string op)()
+        if(op == "++" || op == "--")
+    {
+        mixin(op~"_store[];");
+    }
+
+    /// ditto
+    void opSliceUnary(string op)(size_t i, size_t j)
+        if(op == "++" || op == "--")
+    {
+        mixin(op~"_store[i .. j];");
+    }
+
+    /// ditto
+    void opSliceOpAssign(string op)(T value)
+    {
+        mixin("_store[] "~op~"= value;");
+    }
+
+    /// ditto
+    void opSliceOpAssign(string op)(T value, size_t i, size_t j)
+    {
+        mixin("_store[i .. j] "~op~"= value;");
+    }
+
+/**
+Forwards to $(D insertBack(stuff)).
+     */
+    void opOpAssign(string op, Stuff)(Stuff stuff)
+        if (op == "~")
+    {
+        insertBack(stuff);
+    }
+
+/**
+Removes all contents from the container. 
+
+Postcondition: $(D empty)
+
+Complexity: $(BIGOH n)
+     */
+    void clear()
+    {
+        _length = 0;
+    }
+
+/**
+Releases the underlying store. This FixedArray
+instance is unuseable afterwarts.
+
+     */
+    Store release()
+    {
+        auto result = move(_store);
+        return result[0 .. _length];
+    }
+
+/**
+Picks one value in an unspecified position in the container, removes
+it from the container, and returns it. FixedArray forwards removeAny to
+removeBack.
+
+Precondition: $(D !empty)
+
+Returns: The element removed.
+
+Complexity: $(BIGOH log(n)).
+     */
+    T removeAny()
+    {
+        auto result = back;
+        removeBack();
+        return result;
+    }
+    /// ditto
+    alias stableRemoveAny = removeAny;
+/**
+Inserts $(D value) to the front or back of the container. $(D stuff)
+can be a value convertible to $(D T) or a range of objects convertible
+to $(D T). The stable version behaves the same, but guarantees that
+ranges iterating over the container are never invalidated.
+
+Returns: The number of elements inserted
+
+Complexity: $(BIGOH m * log(n)), where $(D m) is the number of
+elements in $(D stuff)
+     */
+    size_t insertBack(Stuff)(Stuff stuff)
+    if (isImplicitlyConvertible!(Stuff, T))
+    {
+        if(length == capacity)
+            throw new RangeError("FixedArray is full");
+        _store[_length] = stuff;
+        ++_length;
+        return 1;
+    }
+
+    /// ditto
+    size_t insertBack(Stuff)(Stuff stuff)
+    if(isInputRange!Stuff && isImplicitlyConvertible!(ElementType!Stuff, T))
+    {
+        static if(hasLength!Stuff)
+        {
+            if(stuff.length > (capacity - length))
+                throw new RangeError("not enough room for stuff");
+        }
+            
+        size_t count;
+        foreach(s; stuff)
+            count += insertBack(s);
+        
+        return count;
+    }
+
+    /// ditto
+    alias insert = insertBack;
+
+/**
+Removes the value at the back of the container. The stable version
+behaves the same, but guarantees that ranges iterating over the
+container are never invalidated.
+
+Precondition: $(D !empty)
+
+Complexity: $(BIGOH log(n)).
+     */
+    void removeBack()
+    {
+        enforce(!empty);
+        /* static if superfluos? */
+        static if (hasElaborateDestructor!T)
+            .destroy(_store[length - 1]);
+        
+        --_length;
+
+    }
+    /// ditto
+    alias stableRemoveBack = removeBack;
+
+/**
+Removes $(D howMany) values at the front or back of the
+container. Unlike the unparameterized versions above, these functions
+do not throw if they could not remove $(D howMany) elements. Instead,
+if $(D howMany > n), all elements are removed. The returned value is
+the effective number of elements removed. The stable version behaves
+the same, but guarantees that ranges iterating over the container are
+never invalidated.
+
+Returns: The number of elements removed
+
+Complexity: $(BIGOH howMany).
+     */
+    size_t removeBack(size_t howMany)
+    {
+        if (howMany > length) howMany = length;
+        static if (hasElaborateDestructor!T)
+            foreach (ref e; _store[length - howMany .. length])
+                .destroy(e);
+
+        _length -= howMany;
+        return howMany;
+    }
+    /// ditto
+    alias stableRemoveBack = removeBack;
+}
+
+/// use static array as store
+unittest
+{
+    size_t[12] store;
+    auto fx = FixedArray!(size_t[])(store[], 0);
+
+    foreach(i; 0 .. store.length)
+        fx.insertBack(i);
+    
+    foreach(i; 1 .. store.length)
+    {
+        assert(fx[i] > fx[i - 1]);
+    }
+
+    try {
+        fx.insertBack(13);
+        assert(false);
+    }
+    catch(RangeError e) {}
+
+    auto firstFive = fx[0 .. 5];
+    assert(equal(firstFive, [0, 1, 2, 3, 4]));
+
+    fx[] = 1;
+    foreach(i; fx[])
+    {
+        assert(i == 1);
+    }
+
+
+}
+
+/**
+ * Wrap store in a fixedArray and return it
+ */
+auto fixedArray(Store)(Store s, size_t initialLength = size_t.max)
+{
+	auto fA = FixedArray!(Store)(s, initialLength);
+	return fA;
+}
+
+/// create a fixed array over  double[]
+unittest
+{
+	double[] store = new double[100];
+	auto fa = fixedArray(store, 50);
+
+	assert(fa.length == 50);
+	assert(fa.capacity == 100);
+
+	assert(10 == fa.removeBack(10));
+	fa[$-1] = 12.0;
+	assert(fa.removeAny() == 12.0);
+}
+

--- a/std/container/fixedarray.d
+++ b/std/container/fixedarray.d
@@ -73,7 +73,7 @@ elements.
 
 Complexity: $(BIGOH 1)
      */
-    @property bool empty() inout
+    @property bool empty() const
     {
         return _length == 0;
     }
@@ -83,7 +83,7 @@ Returns the number of elements in the container.
 
 Complexity: $(BIGOH 1).
      */
-    @property size_t length() inout
+    @property size_t length() const
     {
         return _length;
     }
@@ -94,7 +94,7 @@ Complexity: $(BIGOH 1).
 /**
 Set length.
 
-Precondition: $(D 0 <= nlength && nlength <= capacity)
+Precondition: $(D nlength <= capacity)
 
 Complexity: $(BIGOH 1).
      */
@@ -109,7 +109,7 @@ Returns the maximum number of elements the container can store
 
 Complexity: $(BIGOH 1)
      */
-    @property size_t capacity() inout
+    @property size_t capacity() const
     {
         return _store.length;
     }

--- a/std/container/fixedarray.d
+++ b/std/container/fixedarray.d
@@ -37,13 +37,13 @@ Constructor taking a random access range
 /**
 Comparison for equality.
      */
-    bool opEquals(const FixedArray rhs) const
+    bool opEquals(const FixedArray rhs) inout
     {
         return opEquals(rhs);
     }
 
     /// ditto
-    bool opEquals(ref const FixedArray rhs) const
+    bool opEquals(ref const FixedArray rhs) inout
     {
         if(length != rhs.length)
             return false;
@@ -67,7 +67,7 @@ elements.
 
 Complexity: $(BIGOH 1)
      */
-    @property bool empty() const
+    @property bool empty() inout
     {
         return _length == 0;
     }
@@ -77,7 +77,7 @@ Returns the number of elements in the container.
 
 Complexity: $(BIGOH 1).
      */
-    @property size_t length() const
+    @property size_t length() inout
     {
         return _length;
     }
@@ -103,7 +103,7 @@ Returns the maximum number of elements the container can store
 
 Complexity: $(BIGOH 1)
      */
-    @property size_t capacity()
+    @property size_t capacity() inout
     {
         return _store.length;
     }
@@ -114,7 +114,7 @@ forward order.
 
 Complexity: $(BIGOH 1)
      */
-    Range opIndex()
+    inout(Range) opIndex() inout
     {
         return _store[0 .. length];
     }
@@ -127,7 +127,7 @@ Precondition: $(D a <= b && b <= length)
 
 Complexity: $(BIGOH 1)
      */
-    Range opSlice(size_t i, size_t j)
+    inout(Range) opSlice(size_t i, size_t j) inout
     {
         version (assert) if (i > j || j > length) throw new RangeError();
         return _store[i .. j];
@@ -141,14 +141,14 @@ Precondition: $(D !empty)
 
 Complexity: $(BIGOH 1)
      */
-    @property ref T front()
+    @property ref inout(T) front() inout
     {
         version (assert) if (empty) throw new RangeError();
         return _store[0];
     }
 
     /// ditto
-    @property ref T back()
+    @property ref inout(T) back() inout
     {
         version (assert) if (empty) throw new RangeError();
         return _store[length - 1];
@@ -161,7 +161,7 @@ Precondition: $(D i < length)
 
 Complexity: $(BIGOH 1)
      */
-    ref T opIndex(size_t i)
+    ref inout(T) opIndex(size_t i) inout
     {
         version (assert) if (i >= _length) throw new RangeError();
         return _store[i];

--- a/std/container/fixedarray.d
+++ b/std/container/fixedarray.d
@@ -1,8 +1,7 @@
 module std.container.fixedarray;
 
-import core.exception,
-  std.algorithm, std.conv, std.exception, std.range,
-  std.traits, std.typecons;
+import core.exception, std.algorithm, std.conv, std.exception, std.range,
+        std.traits, std.typecons;
 
 public import std.container.util;
 version(unittest) import std.stdio;
@@ -13,11 +12,16 @@ No memory is ever allocated. Throws if not enough space is left
 for an operation to succeed. */
 struct FixedArray(Store)
 {
+
+/**
+    Random access range that provides the same range primitives as Store.
+    */
     alias Range = Store;
-    alias T = ElementType!Range;
+
     private {
-         Store _store;
-         size_t _length;
+        alias T = ElementType!Range;
+        Store _store;
+        size_t _length;
     }
 
 /**
@@ -79,10 +83,7 @@ Complexity: $(BIGOH 1).
     }
 
     /// ditto
-    size_t opDollar() const
-    {
-        return length;
-    }
+    alias opDollar = length;
 
 /**
 Set length.
@@ -94,7 +95,7 @@ Complexity: $(BIGOH 1).
 
     @property void length(size_t nlength) 
     {
-        enforce(0 <= nlength && nlength <= capacity);
+        version(assert) if (0 <= nlength && nlength <= capacity) throw new RangeError();
         _length = nlength;
     }
 /**
@@ -177,12 +178,13 @@ Complexity: $(BIGOH slice.length)
      */
     void opSliceAssign(T value)
     {
-        _store[] = value;
+        _store[0 .. length] = value;
     }
 
     /// ditto
     void opSliceAssign(T value, size_t i, size_t j)
     {
+        version(assert) if(j < length) throw new RangeError;
         _store[i .. j] = value;
     }
 
@@ -278,7 +280,7 @@ elements in $(D stuff)
     if (isImplicitlyConvertible!(Stuff, T))
     {
         if(length == capacity)
-            throw new RangeError("FixedArray is full");
+            throw new RangeError("not enough room to insert stuff");
         _store[_length] = stuff;
         ++_length;
         return 1;
@@ -291,7 +293,7 @@ elements in $(D stuff)
         static if(hasLength!Stuff)
         {
             if(stuff.length > (capacity - length))
-                throw new RangeError("not enough room for stuff");
+                throw new RangeError("not enough room to insert stuff");
         }
             
         size_t count;
@@ -315,7 +317,7 @@ Complexity: $(BIGOH log(n)).
      */
     void removeBack()
     {
-        enforce(!empty);
+        version(assert) if(!empty) throw new RangeError;
         /* static if superfluos? */
         static if (hasElaborateDestructor!T)
             .destroy(_store[length - 1]);
@@ -381,8 +383,6 @@ unittest
     {
         assert(i == 1);
     }
-
-
 }
 
 /**

--- a/std/container/fixedarray.d
+++ b/std/container/fixedarray.d
@@ -408,3 +408,23 @@ unittest
 	assert(fa.removeAny() == 12.0);
 }
 
+
+// equality
+unittest
+{
+    double[] store = new double[100];
+    auto fa1 = fixedArray(store, 50);
+    fa1[] = 12;
+
+    auto fa2 = fixedArray(new double[100], 50);
+    fa2[] = 12;
+    assert(fa1 == fa2);
+
+    fa2.insertBack([1, 2, 3, 4]);
+    assert(fa1 != fa2);
+    fa2.removeBack(4);
+
+    const fa3 = fixedArray(fa1.release(), 50);
+    assert(fa3 == fa2);
+
+}

--- a/std/container/fixedarray.d
+++ b/std/container/fixedarray.d
@@ -38,13 +38,13 @@ Constructor taking a random access range
 /**
 Comparison for equality.
      */
-    bool opEquals(const FixedArray rhs) inout
+    bool opEquals(FixedArray rhs)
     {
         return opEquals(rhs);
     }
 
     /// ditto
-    bool opEquals(ref const FixedArray rhs) inout
+    bool opEquals(ref FixedArray rhs)
     {
         if(length != rhs.length)
             return false;
@@ -115,7 +115,7 @@ forward order.
 
 Complexity: $(BIGOH 1)
      */
-    inout(Range) opIndex() inout
+    Range opIndex()
     {
         return _store[0 .. length];
     }
@@ -128,7 +128,7 @@ Precondition: $(D a <= b && b <= length)
 
 Complexity: $(BIGOH 1)
      */
-    inout(Range) opSlice(size_t i, size_t j) inout
+    Range opSlice(size_t i, size_t j)
     {
         version (assert) if (i > j || j > length) throw new RangeError();
         return _store[i .. j];
@@ -142,17 +142,17 @@ Precondition: $(D !empty)
 
 Complexity: $(BIGOH 1)
      */
-    @property ref inout(T) front() inout
+    @property ref T front()
     {
         version (assert) if (empty) throw new RangeError();
         return _store[0];
     }
 
     /// ditto
-    @property ref inout(T) back() inout
+    @property ref T back()
     {
         version (assert) if (empty) throw new RangeError();
-        return _store[length - 1];
+        return _store[_length - 1];
     }
 
 /**
@@ -162,7 +162,7 @@ Precondition: $(D i < length)
 
 Complexity: $(BIGOH 1)
      */
-    ref inout(T) opIndex(size_t i) inout
+    ref T opIndex(size_t i)
     {
         version (assert) if (i >= _length) throw new RangeError();
         return _store[i];
@@ -324,7 +324,6 @@ Complexity: $(BIGOH log(n)).
             .destroy(_store[length - 1]);
         
         --_length;
-
     }
     /// ditto
     alias stableRemoveBack = removeBack;
@@ -425,6 +424,6 @@ unittest
     assert(fa1 != fa2);
     fa2.removeBack(4);
 
-    const fa3 = fixedArray(fa1.release(), 50);
+    auto fa3 = fixedArray(fa1.release(), 50);
     assert(fa3 == fa2);
 }

--- a/std/container/fixedarray.d
+++ b/std/container/fixedarray.d
@@ -95,7 +95,7 @@ Complexity: $(BIGOH 1).
 
     @property void length(size_t nlength) 
     {
-        version(assert) if (0 <= nlength && nlength <= capacity) throw new RangeError();
+        version(assert) if (nlength > capacity) throw new RangeError();
         _length = nlength;
     }
 /**
@@ -317,7 +317,7 @@ Complexity: $(BIGOH log(n)).
      */
     void removeBack()
     {
-        version(assert) if(!empty) throw new RangeError;
+        version(assert) if(empty) throw new RangeError;
         /* static if superfluos? */
         static if (hasElaborateDestructor!T)
             .destroy(_store[length - 1]);
@@ -426,5 +426,4 @@ unittest
 
     const fa3 = fixedArray(fa1.release(), 50);
     assert(fa3 == fa2);
-
 }

--- a/std/container/sorted.d
+++ b/std/container/sorted.d
@@ -9,17 +9,14 @@ version(unittest) import std.stdio;
     True if T provides an std.container interface
     with random access.
 */
-template isRAContainer(T)
-{
-    enum isRAContainer = isRandomAccessRange!(typeof(T.init[])) 
-        &&  is(typeof(
-            () {
-                T t = T.init;
-                t.insert(ElementType!(T.Range).init);   
-                t.removeAny();
-             }
-        ));
-}
+enum isRAContainer(T) = isRandomAccessRange!(typeof(T.init[]))
+	&& is(typeof(
+	() {
+		T t = T.init;
+		t.insertBack(ElementType!(T.Range).init);
+		t.removeAny();
+	}
+));a
 
 ///
 unittest

--- a/std/container/sorted.d
+++ b/std/container/sorted.d
@@ -149,6 +149,8 @@ Returns $(D true) if the store is _empty, $(D false) otherwise.
         return length == 0;
     }
 
+static if(is(typeof(_store.dup())))
+{
 /**
 Returns a wrapped duplicate of the store. The underlying store must also
 support a $(D dup) method.
@@ -159,7 +161,7 @@ support a $(D dup) method.
         result._store = _store.dup();
         return result;
     }
-
+}
 /**
 Returns the number of sorted elements.
      */

--- a/std/container/sorted.d
+++ b/std/container/sorted.d
@@ -1,0 +1,534 @@
+module std.container.sorted;
+            
+import std.range;
+import std.traits;
+
+public import std.container.util;
+version(unittest) import std.stdio;
+/**
+    True if T provides an std.container interface
+    with random access.
+*/
+template isRAContainer(T)
+{
+    enum isRAContainer = isRandomAccessRange!(typeof(T.init[])) 
+        &&  is(typeof(
+            () {
+                T t = T.init;
+                t.insert(ElementType!(T.Range).init);   
+                t.removeAny();
+             }
+        ));
+}
+
+///
+unittest
+{
+    import std.container : Array, RedBlackTree;
+    static assert(isRAContainer!(Array!int));
+    static assert(!isRAContainer!(RedBlackTree!int));
+    static assert(!isRAContainer!(int[]));
+}
+
+// Sorted adapter 
+/**
+Implements a automatically sorted 
+container on top of a given random-access range type (usually $(D
+T[])) or a random-access container type (usually $(D Array!T)).
+The documentation of $(D Sorted) will refer to the underlying range or
+container as the $(I store).
+
+If $(D Store) is a range, it is internally wrapped by std.container.FixedArray,
+and $(D Sorted) cannot grow beyond the size of that range. If $(D Store) is a container that supports $(D insertBack), the $(D Sorted) may grow by adding elements to the container.
+     */
+struct Sorted(Store, alias less = "a < b")
+{
+    import std.functional : binaryFun;
+    import std.exception : enforce;
+    import std.range: SortedRange;
+    import std.algorithm : move, min;
+    
+    private: 
+    // Comparison predicate
+    alias comp = binaryFun!(less);
+    static if(isRAContainer!(Store))
+    {
+        alias _Store = Store;
+        enum storeIsContainer = true;
+    }
+    else static if(isRandomAccessRange!(Store))
+    {
+        import std.container.fixedarray;
+        alias _Store = FixedArray!Store;
+        enum storeIsContainer = false;
+    }
+    else
+        static assert(false, "Store must be a random access range or a container providing one");
+
+    alias _Range = SortedRange!(_Store.Range, comp);
+    alias Element = ElementType!_Range; 
+
+    // disable assignment via Range
+    static struct Range
+    {
+        @property 
+        _Range payload;
+        alias payload this;
+        
+        @property 
+        auto ref const(Element) front() { return payload.front; }
+        @property
+        auto ref const(Element) back() { return payload.front; }
+        @disable void opIndexAssign();
+        @disable void opIndexOpAssign();
+    }
+
+
+    _Store _store;
+
+    // Asserts that the store is sorted 
+    void assertSorted()
+    {
+        debug
+        {
+            assert(std.algorithm.isSorted!(comp)(_store()));
+        }
+    }
+
+public:
+
+    /**
+       Sorts store.  If $(D initialSize) is
+       specified, only the first $(D initialSize) elements in $(D s)
+       are sorted, after which the store can grow up
+       to $(D r.length) (if $(D Store) is a range) or indefinitely (if
+       $(D Store) is a container with $(D insertBack)). Performs
+       $(BIGOH min(r.length, initialSize)) evaluations of $(D less).
+     */
+    this(Store s, size_t initialSize = size_t.max)
+    {
+        acquire(s, initialSize);
+    }
+
+/**
+Takes ownership of a store. After this, manipulating $(D s) may make
+brake Sorted
+     */
+    void acquire(Store s, size_t initialSize = size_t.max)
+    {
+        static if(storeIsContainer)
+            _store = move(s);
+        else
+            _store = _Store(move(s));
+        initialSize = min(_store.length, initialSize);
+        _store.length = initialSize;
+        if (length < 2) return;
+
+        std.algorithm.sort!(comp)(_store[0 .. length]);     
+        assertSorted();
+    }
+
+
+/**
+Takes ownership of a store assuming it already was sorted
+    */
+    void assume(Store s, size_t initialSize = size_t.max)
+    {
+        static if(storeIsContainer)
+            _store = move(s);
+        else
+            _store = _Store(move(s));
+        _store.length = min(_store.length, initialSize);
+        assertSorted();
+    }
+
+/**
+Release the store. Returns the portion of the store from $(D 0) up to
+$(D length). The return value is sorted.
+     */
+    Store release()
+    {
+        assertSorted();
+        static if(storeIsContainer)
+            auto result = _store;
+        else
+            auto result = _store.release();
+        _store = _Store.init;
+        return result;
+    }
+
+/**
+Returns $(D true) if the store is _empty, $(D false) otherwise.
+     */
+    @property bool empty()
+    {
+        return length == 0;
+    }
+
+/**
+Returns a wrapped duplicate of the store. The underlying store must also
+support a $(D dup) method.
+     */
+    @property Sorted dup()
+    {
+        Sorted result;
+        result._store = _store.dup();
+        return result;
+    }
+
+/**
+Returns the number of sorted elements.
+     */
+    @property size_t length()
+    {
+        return _store.length;
+    }
+  
+/**
+Returns the _capacity of the store, which is the length of the
+underlying store (if the store is a range) or the _capacity of the
+underlying store (if the store is a container).
+     */
+    @property size_t capacity()
+    {
+        return _store.capacity;
+    }
+
+/**
+Returns a copy of the _front of the store, which is the smallest element
+according to $(D less).
+     */
+    @property ElementType!Store front()
+    {
+        enforce(!empty, "Cannot call front on an empty range.");
+        return _store.front;
+    }
+
+/**
+Returns a copy of the _back of store, which is the biggest element
+according to $(D less).
+     */
+    @property ElementType!Store back()
+    {
+        enforce(!empty, "Cannot call back on an empty range.");
+        return _store.back();
+    }
+
+/**
+Clears the sorted by detaching it from the underlying store.
+     */
+    void clear()
+    {
+        _store = _Store.init;
+    }
+
+
+/**
+Inserts $(D value) into the store. If the underlying store is a range
+and $(D length == capacity), throws an exception.
+     */
+    // Insert one item
+    size_t insertBack(Value)(Value value)
+        if (isImplicitlyConvertible!(Value, ElementType!Store))
+    {
+        _store.insertBack(value);
+        std.algorithm.completeSort!(comp)(assumeSorted!comp(_store[0 .. length-1]), _store[length-1 .. length]);    
+        debug(Sorted) assertSorted();
+        return 1;
+    }
+/** 
+Inserts all elements of range $(D stuff) into store. If the underlying
+store is a range and has not enough space left, throws an exception.
+    */
+    size_t insertBack(Range)(Range stuff)
+        if (isInputRange!Range 
+           && isImplicitlyConvertible!(ElementType!Range, ElementType!Store))
+    {
+
+        // reserve space if underlying container supports it
+        static if(__traits(compiles, _store.reserve(stuff.length)))
+            _store.reserve(length + stuff.length);
+
+        // insert all at once, if possible
+        size_t count;
+        static if(__traits(compiles, _store.insertBack(stuff)))
+        {
+            count = _store.insertBack(stuff);
+        }
+        else
+        {
+            foreach(s; stuff) 
+            { 
+                insertBack(s);
+                count += 1;
+            }
+        }
+
+        assert(count <= length);
+        std.algorithm.completeSort!(comp)(assumeSorted!comp(_store[0 .. length-count]), _store[length-count .. length]);    
+        debug(Sorted) assertSorted();
+        return count;
+    }
+
+    /// ditto   
+    alias insert = insertBack;
+
+
+/**
+      Removes the given range from the store. Note that
+      this method requires r to be optained from this store
+      and the store to be a container.
+     */
+    void remove(Range r)
+    {
+        import std.algorithm : swapRanges;
+        size_t count = r.length;
+        // if the underlying store supports it natively
+        static if(__traits(compiles, _store.remove(r)))
+            _store.remove(r);
+        else
+            // move elements to the end and reduce length of array
+            swapRanges(r.payload, retro(this[].payload));
+
+        _store.length = length - count;
+        sort!comp(_store[]);    
+        assertSorted(); 
+    }
+
+/// ditto
+    void remove(Take!Range r)
+    {
+        Range source = r.source;
+        auto newT = source.payload.take(r.length);
+        import std.algorithm : swapRanges;
+        size_t count = r.length;
+        // if the underlying store supports it natively
+        static if(__traits(compiles, _store.remove(newT)))
+            _store.remove(newT);
+        else
+            // move elements to the end and reduce length of array
+            swapRanges(newT, retro(this[].payload));
+
+        _store.length = length - count;
+        sort!comp(_store[]);    
+        assertSorted(); 
+    }
+
+/**
+Removes the largest element 
+     */
+    void removeBack()
+    {
+        enforce(!empty, "Cannot call removeFront on an empty range.");
+        _store.removeBack();
+    }
+
+    /// ditto
+    alias popBack = removeBack;
+
+
+/**
+Removes the largest element from the store and returns a copy of
+it. This will use the removeBack function of the underlying store.
+     */
+    ElementType!Store removeAny()
+    {
+        auto result = move(_store.back());
+        removeBack();
+        return result;
+    }
+
+/** 
+Return SortedRange for _store
+    */
+    Range opIndex()
+    {
+        import std.range : assumeSorted;
+        return Range(_store[0 .. length].assumeSorted!comp);
+    }
+
+/**
+    Return SortedRange for _store
+    */
+    Range opSlice(size_t start, size_t stop)
+    {
+        enforce(stop <= length);
+        return Range(_store[0 .. stop].assumeSorted!comp);
+    }
+
+/**
+    Return element at index $(D idx)
+    */
+    auto ref const(Element) opIndex(size_t idx)
+    {
+        return _store[idx];
+    }
+
+    size_t opDollar() { return length; }    
+
+
+/**
+Container primitives
+    */
+    Range lowerBound(Value)(Value val)
+    {
+        return Range(this[].lowerBound(val));
+    }   
+
+/// ditto
+    Range upperBound(Value)(Value val)
+    {
+        return Range(this[].upperBound(val));
+    }   
+
+/// ditto
+    Range equalRange(Value)(Value val)
+    {
+        return Range(this[].equalRange(val));
+    }   
+}
+
+/**
+Convenience function that returns a $(D Sorted!(Store, less)) object
+initialized with $(D s) and $(D initialSize).
+ */
+Sorted!(Store, less) sorted(alias less = "a < b", Store)(Store s,
+        size_t initialSize = size_t.max)
+{
+    return Sorted!(Store, less)(s, initialSize);
+}
+
+version(unittest)
+{
+	import std.typetuple;
+	import std.algorithm;
+}
+/// Example sorting an array by wrapping it in Sorted
+unittest
+{
+    import std.algorithm : equal, isSorted;
+    int[] a = [ 4, 1, 3, 2, 16, 9, 10, 14, 8, 7 ];
+    auto s = sorted(a);
+    // largest element
+    assert(s.back == 16);
+    // smallest element
+    assert(s.front == 1);
+    
+    // aassert that s is sorted 
+    assert(isSorted(s.release()));  
+}
+
+/// Call opIndex on $(D Sorted) to optain a $(D SortedRange). 
+unittest
+{
+    import std.container : Array;
+    enum int[] data = [ 4, 1, 3, 2, 16, 9, 10, 14, 8, 7 ];
+    foreach(T; TypeTuple!(int[], Array!int))
+    {
+        import std.algorithm : equal;
+        import std.range : take;
+        T store = [4, 1, 3, 2, 16, 9, 10, 14, 8, 7];
+        auto sortedArray = sorted!("a > b")(store);
+        auto sr = sortedArray[];
+        auto top5 = sr.take(5);
+        assert(top5.equal([16, 14, 10, 9, 8]));
+        
+        assert(equal(sr.lowerBound(7), [16, 14, 10, 9, 8]));
+        assert(equal(sr.upperBound(7), [4, 3, 2, 1]));
+        assert(equal(sr.equalRange(7), [7]));
+
+        // lowerBound, upperBound and equalRange are 
+        // container primitives and should work on Sorted directly
+        assert(equal(sortedArray.lowerBound(7), [16, 14, 10, 9, 8]));
+        assert(equal(sortedArray.upperBound(7), [4, 3, 2, 1]));
+        assert(equal(sortedArray.equalRange(7), [7]));
+
+
+        // test for subranges as well
+        sr = sortedArray[0 .. 5];
+        assert(equal(sr, [16, 14, 10, 9, 8]));
+    }   
+    
+}
+
+unittest
+{
+    import std.container : Array;
+    enum int[] data = [ 4, 1, 3, 2, 16, 9, 10, 14, 8, 7 ];
+    foreach(T; TypeTuple!(int[], Array!int))
+    {
+        T a = data;
+        auto h = sorted!("a > b")(a);
+        assert(h.front == 16);
+        assert(equal(a[], [ 16, 14, 10, 9, 8, 7, 4, 3, 2, 1 ]));
+        auto witness = [ 16, 14, 10, 9, 8, 7, 4, 3, 2, 1 ];
+        for (; !h.empty; h.removeBack(), witness.popBack())
+        {
+            assert(!witness.empty);
+            assert(witness.back == h.back);
+        }
+        assert(witness.empty);
+    }
+}
+
+// remove elements via range
+unittest
+{
+    {
+        import std.container : Array;
+        enum int[] a = [ 4, 1, 3, 2, 16, 9, 10, 14, 8, 7 ];
+        foreach(T; TypeTuple!(int[], Array!int))
+        {
+            T store = a;
+            auto s = sorted!("a < b")(store);
+            assert(s.back == 16);
+
+            auto removeThese = s[].drop(s.length - 2);
+            s.remove(removeThese);
+            assert(equal(s[], [1, 2, 3, 4, 7, 8, 9, 10]));
+
+            s.remove(s[].drop(2).take(2));
+            assert(equal(s[], [1, 2, 7, 8, 9, 10]));
+
+            s.remove(s[].take(2));
+            assert(equal(s[], [ 7, 8, 9, 10]));
+        }
+    }
+}
+
+unittest
+{
+    int[] a = [1, 2, 3, 4];
+    auto sa = sorted(a);
+    auto s = sa[];
+    static assert(!is(typeof(s.front() = 12)));
+    static assert(!is(typeof(s.back() = 12)));
+    static assert(!is(typeof(s[1] = 12)));
+}
+
+// test insertion
+unittest 
+{
+    import std.array, std.random, std.container;
+    {
+        int[] inputs = iota(20).map!(x => uniform(0, 1000)).array;
+        auto sa = Sorted!(Array!int)();
+        foreach(i; inputs)
+            sa.insertBack(i);
+
+        foreach(idx; 1 .. sa.length())
+            assert(sa[idx-1] <= sa[idx]);
+
+        assert(sa.length == 20);
+    }
+    {
+        auto inputs = iota(20).map!(x => uniform(0, 1000));
+        auto sa = Sorted!(Array!int)();
+        sa.insertBack(inputs);
+
+        foreach(idx; 1 .. sa.length())
+            assert(sa[idx-1] <= sa[idx]);
+        
+        assert(sa.length == 20);
+    }
+}

--- a/std/container/sorted.d
+++ b/std/container/sorted.d
@@ -53,14 +53,14 @@ struct Sorted(Store, alias less = "a < b")
         alias _Store = Store;
         enum storeIsContainer = true;
     }
-    else static if(isRandomAccessRange!(Store))
+    else static if(isRandomAccessRange!(Store) && hasLength!Store)
     {
         import std.container.fixedarray;
         alias _Store = FixedArray!Store;
         enum storeIsContainer = false;
     }
     else
-        static assert(false, "Store must be a random access range or a container providing one");
+        static assert(false, "Store must be a random access range with a length property or a container providing one");
 
     _Store _store;
 

--- a/std/container/sorted.d
+++ b/std/container/sorted.d
@@ -330,6 +330,19 @@ Return SortedRange for _store
 
 
 /**
+ * Return to the first occurence of $(D elem) in store
+ * or null.
+	*/
+	Element* opBinaryRight(string op)(Element e)
+		if(op == "in")
+	{
+		auto er = this.equalRange(e);
+        if(er.empty)
+            return null;
+        return cast(Element*) &er.front();
+	}
+
+/**
 Container primitives
     */
     Range lowerBound(Value)(Value val)
@@ -483,4 +496,21 @@ unittest
         
         assert(sa.length == 20);
     }
+}
+
+// opIn
+unittest
+{
+	import std.array, std.container;
+    enum int[] data = [ 4, 1, 3, 2, 16, 9, 10, 14, 8, 7 ];
+    foreach(T; TypeTuple!(int[], Array!int))
+    {
+        import std.algorithm : equal;
+        import std.range : take;
+        T store = [4, 1, 3, 2, 16, 9, 10, 14, 8, 7];
+		auto sa = sorted(store);
+
+		assert((11 in sa) is null);
+		assert(*(16 in sa) == sa.back());
+	}
 }

--- a/std/container/sorted.d
+++ b/std/container/sorted.d
@@ -144,7 +144,7 @@ $(D length). The return value is sorted.
 /**
 Returns $(D true) if the store is _empty, $(D false) otherwise.
      */
-    @property bool empty() inout
+    @property bool empty() const
     {
         return length == 0;
     }
@@ -165,7 +165,7 @@ support a $(D dup) method.
 /**
 Returns the number of sorted elements.
      */
-    @property size_t length() inout
+    @property size_t length() const
     {
         return _store.length;
     }


### PR DESCRIPTION
This implements two different wrapper structs.

Sorted is designed as a wrapper around a random access range or a container that guarantees  that all elements are stored in sorted order. It should offer all possible container primitives, especially  those that require log(n) search, like lowerBound, upperBound and equalRange.

FixedArray takes a random access range and offers an interface similar to std.container.Array using this range as storage. This is used by std.container.Sorted and could be used by std.container.BinaryHeap as well.

Neither FixedArray nor Sorted use RefCounted to keep track of it's storage, see and answer
http://forum.dlang.org/thread/uapqmdbtadpwnciwfdwn@forum.dlang.org
if you don't agree.
