### PR TITLE
Fix #13872

### DIFF
--- a/std/container/package.d
+++ b/std/container/package.d
@@ -220,7 +220,7 @@ $(BOOKTABLE Container primitives,
 $(TR $(TH Syntax) $(TH $(BIGOH &middot;)) $(TH Description))
 
 $(TR $(TDNW $(D C(x))) $(TDNW $(D n$(SUBSCRIPT x))) $(TD Creates a
-_container of type $(D C) from either another _container or a range.))
+_container of type $(D C) from either another _container or a range. The created _container must not be a null reference even if x is empty.))
 
 $(TR $(TDNW $(D c.dup)) $(TDNW $(D n$(SUBSCRIPT c))) $(TD Returns a
 duplicate of the _container.))


### PR DESCRIPTION
std.container.make!(Array!T) now returns a reference
to an actual container, not a 'null reference' that
initializes itself upon use.

A more elegant solution would be to provide an overload for Array, but if I define it in std/container/array.d it will issue a conflict (even if the template is more specialized) and to do it in std/container/util.d would require to import std.container.array and I am not sure if we want that, because of the ongoing effort to decouple the imports in phobos. Regardless, setting length to 0 shouldn't be a problem for any struct based container constructed without arguments.