### PR TITLE
Fix Issue 13909 - assocArray with const values

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -270,7 +270,8 @@ See_Also: $(XREF typecons, Tuple)
 
 auto assocArray(Range)(Range r)
     if (isInputRange!Range &&
-        ElementType!Range.length == 2)
+        ElementType!Range.length == 2 &&
+        isMutable!(ElementType!Range.Types[1]))
 {
     import std.typecons : isTuple;
     static assert(isTuple!(ElementType!Range), "assocArray: argument must be a range of tuples");
@@ -303,6 +304,16 @@ unittest
     static assert(!__traits(compiles, [ tuple("foo", "bar", "baz") ].assocArray()));
     static assert(!__traits(compiles, [ tuple("foo") ].assocArray()));
     static assert( __traits(compiles, [ tuple("foo", "bar") ].assocArray()));
+}
+
+// Issue 13909
+unittest
+{
+    import std.typecons;
+    auto a = [tuple!(const string, string)("foo", "bar")];
+    auto b = [tuple!(string, const string)("foo", "bar")];
+    static assert( __traits(compiles, assocArray(a)));
+    static assert(!__traits(compiles, assocArray(b)));
 }
 
 private template blockAttribute(T)


### PR DESCRIPTION
Just a diagnostic issue. The assignment in the loop won't work with non-mutable keys. We now catch in the constraint.

https://issues.dlang.org/show_bug.cgi?id=13909