### PR TITLE
[DDoc] add HTML class "quickindex" to manually maintained jump link tables

### DIFF
--- a/std/algorithm/package.d
+++ b/std/algorithm/package.d
@@ -6,10 +6,11 @@ sequences. Sequences processed by these functions define range-based
 interfaces.  See also $(LINK2 std_range.html, Reference on ranges) and
 $(WEB ddili.org/ders/d.en/ranges.html, tutorial on ranges).
 
-<script type="text/javascript">inhibitQuickIndex = 1</script>
+$(SCRIPT inhibitQuickIndex = 1;)
 
 Algorithms are categorized into the following submodules:
 
+$(DIVC quickindex,
 $(BOOKTABLE ,
 $(TR $(TH Category) $(TH Submodule) $(TH Functions)
 )
@@ -132,6 +133,7 @@ $(TR $(TDNW Utility)
     $(TD $(MYREF forward)
     )
 ))
+)
 
 Many functions in this package are parameterized with a function or a
 $(GLOSSARY predicate). The predicate may be passed either as a

--- a/std/digest/crc.d
+++ b/std/digest/crc.d
@@ -1,8 +1,9 @@
 /**
 Cyclic Redundancy Check (32-bit) implementation.
 
-<script type="text/javascript">inhibitQuickIndex = 1</script>
+$(SCRIPT inhibitQuickIndex = 1;)
 
+$(DIVC quickindex,
 $(BOOKTABLE ,
 $(TR $(TH Category) $(TH Functions)
 )
@@ -12,6 +13,7 @@ $(TR $(TDNW Template API) $(TD $(MYREF CRC32)
 $(TR $(TDNW OOP API) $(TD $(MYREF CRC32Digest))
 )
 $(TR $(TDNW Helpers) $(TD $(MYREF crcHexString) $(MYREF crc32Of))
+)
 )
 )
 

--- a/std/digest/digest.d
+++ b/std/digest/digest.d
@@ -2,8 +2,9 @@
  * This module describes the digest APIs used in Phobos. All digests follow these APIs.
  * Additionally, this module contains useful helper methods which can be used with every _digest type.
  *
-<script type="text/javascript">inhibitQuickIndex = 1</script>
+$(SCRIPT inhibitQuickIndex = 1;)
 
+$(DIVC quickindex,
 $(BOOKTABLE ,
 $(TR $(TH Category) $(TH Functions)
 )
@@ -17,6 +18,7 @@ $(TR $(TDNW OOP API) $(TD $(MYREF Digest)
 $(TR $(TDNW Helper functions) $(TD $(MYREF toHexString))
 )
 $(TR $(TDNW Implementation helpers) $(TD $(MYREF digestLength) $(MYREF WrapperDigest))
+)
 )
 )
 

--- a/std/digest/md.d
+++ b/std/digest/md.d
@@ -2,8 +2,9 @@
  * Computes MD5 hashes of arbitrary data. MD5 hashes are 16 byte quantities that are like a
  * checksum or CRC, but are more robust.
  *
-<script type="text/javascript">inhibitQuickIndex = 1</script>
+$(SCRIPT inhibitQuickIndex = 1;)
 
+$(DIVC quickindex,
 $(BOOKTABLE ,
 $(TR $(TH Category) $(TH Functions)
 )
@@ -13,6 +14,7 @@ $(TR $(TDNW Template API) $(TD $(MYREF MD5)
 $(TR $(TDNW OOP API) $(TD $(MYREF MD5Digest))
 )
 $(TR $(TDNW Helpers) $(TD $(MYREF md5Of))
+)
 )
 )
 

--- a/std/digest/ripemd.d
+++ b/std/digest/ripemd.d
@@ -2,8 +2,9 @@
  * Computes RIPEMD-160 hashes of arbitrary data. RIPEMD-160 hashes are 20 byte quantities
  * that are like a checksum or CRC, but are more robust.
  *
-<script type="text/javascript">inhibitQuickIndex = 1</script>
+$(SCRIPT inhibitQuickIndex = 1;)
 
+$(DIVC quickindex,
 $(BOOKTABLE ,
 $(TR $(TH Category) $(TH Functions)
 )
@@ -13,6 +14,7 @@ $(TR $(TDNW Template API) $(TD $(MYREF RIPEMD160)
 $(TR $(TDNW OOP API) $(TD $(MYREF RIPEMD160Digest))
 )
 $(TR $(TDNW Helpers) $(TD $(MYREF ripemd160Of))
+)
 )
 )
 

--- a/std/digest/sha.d
+++ b/std/digest/sha.d
@@ -4,8 +4,9 @@
  * quantities (depending on the SHA algorithm) that are like a checksum or CRC,
  * but are more robust.
  *
-<script type="text/javascript">inhibitQuickIndex = 1</script>
+$(SCRIPT inhibitQuickIndex = 1;)
 
+$(DIVC quickindex,
 $(BOOKTABLE ,
 $(TR $(TH Category) $(TH Functions)
 )
@@ -15,6 +16,7 @@ $(TR $(TDNW Template API) $(TD $(MYREF SHA1)
 $(TR $(TDNW OOP API) $(TD $(MYREF SHA1Digest))
 )
 $(TR $(TDNW Helpers) $(TD $(MYREF sha1Of))
+)
 )
 )
 

--- a/std/math.d
+++ b/std/math.d
@@ -7,6 +7,7 @@
  *
 $(SCRIPT inhibitQuickIndex = 1;)
 
+$(DIVC quickindex,
 $(BOOKTABLE ,
 $(TR $(TH Category) $(TH Members) )
 $(TR $(TDNW Constants) $(TD
@@ -52,6 +53,7 @@ $(TR $(TDNW Complex Numbers) $(TD
 $(TR $(TDNW Hardware Control) $(TD
     $(MYREF IeeeFlags) $(MYREF FloatingPointControl)
 ))
+)
 )
 
  * The functionality closely follows the IEEE754-2008 standard for

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -5,8 +5,9 @@ Networking client functionality as provided by $(WEB _curl.haxx.se/libcurl,
 libcurl). The libcurl library must be installed on the system in order to use
 this module.
 
-<script type="text/javascript">inhibitQuickIndex = 1</script>
+$(SCRIPT inhibitQuickIndex = 1;)
 
+$(DIVC quickindex,
 $(BOOKTABLE ,
 $(TR $(TH Category) $(TH Functions)
 )
@@ -17,6 +18,7 @@ $(MYREF byLineAsync) $(MYREF byChunkAsync) )
 )
 $(TR $(TDNW Low level) $(TD $(MYREF HTTP) $(MYREF FTP) $(MYREF
 SMTP) )
+)
 )
 )
 

--- a/std/string.d
+++ b/std/string.d
@@ -6,6 +6,7 @@ $(D std.algorithm) because all D strings are bidirectional ranges.
 
 $(SCRIPT inhibitQuickIndex = 1;)
 
+$(DIVC quickindex,
 $(BOOKTABLE ,
 $(TR $(TH Category) $(TH Functions) )
 $(TR $(TDNW Searching)
@@ -51,6 +52,7 @@ $(TR $(TDNW Miscellaneous)
     $(TD $(MYREF fromStringz) $(MYREF toStringz) $(MYREF splitLines)
     $(MYREF representation) $(MYREF assumeUTF)
     )
+)
 )
 )
 

--- a/std/traits.d
+++ b/std/traits.d
@@ -3,8 +3,9 @@
 /**
  * Templates which extract information about types and symbols at compile time.
  *
- * <script type="text/javascript">inhibitQuickIndex = 1</script>
+ * $(SCRIPT inhibitQuickIndex = 1;)
  *
+ * $(DIVC quickindex,
  * $(BOOKTABLE ,
  * $(TR $(TH Category) $(TH Templates))
  * $(TR $(TD Symbol Name _traits) $(TD
@@ -124,6 +125,7 @@
  *           $(LREF Select)
  *           $(LREF select)
  * ))
+ * )
  * )
  *
  * Macros:

--- a/std/uuid.d
+++ b/std/uuid.d
@@ -6,8 +6,9 @@
  * used to tag objects with very short lifetimes, or to reliably identify very
  * persistent objects across a network.
  *
-<script type="text/javascript">inhibitQuickIndex = 1</script>
+$(SCRIPT inhibitQuickIndex = 1;)
 
+$(DIVC quickindex,
 $(BOOKTABLE ,
 $(TR $(TH Category) $(TH Functions)
 )
@@ -23,6 +24,7 @@ $(MYREF2 UUID.opEquals, opEquals) $(MYREF2 UUID.opCmp, opCmp) $(MYREF2 UUID.toHa
 )
 $(TR $(TDNW UUID namespaces) $(TD $(MYREF dnsNamespace) $(MYREF urlNamespace)
 $(MYREF oidNamespace) $(MYREF x500Namespace) )
+)
 )
 )
 


### PR DESCRIPTION
Screenshot together with <https://github.com/D-Programming-Language/dlang.org/pull/843>:

![iconscreenshot1](https://cloud.githubusercontent.com/assets/9287500/5892760/dcbf4668-a4ca-11e4-9c32-98d710c448d4.png)

