### PR TITLE
std.math: №1, change protection

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -207,7 +207,7 @@ version(unittest)
 
 
 
-private:
+package:
 // The following IEEE 'real' formats are currently supported.
 version(LittleEndian)
 {


### PR DESCRIPTION
Attribute was changed for `RealFormat`, `floatTraits`, `floorImpl`. This
suff is usefull (#3045) in other modules like `std.numeric` and
`std.mathspecial`.