### PR TITLE
document replacing D1's listdir()

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -2983,6 +2983,31 @@ auto dirEntries(string path, SpanMode mode, bool followSymlink = true)
     return DirIterator(path, mode, followSymlink);
 }
 
+/// Duplicate functionality of D1's $(D std.file.listdir()):
+unittest
+{
+  string[] listdir(string pathname)
+  {
+    import std.file;
+    import std.path;
+    import std.algorithm;
+    import std.array;
+
+    return std.file.dirEntries(pathname, SpanMode.shallow)
+      .filter!(a => a.isFile)
+      .map!(a => std.path.baseName(a.name))
+      .array;
+  }
+
+  void main(string[] args)
+  {
+    import std.stdio;
+
+    string[] files = listdir(args[1]);
+    writefln("%s", files);
+  }
+}
+
 unittest
 {
     import std.algorithm;


### PR DESCRIPTION
Many D1 functions got deleted for D2, and the replacements aren't always obvious. This adds an example to `dirEntries()` showing how it can be used to replace `listdir()`. 