### PR TITLE
Add keepEndOfOptions flag to std.getopt

### DIFF
--- a/std/getopt.d
+++ b/std/getopt.d
@@ -1110,7 +1110,7 @@ unittest
 
     // test keepEndOfOptions
 
-    args = (["program.name", "--foo", "nonoption", "--bar", "--", "--baz"]).dup;
+    args = ["program.name", "--foo", "nonoption", "--bar", "--", "--baz"];
     getopt(args,
         std.getopt.config.keepEndOfOptions,
         "foo", &foo,
@@ -1119,7 +1119,7 @@ unittest
 
     // Ensure old behavior without the keepEndOfOptions
 
-    args = (["program.name", "--foo", "nonoption", "--bar", "--", "--baz"]).dup;
+    args = ["program.name", "--foo", "nonoption", "--bar", "--", "--baz"];
     getopt(args,
         "foo", &foo,
         "bar", &bar);


### PR DESCRIPTION
Currently, the endOfOptions separator ("--" by default) is stripped from args by getopt.  At times it may be advantageous to keep this separator, such as when your program is forwarding command line arguments to some other program.

Without this, hacks such as

```D
auto remaining = args.find(endOfOptions);
args = args[0 .. $ - remaining.length];
getopt(args, opts);
args = args ~ remaining;
```

are needed to achieve the desired behavior.