### PR TITLE
Fix 14081:Table in the document of std.bigint.BigInt.toString() duplicat...

### DIFF
--- a/std/bigint.d
+++ b/std/bigint.d
@@ -449,7 +449,7 @@ public:
 
     /** Convert the BigInt to string, passing it to 'sink'.
      *
-     * $(TABLE  The output format is controlled via formatString:
+     * $(TABLE  The output format is controlled via formatString:,
      * $(TR $(TD "d") $(TD  Decimal))
      * $(TR $(TD "x") $(TD  Hexadecimal, lower case))
      * $(TR $(TD "X") $(TD  Hexadecimal, upper case))


### PR DESCRIPTION
...es.

Small fix of doc comment.
Please do not forget to use the "std.ddoc" template file while ddoc generation.
It involves this bug.