### PR TITLE
Issue 13935: do not assume range can be default-initialized.

### DIFF
--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -14665,6 +14665,13 @@ pure @safe nothrow @nogc unittest
     assert(D.front == front1);
 }
 
+// Issue 13935
+unittest
+{
+    auto seq = [1, 2].map!(x => x);
+    foreach (pair; cartesianProduct(seq, seq)) {}
+}
+
 /**
 Find $(D value) _among $(D values), returning the 1-based index
 of the first matching value in $(D values), or $(D 0) if $(D value)

--- a/std/algorithm.d
+++ b/std/algorithm.d
@@ -14540,13 +14540,12 @@ auto cartesianProduct(RR...)(RR ranges)
         }
         @property Result save()
         {
-            Result copy;
+            Result copy = this;
             foreach (i, r; ranges)
             {
                 copy.ranges[i] = r.save;
                 copy.current[i] = current[i].save;
             }
-            copy.empty = this.empty;
             return copy;
         }
     }


### PR DESCRIPTION
Fixes: https://issues.dlang.org/show_bug.cgi?id=13935

When the incoming range to cartesianProduct is parametrized on something that requires a frame pointer, we cannot declare default-initialized instances of its type. To work around this in .save, just make a copy of `this` and then kick it into shape before returning it.
