### PR TITLE
Fix Issue 14042 - std.conv.to of a immutable char pointer

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -868,7 +868,7 @@ T toImpl(T, S)(S value)
     {
         import core.stdc.string : strlen;
         // It is unsafe because we cannot guarantee that the pointer is null terminated.
-        return value ? cast(T) value[0 .. strlen(value)].dup : cast(string)null;
+        return value ? cast(T) value[0 .. strlen(value)].dup : null;
     }
     else static if (isSomeString!T && is(S == enum))
     {
@@ -911,6 +911,13 @@ T toImpl(T, S)(S value)
         // other non-string values runs formatting
         return toStr!T(value);
     }
+}
+
+// Bugzilla 14042
+unittest
+{
+    immutable(char)* ptr = "hello".ptr;
+    auto result = ptr.to!(char[]);
 }
 
 /*


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14042

Somehow `cond ? char[] : string` was implicitly convertible to `char[]` before D-Programming-Language/dmd#4285 got merged.