### PR TITLE
Fix broken documentation links in all std.container modules.

### DIFF
--- a/std/container/array.d
+++ b/std/container/array.d
@@ -2,7 +2,7 @@
 This module provides an $(D Array) type with deterministic memory usage not
 reliant on the GC, as an alternative to the built-in arrays.
 
-This module is a submodule of $(LINK2 std_container_package, std.container).
+This module is a submodule of $(LINK2 std_container_package.html, std.container).
 
 Source: $(PHOBOSSRC std/container/_array.d)
 Macros:

--- a/std/container/binaryheap.d
+++ b/std/container/binaryheap.d
@@ -2,7 +2,7 @@
 This module provides a $(D BinaryHeap) adaptor that makes a binary heap out of
 any user-provided random-access range.
 
-This module is a submodule of $(LINK2 std_container_package, std.container).
+This module is a submodule of $(LINK2 std_container_package.html, std.container).
 
 Source: $(PHOBOSSRC std/container/_binaryheap.d)
 Macros:

--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -1,7 +1,7 @@
 /**
 This module implements a generic doubly-linked list container.
 
-This module is a submodule of $(LINK2 std_container_package, std.container).
+This module is a submodule of $(LINK2 std_container_package.html, std.container).
 
 Source: $(PHOBOSSRC std/container/_dlist.d)
 Macros:
@@ -63,9 +63,9 @@ private struct DRange
     unittest
     {
         static assert(isBidirectionalRange!DRange);
-        static assert(is(ElementType!DRange == BaseNode*));       
+        static assert(is(ElementType!DRange == BaseNode*));
     }
- 
+
 nothrow @safe pure:
     private BaseNode* _first;
     private BaseNode* _last;
@@ -148,9 +148,9 @@ struct DList(T)
     {
         BaseNode _base;
         alias _base this;
-    
+
         T _payload = T.init;
-    
+
         inout(BaseNode)* asBaseNode() inout @trusted
         {
             return &_base;

--- a/std/container/package.d
+++ b/std/container/package.d
@@ -9,29 +9,29 @@ This module consists of the following submodules:
 
 $(UL
     $(LI
-        The $(LINK2 std_container_array, std._container.array) module provides
+        The $(LINK2 std_container_array.html, std._container.array) module provides
         an $(D Array) type with deterministic control of memory, not reliant on
         the GC unlike the built-in arrays.
     )
     $(LI
-        The $(LINK2 std_container_binaryheap, std._container.binaryheap) module
+        The $(LINK2 std_container_binaryheap.html, std._container.binaryheap) module
         provides a binary heap implementation that can be applied to any
         user-provided random-access range.
     )
     $(LI
-        The $(LINK2 std_container_dlist, std._container.dlist) module provides
+        The $(LINK2 std_container_dlist.html, std._container.dlist) module provides
         a doubly-linked list implementation.
     )
     $(LI
-        The $(LINK2 std_container_rbtree, std._container.rbtree) module
+        The $(LINK2 std_container_rbtree.html, std._container.rbtree) module
         implements red-black trees.
     )
     $(LI
-        The $(LINK2 std_container_slist, std._container.slist) module
+        The $(LINK2 std_container_slist.html, std._container.slist) module
         implements singly-linked lists.
     )
     $(LI
-        The $(LINK2 std_container_util, std._container.util) module contains
+        The $(LINK2 std_container_util.html, std._container.util) module contains
         some generic tools commonly used by container implementations.
     )
 )

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -1,7 +1,7 @@
 /**
 This module implements a red-black tree container.
 
-This module is a submodule of $(LINK2 std_container_package, std.container).
+This module is a submodule of $(LINK2 std_container_package.html, std.container).
 
 Source: $(PHOBOSSRC std/container/_rbtree.d)
 Macros:

--- a/std/container/slist.d
+++ b/std/container/slist.d
@@ -1,7 +1,7 @@
 /**
 This module implements a singly-linked list container.
 
-This module is a submodule of $(LINK2 std_container_package, std.container).
+This module is a submodule of $(LINK2 std_container_package.html, std.container).
 
 Source: $(PHOBOSSRC std/container/_slist.d)
 Macros:

--- a/std/container/util.d
+++ b/std/container/util.d
@@ -1,7 +1,7 @@
 /**
 This module contains some common utilities used by containers.
 
-This module is a submodule of $(LINK2 std_container_package, std.container).
+This module is a submodule of $(LINK2 std_container_package.html, std.container).
 
 Source: $(PHOBOSSRC std/container/_util.d)
 Macros:


### PR DESCRIPTION
In the header of each std.container module, the links to other std.container modules were missing the .html extension.