### PR TITLE
use initOnce for lazy shared initialization

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -75,7 +75,6 @@ private
     import core.sync.mutex;
     import core.sync.condition;
     import std.algorithm;
-    import std.datetime;
     import std.exception;
     import std.range;
     import std.string;
@@ -1373,11 +1372,12 @@ private:
 
         override bool wait( Duration period ) nothrow
         {
+            import core.time;
             scope(exit) notified = false;
 
-            for( auto limit = Clock.currSystemTick + period;
+            for( auto limit = TickDuration.currSystemTick + period;
                  !notified && !period.isNegative;
-                 period = limit - Clock.currSystemTick )
+                 period = limit - TickDuration.currSystemTick )
             {
                 yield();
             }
@@ -2040,7 +2040,8 @@ private
 
             static if( timedWait )
             {
-                auto limit = Clock.currSystemTick + period;
+                import core.time;
+                auto limit = TickDuration.currSystemTick + period;
             }
 
             while( true )
@@ -2088,7 +2089,7 @@ private
                     {
                         static if( timedWait )
                         {
-                            period = limit - Clock.currSystemTick;
+                            period = limit - TickDuration.currSystemTick;
                         }
                         continue;
                     }

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -27326,31 +27326,15 @@ private:
     }
 
 
-    static immutable LocalTime _localTime = new immutable(LocalTime)();
-    // Use low-lock singleton pattern with _tzsetWasCalled (see http://dconf.org/talks/simcha.html)
-    static bool _lowLock;
-    static shared bool _tzsetWasCalled;
-
-
     // This is done so that we can maintain purity in spite of doing an impure
     // operation the first time that LocalTime() is called.
     static immutable(LocalTime) singleton() @trusted
     {
-        if(!_lowLock)
-        {
-            synchronized
-            {
-                if(!_tzsetWasCalled)
-                {
-                    tzset();
-                    _tzsetWasCalled = true;
-                }
-            }
-
-            _lowLock = true;
-        }
-
-        return _localTime;
+        import std.concurrency : initOnce;
+        static instance = new immutable(LocalTime)();
+        static shared bool guard;
+        initOnce!guard({tzset(); return true;}());
+        return instance;
     }
 }
 

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -3278,24 +3278,13 @@ terminating the main thread.
 */
 @property TaskPool taskPool() @trusted
 {
-    static bool initialized;
-    __gshared static TaskPool pool;
-
-    if(!initialized)
-    {
-        synchronized(typeid(TaskPool))
-        {
-            if(!pool)
-            {
-                pool = new TaskPool(defaultPoolThreads);
-                pool.isDaemon = true;
-            }
-        }
-
-        initialized = true;
-    }
-
-    return pool;
+    import std.concurrency : initOnce;
+    __gshared TaskPool pool;
+    return initOnce!pool({
+        auto p = new TaskPool(defaultPoolThreads);
+        p.isDaemon = true;
+        return p;
+    }());
 }
 
 private shared uint _defaultPoolThreads;
@@ -4572,7 +4561,7 @@ version(unittest)
 {
     struct __S_12733
     {
-        invariant() { assert(checksum == 1234567890); }    
+        invariant() { assert(checksum == 1234567890); }
         this(ulong u){n = u;}
         void opAssign(__S_12733 s){this.n = s.n;}
         ulong n;
@@ -4585,6 +4574,6 @@ version(unittest)
 unittest
 {
     immutable ulong[] data = [ 2UL^^59-1, 2UL^^59-1, 2UL^^59-1, 112_272_537_195_293UL ];
- 
+
     auto result = taskPool.amap!__genPair_12733(data);
 }


### PR DESCRIPTION
- use core.time.MonoTime in std.concurrency to break
  cyclic dependency of std.datetime and std.concurrency

requires #3208