### PR TITLE
Issue 6447 & 10762: support user-defined types in iota()

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -4460,7 +4460,7 @@ auto iota(B, E)(B begin, E end)
     if (!isIntegral!(CommonType!(B, E)) &&
         !isFloatingPoint!(CommonType!(B, E)) &&
         !isPointer!(CommonType!(B, E)) &&
-        is(typeof(++B.init)) &&
+        is(typeof((ref B b) { ++b; })) &&
         (is(typeof(B.init < E.init)) || is(typeof(B.init == E.init))) )
 {
     static struct Result

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -3980,12 +3980,26 @@ unittest
 }
 
 /**
-   Returns a range that goes through the numbers $(D begin), $(D begin +
-   step), $(D begin + 2 * step), $(D ...), up to and excluding $(D
-   end). The range offered is a random access range. The two-arguments
-   version has $(D step = 1). If $(D begin < end && step < 0) or $(D
-   begin > end && step > 0) or $(D begin == end), then an empty range is
-   returned.
+   Construct a range of values that span the given starting and stopping
+   values.
+
+   Params:
+   begin = The starting value.
+   end = The value that serves as the stopping criterion. This value is not
+        included in the range.
+   step = The value to add to the current value at each iteration.
+
+   Returns:
+   A range that goes through the numbers $(D begin), $(D begin + step),
+   $(D begin + 2 * step), $(D ...), up to and excluding $(D end).
+
+   The two-argument overloads have $(D step = 1). If $(D begin < end && step <
+   0) or $(D begin > end && step > 0) or $(D begin == end), then an empty range
+   is returned.
+
+   For built-in types, the range returned is a random access range. For
+   user-defined types that support $(D <) and $(D ++), the range is an input
+   range.
 
    Throws:
    $(D Exception) if $(D begin != end && step == 0), an exception is
@@ -4157,6 +4171,7 @@ auto iota(E)(E end)
     return iota(begin, end);
 }
 
+/// Ditto
 // Specialization for floating-point types
 auto iota(B, E, S)(B begin, E end, S step)
 if (isFloatingPoint!(CommonType!(B, E, S)))
@@ -4244,15 +4259,15 @@ if (isFloatingPoint!(CommonType!(B, E, S)))
 @safe unittest
 {
     import std.algorithm : equal;
+    import std.math : approxEqual;
 
-   import std.math : approxEqual;
-   auto r = iota(0, 10, 1);
-   assert(equal(r, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9][]));
-   r = iota(0, 11, 3);
-   assert(equal(r, [0, 3, 6, 9][]));
-   assert(r[2] == 6);
-   auto rf = iota(0.0, 0.5, 0.1);
-   assert(approxEqual(rf, [0.0, 0.1, 0.2, 0.3, 0.4]));
+    auto r = iota(0, 10, 1);
+    assert(equal(r, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9][]));
+    r = iota(0, 11, 3);
+    assert(equal(r, [0, 3, 6, 9][]));
+    assert(r[2] == 6);
+    auto rf = iota(0.0, 0.5, 0.1);
+    assert(approxEqual(rf, [0.0, 0.1, 0.2, 0.3, 0.4]));
 }
 
 unittest
@@ -4464,6 +4479,10 @@ auto iota(B, E)(B begin, E end)
     return Result(begin, end);
 }
 
+/**
+User-defined types such as $(XREF bigint, BigInt) are also supported, as long
+as they can be compared with $(D <) and incremented with $(D ++).
+*/
 // Issue 6447
 unittest
 {
@@ -4476,7 +4495,7 @@ unittest
     assert(r.equal([
         BigInt(1_000_000_000_000),
         BigInt(1_000_000_000_001),
-        BigInt(1_000_000_000_002),
+        BigInt(1_000_000_000_002)
     ]));
 }
 


### PR DESCRIPTION
Fixes: https://issues.dlang.org/show_bug.cgi?id=6447
Partially fixes: https://issues.dlang.org/show_bug.cgi?id=10762

Basically, as long as a type supports comparison via `<` and incrementing via `++`, `iota` should work.

This is an initial stab at issue 10762; it provides the baseline for the most general user-defined types, so the returned range for non-built-in types will only be input ranges. Subsequent PRs will gradually refine this, e.g., to support random access if `x + y*k` is a supported operation in the underlying type.