### PR TITLE
Use presence of __va_argsave to determine if __va_argsave hack is needed

### DIFF
--- a/std/outbuffer.d
+++ b/std/outbuffer.d
@@ -312,24 +312,13 @@ class OutBuffer
 
     void printf(string format, ...) @trusted
     {
-        version (Win64)
-        {
-            vprintf(format, _argptr);
-        }
-        else version (X86_64)
-        {
-            va_list ap;
+        va_list ap;
+        static if (is(typeof(__va_argsave)))
             va_start(ap, __va_argsave);
-            vprintf(format, ap);
-            va_end(ap);
-        }
         else
-        {
-            va_list ap;
-            ap = cast(va_list)&format;
-            ap += format.sizeof;
-            vprintf(format, ap);
-        }
+            va_start(ap, format);
+        vprintf(format, ap);
+        va_end(ap);
     }
 
     /*****************************************

--- a/std/stream.d
+++ b/std/stream.d
@@ -1204,24 +1204,15 @@ class Stream : InputStream, OutputStream {
 
   // writes data to stream using printf() syntax,
   // returns number of bytes written
-  version (Win64)
-  size_t printf(const(char)[] format, ...) {
-    return vprintf(format, _argptr);
-  }
-  else version (X86_64)
   size_t printf(const(char)[] format, ...) {
     va_list ap;
-    va_start(ap, __va_argsave);
+    static if (is(typeof(__va_argsave)))
+        va_start(ap, __va_argsave);
+    else
+        va_start(ap, format);
     auto result = vprintf(format, ap);
     va_end(ap);
     return result;
-  }
-  else
-  size_t printf(const(char)[] format, ...) {
-    va_list ap;
-    ap = cast(va_list) &format;
-    ap += format.sizeof;
-    return vprintf(format, ap);
   }
 
   private void doFormatCallback(dchar c) {


### PR DESCRIPTION
This replaces the current awkward version condition, and makes the code future-proof with regards to the hopefully imminent removal of `__va_argsave`.