### PR TITLE
Fix issue 14082 -- RedBlackTree unittest fails with custom predicate less

### DIFF
--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -716,7 +716,12 @@ final class RedBlackTree(T, alias less = "a < b", bool allowDuplicates = false)
 
     version(unittest)
     {
-        private enum doUnittest = isIntegral!T && (less == "a < b" || less == "a > b");
+        static if(is(typeof(less) == string))
+        {
+            private enum doUnittest = isIntegral!T && (less == "a < b" || less == "a > b");
+        }
+        else
+            enum doUnittest = false;
 
         // note, this must be final so it does not affect the vtable layout
         final bool arrayEqual(T[] arr)

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -716,7 +716,7 @@ final class RedBlackTree(T, alias less = "a < b", bool allowDuplicates = false)
 
     version(unittest)
     {
-        private enum doUnittest = isIntegral!T;
+        private enum doUnittest = isIntegral!T && (less == "a < b" || less == "a > b");
 
         // note, this must be final so it does not affect the vtable layout
         final bool arrayEqual(T[] arr)


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14082

The red black tree unit tests are template-based, so they instantiate based on the parameters to the template. Previously, the only consideration was that the type should be integral. If someone created a Red Black Tree with a custom lambda, it still tries to run the unit test with the assumption that it's "a > b". This precludes that.