### PR TITLE
Use needed html.ddoc, dlang.org.ddoc files for HTML generation

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -92,7 +92,7 @@ WEBSITE_DIR = ../web
 DOC_OUTPUT_DIR = $(WEBSITE_DIR)/phobos-prerelease
 BIGDOC_OUTPUT_DIR = /tmp
 SRC_DOCUMENTABLES = index.d $(addsuffix .d,$(STD_MODULES) $(STD_NET_MODULES) $(STD_DIGEST_MODULES) $(STD_CONTAINER_MODULES) $(STD_RANGE_MODULES) std/regex/package $(EXTRA_DOCUMENTABLES))
-STDDOC = $(DOCSRC)/std_navbar-prerelease.ddoc $(DOCSRC)/std.ddoc $(DOCSRC)/macros.ddoc
+STDDOC = $(DOCSRC)/html.ddoc $(DOCSRC)/dlang.org.ddoc $(DOCSRC)/std_navbar-prerelease.ddoc $(DOCSRC)/std.ddoc $(DOCSRC)/macros.ddoc
 BIGSTDDOC = $(DOCSRC)/std_consolidated.ddoc $(DOCSRC)/macros.ddoc
 # Set DDOC, the documentation generator
 DDOC=$(DMD) -m$(MODEL) -w -c -o- -version=StdDdoc \

--- a/win32.mak
+++ b/win32.mak
@@ -61,7 +61,7 @@ DMD=dmd
 ## Location of where to write the html documentation files
 
 DOCSRC = ../dlang.org
-STDDOC = $(DOCSRC)/std.ddoc $(DOCSRC)/macros.ddoc
+STDDOC = $(DOCSRC)/html.ddoc $(DOCSRC)/dlang.org.ddoc $(DOCSRC)/std.ddoc $(DOCSRC)/macros.ddoc
 
 DOC=..\..\html\d\phobos
 #DOC=..\doc\phobos


### PR DESCRIPTION
After recent dlang.org pulls, these files are now necessary.