### PR TITLE
Change foreach loop in std.algorithm.searching.find to a for-loop

### DIFF
--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -1489,9 +1489,9 @@ if (isInputRange!InputRange)
     else static if (!isInfinite!R && hasSlicing!R && is(typeof(haystack[cast(size_t)0 .. $])))
     {
         size_t i = 0;
-        foreach (ref e; haystack)
+        for (auto h = haystack.save; !h.empty; h.popFront())
         {
-            if (predFun(e))
+            if (predFun(h.front))
                 return haystack[i .. $];
             ++i;
         }


### PR DESCRIPTION
I'd file an issue but it's unclear what the bug is here; see [this thread](http://forum.dlang.org/post/eznmimqkrcfkghizcvwz@forum.dlang.org) for more information.

The path is already tested as verified by coverage analysis.