### PR TITLE
Avoid use after remove from hashtable

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -1938,11 +1938,12 @@ private
                 assert( msg.convertsTo!(Tid) );
                 auto tid = msg.get!(Tid);
 
-                if( bool* depends = (tid in thisInfo.links) )
+                if( bool* pDepends = (tid in thisInfo.links) )
                 {
+                    auto depends = *pDepends;
                     thisInfo.links.remove( tid );
                     // Give the owner relationship precedence.
-                    if( *depends && tid != thisInfo.owner )
+                    if( depends && tid != thisInfo.owner )
                     {
                         auto e = new LinkTerminated( tid );
                         auto m = Message( MsgType.standard, e );


### PR DESCRIPTION
Although https://github.com/D-Programming-Language/druntime/pull/1143 technically takes care of this, use after remove is not nice. cc @complexmath 