### PR TITLE
Do not call destructor in VariantN.opAssign if no allowed type requires

### DIFF
--- a/std/variant.d
+++ b/std/variant.d
@@ -1322,6 +1322,14 @@ unittest
     assert(aa["b"] == 3);
 }
 
+pure nothrow @nogc
+unittest
+{
+    Algebraic!(int, double) a;
+    a = 100;
+    a = 1.0;
+}
+
 
 /**
  * Algebraic data type restricted to a closed set of possible

--- a/std/variant.d
+++ b/std/variant.d
@@ -618,8 +618,11 @@ public:
         }
         else
         {
-            // Assignment should destruct previous value
-            fptr(OpID.destruct, &store, null);
+            static if (!AllowedTypes.length || anySatisfy!(hasElaborateDestructor, AllowedTypes))
+            {
+                // Assignment should destruct previous value
+                fptr(OpID.destruct, &store, null);
+            }
 
             static if (T.sizeof <= size)
             {


### PR DESCRIPTION
Same logic as #2439.