### PR TITLE
Fix imports

### DIFF
--- a/std/experimental/logger/multilogger.d
+++ b/std/experimental/logger/multilogger.d
@@ -69,7 +69,7 @@ class MultiLogger : Logger
     Logger removeLogger(in char[] toRemove) @safe
     {
         import std.algorithm : copy;
-        import std.range.interfaces : back, popBack;
+        import std.range.primitives : back, popBack;
         for (size_t i = 0; i < this.logger.length; ++i)
         {
             if (this.logger[i].name == toRemove)


### PR DESCRIPTION
`std.range.interfaces` privately imports `std.range.primitives`. So selective importing `back` and `popBack` via `std.range.interfaces` is not possible.