### PR TITLE
[DDoc] [trivial] Mentioning that a container is not a range.

### DIFF
--- a/std/container/array.d
+++ b/std/container/array.d
@@ -36,6 +36,12 @@ This means that pointers to elements of an $(D Array) will become
 dangling as soon as the element is removed from the $(D Array). On the other hand
 the memory allocated by an $(D Array) will be scanned by the GC and
 GC managed objects referenced from an $(D Array) will be kept alive.
+
+Note:
+
+When using $(D Array) with range-based functions like those in $(D std.algorithm),
+$(Array) must be sliced to get a range (for example, use $(D array[].map!)
+instead of $(D array.map!)). The container itself is not a range.
  */
 struct Array(T)
 if (!is(Unqual!T == bool))


### PR DESCRIPTION
This often comes up on the forum/stackoverflow, and I think it's best to mention it right in Array's documentation.
It should probably be mentioned in `std.algorithm` docs too, but in more detail/more generally.