### PR TITLE
Revert "Merge pull request #2902 from yebblies/typeofva_argsave"

### DIFF
--- a/std/outbuffer.d
+++ b/std/outbuffer.d
@@ -312,13 +312,24 @@ class OutBuffer
 
     void printf(string format, ...) @trusted
     {
-        va_list ap;
-        static if (is(typeof(__va_argsave)))
+        version (Win64)
+        {
+            vprintf(format, _argptr);
+        }
+        else version (X86_64)
+        {
+            va_list ap;
             va_start(ap, __va_argsave);
+            vprintf(format, ap);
+            va_end(ap);
+        }
         else
-            va_start(ap, format);
-        vprintf(format, ap);
-        va_end(ap);
+        {
+            va_list ap;
+            ap = cast(va_list)&format;
+            ap += format.sizeof;
+            vprintf(format, ap);
+        }
     }
 
     /*****************************************

--- a/std/stream.d
+++ b/std/stream.d
@@ -1204,15 +1204,24 @@ class Stream : InputStream, OutputStream {
 
   // writes data to stream using printf() syntax,
   // returns number of bytes written
+  version (Win64)
+  size_t printf(const(char)[] format, ...) {
+    return vprintf(format, _argptr);
+  }
+  else version (X86_64)
   size_t printf(const(char)[] format, ...) {
     va_list ap;
-    static if (is(typeof(__va_argsave)))
-        va_start(ap, __va_argsave);
-    else
-        va_start(ap, format);
+    va_start(ap, __va_argsave);
     auto result = vprintf(format, ap);
     va_end(ap);
     return result;
+  }
+  else
+  size_t printf(const(char)[] format, ...) {
+    va_list ap;
+    ap = cast(va_list) &format;
+    ap += format.sizeof;
+    return vprintf(format, ap);
   }
 
   private void doFormatCallback(dchar c) {


### PR DESCRIPTION
This reverts commit f07a77d106432d70468bb86e34f2ef5b8cb12d61, reversing
changes made to 4bd949406af646370504208cd569ace0707f2b82.

It's breaking std.outbuffer unittest in Win64 platform.