### PR TITLE
Improve std.exception.handle

### DIFF
--- a/std/exception.d
+++ b/std/exception.d
@@ -1900,7 +1900,7 @@ auto handle(E : Throwable, RangePrimitive primitivesToHandle, alias handler, Ran
 }
 
 ///
-unittest
+pure @safe unittest
 {
     import std.algorithm : equal, map, splitter;
     import std.conv : to, ConvException;
@@ -1917,7 +1917,7 @@ unittest
 }
 
 ///
-unittest
+pure @safe unittest
 {
     import std.algorithm : equal;
     import std.range : retro;
@@ -1932,10 +1932,11 @@ unittest
     assert(handled.retro.equal("dlrow olleh")); // as well as `back`
 }
 
-unittest
+pure nothrow @safe unittest
 {
     static struct ThrowingRange
     {
+        pure @safe:
         @property bool empty()
         {
             throw new Exception("empty has thrown");
@@ -2045,6 +2046,7 @@ unittest
 
     static struct Infinite
     {
+        pure @safe:
         enum bool empty = false;
         int front() { assert(false); }
         void popFront() { assert(false); }


### PR DESCRIPTION
* Refactored to not use AliasThis as discussed in #2949
* Added `RangePrimitive.access` and `RangePrimitive.pop` to make doing the right thing in the common case easier
* Added example using `handle` to replace invalid code points with spaces instead of throwing

Ping @burner; I examined the possibility of adding `handleAccess` and `handlePop` convenience functions, but I think this way, using additional members of `RangePrimitive` is cleaner. IMO, this way, doing the right thing is easy while flexibility is still available. What do you think?

About opSlice infinite ranges, maybe leaving the `take`ing to the handler function and static-asserting if the return type isn't correct would be a nice solution. That way the user can't make the easy mistake of not implementing slicing properly, but still has the flexibility of returning a slice of whatever length the user wants.