### PR TITLE
Issue 14059 - Formatted write with wrong formatting string

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -867,7 +867,7 @@ struct FormatSpec(Char)
                 // Get the matching balanced paren
                 for (uint innerParens;;)
                 {
-                    enforce(j + 1 < trailing.length,
+                    enforceFmt(j + 1 < trailing.length,
                         text("Incorrect format specifier: %", trailing[i .. $]));
                     if (trailing[j++] != '%')
                     {
@@ -877,7 +877,7 @@ struct FormatSpec(Char)
                     if (trailing[j] == '-') // for %-(
                     {
                         ++j;    // skip
-                        enforce(j < trailing.length,
+                        enforceFmt(j < trailing.length,
                             text("Incorrect format specifier: %", trailing[i .. $]));
                     }
                     if (trailing[j] == ')')

--- a/std/format.d
+++ b/std/format.d
@@ -867,7 +867,7 @@ struct FormatSpec(Char)
                 // Get the matching balanced paren
                 for (uint innerParens;;)
                 {
-                    enforce(j < trailing.length,
+                    enforce(j + 1 < trailing.length,
                         text("Incorrect format specifier: %", trailing[i .. $]));
                     if (trailing[j++] != '%')
                     {
@@ -875,7 +875,11 @@ struct FormatSpec(Char)
                         continue;
                     }
                     if (trailing[j] == '-') // for %-(
+                    {
                         ++j;    // skip
+                        enforce(j < trailing.length,
+                            text("Incorrect format specifier: %", trailing[i .. $]));
+                    }
                     if (trailing[j] == ')')
                     {
                         if (innerParens-- == 0) break;
@@ -1197,6 +1201,19 @@ struct FormatSpec(Char)
     assert(a.data == "Number: \nString: ");
     assert(f.trailing == "");
     assert(f.spec == 's');
+}
+
+// Issue 14059
+unittest
+{
+    import std.array : appender;
+    auto a = appender!(string)();
+
+    auto f = FormatSpec!char("%-(%s%");
+    assertThrown(f.writeUpToNextSpec(a));
+
+    f = FormatSpec!char("%(%-");
+    assertThrown(f.writeUpToNextSpec(a));
 }
 
 /**


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14059

I adjusted enforce condition, because it reads two(or three if '-' exists) characters in one loop.