### PR TITLE
Fix broken link to isForwardRange in split doc.

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -1311,7 +1311,7 @@ deprecated("Please use std.algorithm.splitter instead.") alias splitter = std.al
 /++
     Eagerly splits $(D range) into an array, using $(D sep) as the delimiter.
 
-    The range must be a $(FULL_XREF std_range.html#isForwardRange, forward range).
+    The range must be a $(XREF2 range, isForwardRange, forward range).
     The separator can be a value of the same type as the elements in $(D range) or
     it can be another forward range.
 


### PR DESCRIPTION
I messed up the syntax for FULL_XREF in #2817. FULL_XREF wasn't appropriate anyway. This replaces it with the new XREF2 (see https://github.com/D-Programming-Language/dlang.org/pull/748).