### PR TITLE
Do not build druntime if DRUNTIME is explicit in the command line

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -99,9 +99,12 @@ DDOC=$(DMD) -m$(MODEL) -w -c -o- -version=StdDdoc \
 	-I$(DRUNTIME_PATH)/import $(DMDEXTRAFLAGS)
 
 # Set DRUNTIME name and full path
+ifneq (,$(DRUNTIME))
+	CUSTOM_DRUNTIME=1
+endif
 ifeq (,$(findstring win,$(OS)))
 	DRUNTIME = $(DRUNTIME_PATH)/lib/libdruntime-$(OS)$(MODEL).a
-	DRUNTIMESO = $(DRUNTIME_PATH)/lib/libdruntime-$(OS)$(MODEL)so.a
+	DRUNTIMESO = $(basename $(DRUNTIME))so.a
 else
 	DRUNTIME = $(DRUNTIME_PATH)/lib/druntime.lib
 endif
@@ -382,6 +385,9 @@ endif
 	cp -r etc/* $(INSTALL_DIR)/src/phobos/etc/
 	cp LICENSE_1_0.txt $(INSTALL_DIR)/phobos-LICENSE.txt
 
+ifeq (1,$(CUSTOM_DRUNTIME))
+# We consider a custom-set DRUNTIME a sign they build druntime themselves
+else
 # This rule additionally produces $(DRUNTIMESO). Add a fake dependency
 # to always invoke druntime's make. Use FORCE instead of .PHONY to
 # avoid rebuilding phobos when $(DRUNTIME) didn't change.
@@ -393,6 +399,8 @@ $(DRUNTIMESO): $(DRUNTIME)
 endif
 
 FORCE:
+
+endif
 
 ###########################################################
 # html documentation


### PR DESCRIPTION
At work we have a custom build of druntime for a variety of reasons. Currently we need to modify phobos/posix.mak by hand because it insists on building druntime by itself. This pull detects DRUNTIME when defined in the command line and does not attempt to build it.