### PR TITLE
Fix Issue 13781 - Tuple assign should be @nogc

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -2670,7 +2670,7 @@ If $(D lhs) and $(D rhs) reference the same instance, then nothing is done.
 $(D lhs) and $(D rhs) must be mutable. If $(D T) is a struct or union, then
 its fields must also all be (recursively) mutable.
 */
-void swap(T)(ref T lhs, ref T rhs) @trusted pure nothrow
+void swap(T)(ref T lhs, ref T rhs) @trusted pure nothrow @nogc
 if (isBlitAssignable!T && !is(typeof(lhs.proxySwap(rhs))))
 {
     static if (hasAliasing!T) if (!__ctfe)
@@ -2854,6 +2854,25 @@ unittest // 9975
     assertThrown!Error(move(p));
     assertThrown!Error(move(p, pp));
     assertThrown!Error(swap(p, pp));
+}
+
+unittest
+{
+    static struct A
+    {
+        int* x;
+        this(this) { x = new int; }
+    }
+    A a1, a2;
+    swap(a1, a2);
+
+    static struct B
+    {
+        int* x;
+        void opAssign(B) { x = new int; }
+    }
+    B b1, b2;
+    swap(b1, b2);
 }
 
 void swapFront(R1, R2)(R1 r1, R2 r2)

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1124,6 +1124,13 @@ unittest
     a = b;
 }
 
+@nogc unittest
+{
+    alias T = Tuple!(string, "s");
+    T x;
+    x = T.init;
+}
+
 /**
 Returns a $(D Tuple) object instantiated and initialized according to
 the arguments.


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13781

@9rnsr explains why Tuple.opAssign isn't deduced to be @nogc:

"'swap' is used from the opAssign template function in Tuple, but swap checks (hasElaborateAssign!T || !isAssignable!T) and it would see the signature of T.opAssign. On mutual function calls, attributes are inferred as non-@nogc by default. It's a design so this is not a compiler bug.

The correct fix is to mark std.algorithm.swap function as @nogc."