### PR TITLE
Fix Issue #14058 -- 'make install' should not copy non-source files

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -387,10 +387,9 @@ ifneq (,$(findstring $(OS),linux))
 	cp -P $(LIBSO) $(INSTALL_DIR)/$(OS)/$(lib_dir)/
 	ln -sf $(notdir $(LIBSO)) $(INSTALL_DIR)/$(OS)/$(lib_dir)/libphobos2.so
 endif
-	mkdir -p $(INSTALL_DIR)/src/phobos/etc
-	mkdir -p $(INSTALL_DIR)/src/phobos/std
-	cp -r std/* $(INSTALL_DIR)/src/phobos/std/
-	cp -r etc/* $(INSTALL_DIR)/src/phobos/etc/
+	mkdir -p $(INSTALL_DIR)/src/phobos
+	find std -type f -name "*.d" | xargs -n1 -i cp -r --parents {} $(INSTALL_DIR)/src/phobos/
+	find etc -type f -name "*.d" | xargs -n1 -i cp -r --parents {} $(INSTALL_DIR)/src/phobos/
 	cp LICENSE_1_0.txt $(INSTALL_DIR)/phobos-LICENSE.txt
 
 ifeq (1,$(CUSTOM_DRUNTIME))


### PR DESCRIPTION
This patch ensures that `make install` will copy only actual phobos files to the install `src/` dir and not (for example) backup files left behind by code editors.