### PR TITLE
[trivial but see description][DDoc] Throws: for std.net.curl.get()

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -390,7 +390,7 @@ unittest
  *
  * Throws:
  *
- * CurlException on error.
+ * $(D CurlException) on error.
  *
  * See_Also: $(LREF HTTP.Method)
  */

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -20,6 +20,10 @@ SMTP) )
 )
 )
 
+Note:
+You may need to link to the $(B curl) library, e.g. by adding $(D "libs": ["curl"]) 
+to your $(B dub.json) file if you are using $(LINK2 http://code.dlang.org DUB).
+
 Windows x86 note:
 A DMD compatible libcurl static library can be downloaded from the dlang.org
 $(LINK2 http://dlang.org/download.html, download page).
@@ -383,6 +387,10 @@ unittest
  *
  * Returns:
  * A T[] range containing the content of the resource pointed to by the URL.
+ *
+ * Throws:
+ *
+ * CurlException on error.
  *
  * See_Also: $(LREF HTTP.Method)
  */

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -22,7 +22,7 @@ SMTP) )
 
 Note:
 You may need to link to the $(B curl) library, e.g. by adding $(D "libs": ["curl"]) 
-to your $(B dub.json) file if you are using $(LINK2 http://code.dlang.org DUB).
+to your $(B dub.json) file if you are using $(LINK2 http://code.dlang.org, DUB).
 
 Windows x86 note:
 A DMD compatible libcurl static library can be downloaded from the dlang.org


### PR DESCRIPTION
Also added a note about needing to link `libcurl`.

=====
Note:
=====

I'm pretty sure other functions in this module are missing `Throws:`, but only added it for `get()` which I tried.
Someone who knows more about http/etc should improve this.

Also, `CurlException on error` works, but it would be better to explain possible error cases.