### PR TITLE
Reject instantiating RefCounted with interface types

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -4030,7 +4030,7 @@ pointer dereference.
  */
 struct RefCounted(T, RefCountedAutoInitialize autoInit =
         RefCountedAutoInitialize.yes)
-if (!is(T == class))
+if (!is(T == class) && !(is(T == interface)))
 {
     /// $(D RefCounted) storage implementation.
     struct RefCountedStore


### PR DESCRIPTION
Issue noticed in [this thread](http://forum.dlang.org/post/axgwaskjtkozmjuoifyi@forum.dlang.org).

For the purposes of forward-compatibility, `RefCounted` has rejected classes because it is intended that in the future `RefCounted!SomeClass` reference-counts the actual instance and not just a class reference. Once implemented, interfaces should be handled in a similar way.

It is my intention to work on class support for `RefCounted`, but in case the status quo continues for a long time, we have to reject interfaces as well.
