### PR TITLE
documentation update for bigint.d

### DIFF
--- a/std/bigint.d
+++ b/std/bigint.d
@@ -38,42 +38,13 @@ private import std.traits;
  * assignment is cheap, but operations such as x++ will cause heap
  * allocation. (But note that for most bigint operations, heap allocation is
  * inevitable anyway).
-
- Example:
-----------------------------------------------------
-        BigInt a = "9588669891916142";
-        BigInt b = "7452469135154800";
-        auto c = a * b;
-        assert(c == BigInt("71459266416693160362545788781600"));
-        auto d = b * a;
-        assert(d == BigInt("71459266416693160362545788781600"));
-        assert(d == c);
-        d = c * BigInt("794628672112");
-        assert(d == BigInt("56783581982794522489042432639320434378739200"));
-        auto e = c + d;
-        assert(e == BigInt("56783581982865981755459125799682980167520800"));
-        auto f = d + c;
-        assert(f == e);
-        auto g = f - c;
-        assert(g == d);
-        g = f - d;
-        assert(g == c);
-        e = 12345678;
-        g = c + e;
-        auto h = g / b;
-        auto i = g % b;
-        assert(h == a);
-        assert(i == e);
-        BigInt j = "-0x9A56_57f4_7B83_AB78";
-        j ^^= 11;
-----------------------------------------------------
  *
  */
 struct BigInt
 {
 private:
-        BigUint data;     // BigInt adds signed arithmetic to BigUint.
-        bool sign = false;
+    BigUint data;     // BigInt adds signed arithmetic to BigUint.
+    bool sign = false;
 public:
     /// Construct a BigInt from a decimal or hexadecimal string.
     /// The number must be in the form of a D decimal or hex literal:
@@ -519,20 +490,7 @@ public:
             foreach (i; 0 .. difw)
                 sink(" ");
     }
-/+
-private:
-    /// Convert to a hexadecimal string, with an underscore every
-    /// 8 characters.
-    string toHex()
-    {
-        string buff = data.toHexString(1, '_');
-        if (isNegative())
-            buff[0] = '-';
-        else
-            buff = buff[1..$];
-        return buff;
-    }
-+/
+
     // Implement toHash so that BigInt works properly as an AA key.
     size_t toHash() const @trusted nothrow
     {
@@ -562,6 +520,45 @@ private:
     }
 }
 
+///
+unittest
+{
+    BigInt a = "9588669891916142";
+    BigInt b = "7452469135154800";
+    auto c = a * b;
+    assert(c == BigInt("71459266416693160362545788781600"));
+    auto d = b * a;
+    assert(d == BigInt("71459266416693160362545788781600"));
+    assert(d == c);
+    d = c * BigInt("794628672112");
+    assert(d == BigInt("56783581982794522489042432639320434378739200"));
+    auto e = c + d;
+    assert(e == BigInt("56783581982865981755459125799682980167520800"));
+    auto f = d + c;
+    assert(f == e);
+    auto g = f - c;
+    assert(g == d);
+    g = f - d;
+    assert(g == c);
+    e = 12345678;
+    g = c + e;
+    auto h = g / b;
+    auto i = g % b;
+    assert(h == a);
+    assert(i == e);
+    BigInt j = "-0x9A56_57f4_7B83_AB78";
+    j ^^= 11;
+}
+
+/** This function returns a $(D string) representation of a $(D BigInt).
+
+Params:
+    x = The $(D BigInt) to convert to a decimal $(D string).
+
+Returns:
+    A $(D string) that represents the $(D BigInt) as a decimal number.
+
+*/
 string toDecimalString(const(BigInt) x)
 {
     string outbuff="";
@@ -570,6 +567,15 @@ string toDecimalString(const(BigInt) x)
     return outbuff;
 }
 
+/** This function returns a $(D string) representation of a $(D BigInt).
+
+Params:
+    x = The $(D BigInt) to convert to a hexadecimal $(D string).
+
+Returns:
+    A $(D string) that represents the $(D BigInt) as a hexadecimal  number.
+
+*/
 string toHex(const(BigInt) x)
 {
     string outbuff="";
@@ -578,7 +584,16 @@ string toHex(const(BigInt) x)
     return outbuff;
 }
 
-// Returns the absolute value of x converted to the corresponding unsigned type
+/** Returns the absolute value of x converted to the corresponding unsigned
+type.
+
+Params:
+    x = The integral value to return the absolute value of.
+
+Returns:
+    The absolute value of x.
+
+*/
 Unsigned!T absUnsign(T)(T x) if (isIntegral!T)
 {
     static if (isSigned!T)


### PR DESCRIPTION
* moved example from comment to unittest
* documentation for three function (toDecimalString,toHexString,absUnsign)
	all were public and had no doc
* fix some indentation
* removed bad code from 2010