### PR TITLE
Stop using va_argsave now that va_start works correctly without it

### DIFF
--- a/std/outbuffer.d
+++ b/std/outbuffer.d
@@ -313,10 +313,7 @@ class OutBuffer
     void printf(string format, ...) @trusted
     {
         va_list ap;
-        static if (is(typeof(__va_argsave)))
-            va_start(ap, __va_argsave);
-        else
-            va_start(ap, format);
+        va_start(ap, format);
         vprintf(format, ap);
         va_end(ap);
     }

--- a/std/stream.d
+++ b/std/stream.d
@@ -1206,10 +1206,7 @@ class Stream : InputStream, OutputStream {
   // returns number of bytes written
   size_t printf(const(char)[] format, ...) {
     va_list ap;
-    static if (is(typeof(__va_argsave)))
-        va_start(ap, __va_argsave);
-    else
-        va_start(ap, format);
+    va_start(ap, format);
     auto result = vprintf(format, ap);
     va_end(ap);
     return result;


### PR DESCRIPTION
Finally!  `va_start` works on all dmd platforms.  Now only `va_copy` remains horrifically broken.

@andralex @ibuclaw