### PR TITLE
std.algorithm: fix execrable formatting

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -78,302 +78,222 @@ sort(a);            // no predicate, "a < b" is implicit
 ----
 
 $(BOOKTABLE Cheat Sheet,
-$(TR $(TH Function Name) $(TH Description)
-)
-$(LEADINGROW Searching
-)
-$(TR $(TDNW $(LREF all)) $(TD $(D all!"a > 0"([1, 2, 3, 4])) returns $(D true) because all elements are positive)
-)
-$(TR $(TDNW $(LREF any)) $(TD $(D any!"a > 0"([1, 2, -3, -4])) returns $(D true) because at least one element is positive)
-)
-$(TR $(TDNW $(LREF balancedParens)) $(TD $(D
-balancedParens("((1 + 1) / 2)")) returns $(D true) because the string
-has balanced parentheses.)
-)
-$(TR $(TDNW $(LREF boyerMooreFinder)) $(TD $(D find("hello
-world", boyerMooreFinder("or"))) returns $(D "orld") using the $(LUCKY
-Boyer-Moore _algorithm).)
-)
-$(TR $(TDNW $(LREF canFind)) $(TD $(D canFind("hello world",
-"or")) returns $(D true).)
-)
-$(TR $(TDNW $(LREF count)) $(TD Counts elements that are equal
-to a specified value or satisfy a predicate. $(D count([1, 2, 1], 1))
-returns $(D 2) and $(D count!"a < 0"([1, -3, 0])) returns $(D 1).)
-)
-$(TR $(TDNW $(LREF countUntil)) $(TD $(D countUntil(a, b))
-returns the number of steps taken in $(D a) to reach $(D b); for
-example, $(D countUntil("hello!", "o")) returns $(D 4).)
-)
-$(TR $(TDNW $(LREF commonPrefix)) $(TD $(D commonPrefix("parakeet",
-"parachute")) returns $(D "para").)
-)
-$(TR $(TDNW $(LREF endsWith)) $(TD $(D endsWith("rocks", "ks"))
-returns $(D true).)
-)
-$(TR $(TD $(LREF find)) $(TD $(D find("hello world",
-"or")) returns $(D "orld") using linear search. (For binary search refer
-to $(XREF range,sortedRange).))
-)
-$(TR $(TDNW $(LREF findAdjacent)) $(TD $(D findAdjacent([1, 2,
-3, 3, 4])) returns the subrange starting with two equal adjacent
-elements, i.e. $(D [3, 3, 4]).)
-)
-$(TR $(TDNW $(LREF findAmong)) $(TD $(D findAmong("abcd",
-"qcx")) returns $(D "cd") because $(D 'c') is among $(D "qcx").)
-)
-$(TR $(TDNW $(LREF findSkip)) $(TD If $(D a = "abcde"), then
-$(D findSkip(a, "x")) returns $(D false) and leaves $(D a) unchanged,
-whereas $(D findSkip(a, 'c')) advances $(D a) to $(D "cde") and
-returns $(D true).)
-)
-$(TR $(TDNW $(LREF findSplit)) $(TD $(D findSplit("abcdefg",
-"de")) returns the three ranges $(D "abc"), $(D "de"), and $(D
-"fg").)
-)
-$(TR $(TDNW $(LREF findSplitAfter)) $(TD $(D
-findSplitAfter("abcdefg", "de")) returns the two ranges $(D "abcde")
-and $(D "fg").)
-)
-$(TR $(TDNW $(LREF findSplitBefore)) $(TD $(D
-findSplitBefore("abcdefg", "de")) returns the two ranges $(D "abc") and
-$(D "defg").)
-)
-$(TR $(TDNW $(LREF minCount)) $(TD $(D minCount([2, 1, 1, 4,
-1])) returns $(D tuple(1, 3)).)
-)
-$(TR $(TDNW $(LREF minPos)) $(TD $(D minPos([2, 3, 1, 3, 4,
-1])) returns the subrange $(D [1, 3, 4, 1]), i.e., positions the range
-at the first occurrence of its minimal element.)
-)
-$(TR $(TDNW $(LREF mismatch)) $(TD $(D mismatch("parakeet", "parachute"))
-returns the two ranges $(D "keet") and $(D "chute").)
-)
-$(TR $(TDNW $(LREF skipOver)) $(TD Assume $(D a = "blah"). Then
-$(D skipOver(a, "bi")) leaves $(D a) unchanged and returns $(D false),
-whereas $(D skipOver(a, "bl")) advances $(D a) to refer to $(D "ah")
-and returns $(D true).)
-)
-$(TR $(TDNW $(LREF startsWith)) $(TD $(D startsWith("hello,
-world", "hello")) returns $(D true).)
-)
-$(TR $(TDNW $(LREF until)) $(TD Lazily iterates a range
-until a specific value is found.)
-)
-$(LEADINGROW Comparison
-)
-$(TR $(TDNW $(LREF among)) $(TD Checks if a value is among a set
-of values, e.g. $(D if (v.among(1, 2, 3)) // `v` is 1, 2 or 3))
-)
-$(TR $(TDNW $(LREF castSwitch)) $(TD $(D (new A()).castSwitch((A a)=>1,(B
-b)=>2)) returns $(D 1).)
-)
-$(TR $(TDNW $(LREF clamp)) $(TD $(D clamp(1, 3, 6)) returns $(D
-3). $(D clamp(4, 3, 6)) returns $(D 4).)
-)
-$(TR $(TDNW $(LREF cmp)) $(TD $(D cmp("abc", "abcd")) is $(D
--1), $(D cmp("abc", "aba")) is $(D 1), and $(D cmp("abc", "abc")) is
-$(D 0).)
-)
-$(TR $(TDNW $(LREF equal)) $(TD Compares ranges for
-element-by-element equality, e.g. $(D equal([1, 2, 3], [1.0, 2.0,
-3.0])) returns $(D true).)
-)
-$(TR $(TDNW $(LREF levenshteinDistance)) $(TD $(D
-levenshteinDistance("kitten", "sitting")) returns $(D 3) by using the
-$(LUCKY Levenshtein distance _algorithm).)
-)
-$(TR $(TDNW $(LREF levenshteinDistanceAndPath)) $(TD $(D
-levenshteinDistanceAndPath("kitten", "sitting")) returns $(D tuple(3,
-"snnnsni")) by using the $(LUCKY Levenshtein distance _algorithm).)
-)
-$(TR $(TDNW $(LREF max)) $(TD $(D max(3, 4, 2)) returns $(D
-4).)
-)
-$(TR $(TDNW $(LREF min)) $(TD $(D min(3, 4, 2)) returns $(D
-2).)
-)
-$(TR $(TDNW $(LREF mismatch)) $(TD $(D mismatch("oh hi",
-"ohayo")) returns $(D tuple(" hi", "ayo")).)
-)
-$(TR $(TDNW $(LREF predSwitch)) $(TD $(D 2.predSwitch(1, "one", 2, "two",
-3, "three")) returns $(D "two").)
-)
-$(LEADINGROW Iteration
-)
-$(TR $(TDNW $(LREF cache)) $(TD Eagerly evaluates and caches
-another range's $(D front).)
-)
-$(TR $(TDNW $(LREF cacheBidirectional)) $(TD As above, but also
-provides $(D back) and $(D popBack).)
-)
-$(TR $(TDNW $(LREF filter)) $(TD $(D filter!"a > 0"([1, -1, 2,
-0, -3])) iterates over elements $(D 1) and $(D 2).)
-)
-$(TR $(TDNW $(LREF filterBidirectional)) $(TD Similar to $(D
-filter), but also provides $(D back) and $(D popBack) at a small
-increase in cost.)
-)
-$(TR $(TDNW $(LREF group)) $(TD $(D group([5, 2, 2, 3, 3]))
-returns a range containing the tuples $(D tuple(5, 1)),
-$(D tuple(2, 2)), and $(D tuple(3, 2)).)
-)
-$(TR $(TDNW $(LREF groupBy)) $(TD $(D groupBy!((a,b) => a[1] == b[1])([[1, 1], [1, 2], [2, 2], [2, 1]]))
-returns a range containing 3 subranges: the first with just $(D [1, 1]); the
-second with the elements $(D [1, 2]) and $(D [2, 2]); and the third with just
-$(D [2, 1]).)
-)
-$(TR $(TDNW $(LREF joiner)) $(TD $(D joiner(["hello",
-"world!"], "; ")) returns a range that iterates over the characters $(D
-"hello; world!"). No new string is created - the existing inputs are
-iterated.)
-)
-$(TR $(TDNW $(LREF map)) $(TD $(D map!"2 * a"([1, 2, 3]))
-lazily returns a range with the numbers $(D 2), $(D 4), $(D 6).)
-)
-$(TR $(TDNW $(LREF reduce)) $(TD $(D reduce!"a + b"([1, 2, 3,
-4])) returns $(D 10).)
-)
-$(TR $(TDNW $(LREF splitter)) $(TD Lazily splits a range by a
-separator.)
-)
-$(TR $(TDNW $(LREF sum)) $(TD Same as $(D reduce), but specialized for
-accurate summation.)
-)
-$(TR $(TDNW $(LREF uniq)) $(TD Iterates over the unique elements
-in a range, which is assumed sorted.)
-)
-$(LEADINGROW Sorting
-)
-$(TR $(TDNW $(LREF completeSort)) $(TD If $(D a = [10, 20, 30])
-and $(D b = [40, 6, 15]), then $(D completeSort(a, b)) leaves $(D a =
-[6, 10, 15]) and $(D b = [20, 30, 40]). The range $(D a) must be
-sorted prior to the call, and as a result the combination $(D $(XREF
-range,chain)(a, b)) is sorted.)
-)
-$(TR $(TDNW $(LREF isPartitioned)) $(TD $(D isPartitioned!"a <
-0"([-1, -2, 1, 0, 2])) returns $(D true) because the predicate is $(D
-true) for a portion of the range and $(D false) afterwards.)
-)
-$(TR $(TDNW $(LREF isSorted)) $(TD $(D isSorted([1, 1, 2, 3]))
-returns $(D true).)
-)
-$(TR $(TDNW $(LREF makeIndex)) $(TD Creates a separate index
-for a range.)
-)
-$(TR $(TDNW $(LREF nextPermutation)) $(TD Computes the next lexicographically
-greater permutation of a range in-place.)
-)
-$(TR $(TDNW $(LREF nextEvenPermutation)) $(TD Computes the next
-lexicographically greater even permutation of a range in-place.)
-)
-$(TR $(TDNW $(LREF partialSort)) $(TD If $(D a = [5, 4, 3, 2,
-1]), then $(D partialSort(a, 3)) leaves $(D a[0 .. 3] = [1, 2,
-3]). The other elements of $(D a) are left in an unspecified order.)
-)
-$(TR $(TDNW $(LREF partition)) $(TD Partitions a range
-according to a predicate.)
-)
-$(TR $(TDNW $(LREF partition3)) $(TD Partitions a range
-in three parts (less than, equal, greater than the given pivot).)
-)
-$(TR $(TDNW $(LREF schwartzSort)) $(TD Sorts with the help of
-the $(LUCKY Schwartzian transform).)
-)
-$(TR $(TDNW $(LREF sort)) $(TD Sorts.)
-)
-$(TR $(TDNW $(LREF topN)) $(TD Separates the top elements in a
-range.)
-)
-$(TR $(TDNW $(LREF topNCopy)) $(TD Copies out the top elements
-of a range.)
-)
-$(LEADINGROW Set operations
-)
-$(TR $(TDNW $(LREF cartesianProduct)) $(TD Computes Cartesian product of two
-ranges.)
-)
-$(TR $(TDNW $(LREF largestPartialIntersection)) $(TD Copies out
-the values that occur most frequently in a range of ranges.)
-)
-$(TR $(TDNW $(LREF largestPartialIntersectionWeighted)) $(TD
-Copies out the values that occur most frequently (multiplied by
-per-value weights) in a range of ranges.)
-)
-$(TR $(TDNW $(LREF nWayUnion)) $(TD Computes the union of a set
-of sets implemented as a range of sorted ranges.)
-)
-$(TR $(TDNW $(LREF setDifference)) $(TD Lazily computes the set
-difference of two or more sorted ranges.)
-)
-$(TR $(TDNW $(LREF setIntersection)) $(TD Lazily computes the
-intersection of two or more sorted ranges.)
-)
-$(TR $(TDNW $(LREF setSymmetricDifference)) $(TD Lazily
-computes the symmetric set difference of two or more sorted ranges.)
-)
-$(TR $(TDNW $(LREF setUnion)) $(TD Lazily computes the set
-union of two or more sorted ranges.)
-)
-$(LEADINGROW Mutation
-)
-$(TR $(TDNW $(LREF bringToFront)) $(TD If $(D a = [1, 2, 3])
-and $(D b = [4, 5, 6, 7]), $(D bringToFront(a, b)) leaves $(D a = [4,
-5, 6]) and $(D b = [7, 1, 2, 3]).)
-)
-$(TR $(TDNW $(LREF copy)) $(TD Copies a range to another. If
-$(D a = [1, 2, 3]) and $(D b = new int[5]), then $(D copy(a, b))
-leaves $(D b = [1, 2, 3, 0, 0]) and returns $(D b[3 .. $]).)
-)
-$(TR $(TDNW $(LREF fill)) $(TD Fills a range with a pattern,
-e.g., if $(D a = new int[3]), then $(D fill(a, 4)) leaves $(D a = [4,
-4, 4]) and $(D fill(a, [3, 4])) leaves $(D a = [3, 4, 3]).)
-)
-$(TR $(TDNW $(LREF initializeAll)) $(TD If $(D a = [1.2, 3.4]),
-then $(D initializeAll(a)) leaves $(D a = [double.init,
-double.init]).)
-)
-$(TR $(TDNW $(LREF move)) $(TD $(D move(a, b)) moves $(D a)
-into $(D b). $(D move(a)) reads $(D a) destructively.)
-)
-$(TR $(TDNW $(LREF moveAll)) $(TD Moves all elements from one
-range to another.)
-)
-$(TR $(TDNW $(LREF moveSome)) $(TD Moves as many elements as
-possible from one range to another.)
-)
-$(TR $(TDNW $(LREF remove)) $(TD Removes elements from a range
-in-place, and returns the shortened range.)
-)
-$(TR $(TDNW $(LREF reverse)) $(TD If $(D a = [1, 2, 3]), $(D
-reverse(a)) changes it to $(D [3, 2, 1]).)
-)
-$(TR $(TDNW $(LREF strip)) $(TD Strips all leading and trailing
-elements equal to a value, or that satisfy a predicate.
-If $(D a = [1, 1, 0, 1, 1]), then $(D strip(a, 1)) and $(D strip!(e => e == 1)(a))
-returns $(D [0]).)
-)
-$(TR $(TDNW $(LREF stripLeft)) $(TD Strips all leading elements equal to a value,
-or that satisfy a predicate.
-If $(D a = [1, 1, 0, 1, 1]), then $(D stripLeft(a, 1)) and $(D stripLeft!(e => e == 1)(a))
-returns $(D [0, 1, 1]).)
-)
-$(TR $(TDNW $(LREF stripRight)) $(TD Strips all trailing elements equal to a value,
-or that satisfy a predicate.
-If $(D a = [1, 1, 0, 1, 1]), then $(D stripRight(a, 1)) and $(D stripRight!(e => e == 1)(a))
-returns $(D [1, 1, 0]).)
-)
-$(TR $(TDNW $(LREF swap)) $(TD Swaps two values.)
-)
-$(TR $(TDNW $(LREF swapRanges)) $(TD Swaps all elements of two
-ranges.)
-)
-$(TR $(TDNW $(LREF uninitializedFill)) $(TD Fills a range
-(assumed uninitialized) with a value.)
-)
+
+$(TR $(TH Function Name) $(TH Description))
+
+$(LEADINGROW Searching)
+
+$(T2 all,
+        $(D all!"a > 0"([1, 2, 3, 4])) returns $(D true) because all elements are positive)
+$(T2 any,
+        $(D any!"a > 0"([1, 2, -3, -4])) returns $(D true) because at least one element is positive)
+$(T2 balancedParens,
+        $(D balancedParens("((1 + 1) / 2)")) returns $(D true) because the string has balanced parentheses.)
+$(T2 boyerMooreFinder,
+        $(D find("hello world", boyerMooreFinder("or"))) returns $(D "orld") using the $(LUCKY Boyer-Moore _algorithm).)
+$(T2 canFind,
+        $(D canFind("hello world", "or")) returns $(D true).)
+$(T2 count,
+        Counts elements that are equal to a specified value or satisfy a predicate.
+        $(D count([1, 2, 1], 1)) returns $(D 2) and $(D count!"a < 0"([1, -3, 0])) returns $(D 1).)
+$(T2 countUntil,
+        $(D countUntil(a, b)) returns the number of steps taken in $(D a) to reach $(D b);
+        for example, $(D countUntil("hello!", "o")) returns $(D 4).)
+$(T2 commonPrefix,
+        $(D commonPrefix("parakeet", "parachute")) returns $(D "para").)
+$(T2 endsWith,
+        $(D endsWith("rocks", "ks")) returns $(D true).)
+$(T2 find,
+        $(D find("hello world", "or")) returns $(D "orld") using linear search.
+        (For binary search refer to $(XREF range,sortedRange).))
+$(T2 findAdjacent,
+        $(D findAdjacent([1, 2, 3, 3, 4])) returns the subrange starting with two equal adjacent elements, i.e. $(D [3, 3, 4]).)
+$(T2 findAmong,
+        $(D findAmong("abcd", "qcx")) returns $(D "cd") because $(D 'c') is among $(D "qcx").)
+$(T2 findSkip,
+        If $(D a = "abcde"), then $(D findSkip(a, "x")) returns $(D false) and leaves $(D a) unchanged,
+        whereas $(D findSkip(a, 'c')) advances $(D a) to $(D "cde") and returns $(D true).)
+$(T2 findSplit,
+        $(D findSplit("abcdefg", "de")) returns the three ranges $(D "abc"), $(D "de"), and $(D "fg").)
+$(T2 findSplitAfter,
+        $(D findSplitAfter("abcdefg", "de")) returns the two ranges $(D "abcde") and $(D "fg").)
+$(T2 findSplitBefore,
+        $(D findSplitBefore("abcdefg", "de")) returns the two ranges $(D "abc") and $(D "defg").)
+$(T2 minCount,
+        $(D minCount([2, 1, 1, 4, 1])) returns $(D tuple(1, 3)).)
+$(T2 minPos,
+        $(D minPos([2, 3, 1, 3, 4, 1])) returns the subrange $(D [1, 3, 4, 1]),
+        i.e., positions the range at the first occurrence of its minimal element.)
+$(T2 mismatch,
+        $(D mismatch("parakeet", "parachute")) returns the two ranges $(D "keet") and $(D "chute").)
+$(T2 skipOver,
+        Assume $(D a = "blah"). Then $(D skipOver(a, "bi")) leaves $(D a) unchanged and returns $(D false),
+        whereas $(D skipOver(a, "bl")) advances $(D a) to refer to $(D "ah")
+        and returns $(D true).)
+$(T2 startsWith,
+        $(D startsWith("hello, world", "hello")) returns $(D true).)
+$(T2 until,
+        Lazily iterates a range until a specific value is found.)
+
+$(LEADINGROW Comparison)
+
+$(T2 among,
+        Checks if a value is among a set of values, e.g. $(D if (v.among(1, 2, 3)) // `v` is 1, 2 or 3))
+$(T2 castSwitch,
+        $(D (new A()).castSwitch((A a)=>1,(B b)=>2)) returns $(D 1).)
+$(T2 clamp,
+        $(D clamp(1, 3, 6)) returns $(D 3). $(D clamp(4, 3, 6)) returns $(D 4).)
+$(T2 cmp,
+        $(D cmp("abc", "abcd")) is $(D -1), $(D cmp("abc", "aba")) is $(D 1), and $(D cmp("abc", "abc")) is $(D 0).)
+$(T2 equal,
+        Compares ranges for element-by-element equality, e.g. $(D equal([1, 2, 3], [1.0, 2.0, 3.0])) returns $(D true).)
+$(T2 levenshteinDistance,
+        $(D levenshteinDistance("kitten", "sitting")) returns $(D 3) by using the
+        $(LUCKY Levenshtein distance _algorithm).)
+$(T2 levenshteinDistanceAndPath,
+        $(D levenshteinDistanceAndPath("kitten", "sitting")) returns $(D tuple(3, "snnnsni"))
+        by using the $(LUCKY Levenshtein distance _algorithm).)
+$(T2 max,
+        $(D max(3, 4, 2)) returns $(D 4).)
+$(T2 min,
+        $(D min(3, 4, 2)) returns $(D 2).)
+$(T2 mismatch,
+        $(D mismatch("oh hi", "ohayo")) returns $(D tuple(" hi", "ayo")).)
+$(T2 predSwitch,
+        $(D 2.predSwitch(1, "one", 2, "two", 3, "three")) returns $(D "two").)
+
+$(LEADINGROW Iteration)
+
+$(T2 cache,
+        Eagerly evaluates and caches another range's $(D front).)
+$(T2 cacheBidirectional,
+        As above, but also provides $(D back) and $(D popBack).)
+$(T2 filter,
+        $(D filter!"a > 0"([1, -1, 2, 0, -3])) iterates over elements $(D 1) and $(D 2).)
+$(T2 filterBidirectional,
+        Similar to $(D filter), but also provides $(D back) and $(D popBack) at a small increase in cost.)
+$(T2 group,
+        $(D group([5, 2, 2, 3, 3])) returns a range containing the tuples $(D tuple(5, 1)), $(D tuple(2, 2)), and $(D tuple(3, 2)).)
+$(T2 groupBy,
+        $(D groupBy!((a,b) => a[1] == b[1])([[1, 1], [1, 2], [2, 2], [2, 1]]))
+        returns a range containing 3 subranges: the first with just $(D [1, 1]);
+        the second with the elements $(D [1, 2]) and $(D [2, 2]);
+        and the third with just $(D [2, 1]).)
+$(T2 joiner,
+        $(D joiner(["hello", "world!"], "; ")) returns a range that iterates over the characters
+        $(D "hello; world!"). No new string is created - the existing inputs are iterated.)
+$(T2 map,
+        $(D map!"2 * a"([1, 2, 3])) lazily returns a range with the numbers $(D 2), $(D 4), $(D 6).)
+$(T2 reduce,
+        $(D reduce!"a + b"([1, 2, 3, 4])) returns $(D 10).)
+$(T2 splitter,
+        Lazily splits a range by a separator.)
+$(T2 sum,
+        Same as $(D reduce), but specialized for accurate summation.)
+$(T2 uniq,
+        Iterates over the unique elements in a range, which is assumed sorted.)
+
+$(LEADINGROW Sorting)
+
+$(T2 completeSort,
+        If $(D a = [10, 20, 30]) and $(D b = [40, 6, 15]), then $(D completeSort(a, b)) leaves
+        $(D a = [6, 10, 15]) and $(D b = [20, 30, 40]).
+        The range $(D a) must be sorted prior to the call, and as a result the combination
+        $(D $(XREF range,chain)(a, b)) is sorted.)
+$(T2 isPartitioned,
+        $(D isPartitioned!"a < 0"([-1, -2, 1, 0, 2])) returns $(D true) because the predicate is
+        $(D true) for a portion of the range and $(D false) afterwards.)
+$(T2 isSorted,
+        $(D isSorted([1, 1, 2, 3])) returns $(D true).)
+$(T2 makeIndex,
+        Creates a separate index for a range.)
+$(T2 nextPermutation,
+        Computes the next lexicographically greater permutation of a range in-place.)
+$(T2 nextEvenPermutation,
+        Computes the next lexicographically greater even permutation of a range in-place.)
+$(T2 partialSort,
+        If $(D a = [5, 4, 3, 2, 1]), then $(D partialSort(a, 3)) leaves
+        $(D a[0 .. 3] = [1, 2, 3]).
+        The other elements of $(D a) are left in an unspecified order.)
+$(T2 partition,
+        Partitions a range according to a predicate.)
+$(T2 partition3,
+        Partitions a range in three parts (less than, equal, greater than the given pivot).)
+$(T2 schwartzSort,
+        Sorts with the help of the $(LUCKY Schwartzian transform).)
+$(T2 sort,
+        Sorts.)
+$(T2 topN,
+        Separates the top elements in a range.)
+$(T2 topNCopy,
+        Copies out the top elements of a range.)
+
+$(LEADINGROW Set operations)
+
+$(T2 cartesianProduct,
+        Computes Cartesian product of two ranges.)
+$(T2 largestPartialIntersection,
+        Copies out the values that occur most frequently in a range of ranges.)
+$(T2 largestPartialIntersectionWeighted,
+        Copies out the values that occur most frequently (multiplied by per-value weights) in a range of ranges.)
+$(T2 nWayUnion,
+        Computes the union of a set of sets implemented as a range of sorted ranges.)
+$(T2 setDifference,
+        Lazily computes the set difference of two or more sorted ranges.)
+$(T2 setIntersection,
+        Lazily computes the intersection of two or more sorted ranges.)
+$(T2 setSymmetricDifference,
+        Lazily computes the symmetric set difference of two or more sorted ranges.)
+$(T2 setUnion,
+        Lazily computes the set union of two or more sorted ranges.)
+
+$(LEADINGROW Mutation)
+
+$(T2 bringToFront,
+        If $(D a = [1, 2, 3]) and $(D b = [4, 5, 6, 7]), $(D bringToFront(a, b))
+        leaves $(D a = [4, 5, 6]) and $(D b = [7, 1, 2, 3]).)
+$(T2 copy,
+        Copies a range to another. If
+        $(D a = [1, 2, 3]) and $(D b = new int[5]), then $(D copy(a, b))
+        leaves $(D b = [1, 2, 3, 0, 0]) and returns $(D b[3 .. $]).)
+$(T2 fill,
+        Fills a range with a pattern,
+        e.g., if $(D a = new int[3]), then $(D fill(a, 4))
+        leaves $(D a = [4, 4, 4]) and $(D fill(a, [3, 4])) leaves $(D a = [3, 4, 3]).)
+$(T2 initializeAll,
+        If $(D a = [1.2, 3.4]), then $(D initializeAll(a)) leaves $(D a = [double.init, double.init]).)
+$(T2 move,
+        $(D move(a, b)) moves $(D a) into $(D b). $(D move(a)) reads $(D a) destructively.)
+$(T2 moveAll,
+        Moves all elements from one range to another.)
+$(T2 moveSome,
+        Moves as many elements as possible from one range to another.)
+$(T2 remove,
+        Removes elements from a range in-place, and returns the shortened range.)
+$(T2 reverse,
+        If $(D a = [1, 2, 3]), $(D reverse(a)) changes it to $(D [3, 2, 1]).)
+$(T2 strip,
+        Strips all leading and trailing elements equal to a value, or that satisfy a predicate.
+        If $(D a = [1, 1, 0, 1, 1]), then $(D strip(a, 1)) and $(D strip!(e => e == 1)(a))
+        returns $(D [0]).)
+$(T2 stripLeft,
+        Strips all leading elements equal to a value, or that satisfy a predicate.
+        If $(D a = [1, 1, 0, 1, 1]), then $(D stripLeft(a, 1)) and $(D stripLeft!(e => e == 1)(a))
+        returns $(D [0, 1, 1]).)
+$(T2 stripRight,
+        Strips all trailing elements equal to a value, or that satisfy a predicate.
+        If $(D a = [1, 1, 0, 1, 1]), then $(D stripRight(a, 1)) and $(D stripRight!(e => e == 1)(a))
+        returns $(D [1, 1, 0]).)
+$(T2 swap,
+        Swaps two values.)
+$(T2 swapRanges,
+        Swaps all elements of two ranges.)
+$(T2 uninitializedFill,
+        Fills a range (assumed uninitialized) with a value.)
 )
 
 Macros:
+T2=$(TR $(TDNW $(LREF $1)) $(TD $+))
 WIKI = Phobos/StdAlgorithm
 MYREF = <font face='Consolas, "Bitstream Vera Sans Mono", "Andale Mono", Monaco, "DejaVu Sans Mono", "Lucida Console", monospace'><a href="#.$1">$1</a>&nbsp;</font>
 


### PR DESCRIPTION
Fix canonical bad example of how to format Ddoc comments. Shorter and much simpler. No semantic changes.