### PR TITLE
Total ordering for floating-point values.

### DIFF
--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -929,6 +929,7 @@ $(D less(a,c)) (transitivity), and, conversely, $(D !less(a,b) && !less(b,c)) to
 imply $(D !less(a,c)). Note that the default predicate ($(D "a < b")) does not
 always satisfy these conditions for floating point types, because the expression
 will always be $(D false) when either $(D a) or $(D b) is NaN.
+Use $(XREF math, cmp) instead.
 
 Returns: The initial range wrapped as a $(D SortedRange) with the predicate
 $(D binaryFun!less).
@@ -1004,6 +1005,21 @@ unittest
     string[] words = [ "aBc", "a", "abc", "b", "ABC", "c" ];
     sort!("toUpper(a) < toUpper(b)", SwapStrategy.stable)(words);
     assert(words == [ "a", "aBc", "abc", "ABC", "b", "c" ]);
+}
+
+///
+unittest
+{
+    // Sorting floating-point numbers in presence of NaN
+    double[] numbers = [-0.0, 3.0, -2.0, double.nan, 0.0, -double.nan];
+
+    import std.math : cmp, isIdentical;
+    import std.algorithm.comparison : equal;
+
+    sort!((a, b) => cmp(a, b) < 0)(numbers);
+
+    double[] sorted = [-double.nan, -2.0, -0.0, 0.0, 3.0, double.nan];
+    assert(numbers.equal!isIdentical(sorted));
 }
 
 unittest

--- a/std/math.d
+++ b/std/math.d
@@ -7035,8 +7035,9 @@ unittest
     import std.typetuple;
     foreach (T; TypeTuple!(float, double, real))
     {
-        T[] values = [-cast(T)NaN(20), -T.nan, -T.infinity, -T.max, -T.max / 2,
-                      T(-16.0), T(-1.0).nextDown, T(-1.0), T(-1.0).nextUp,
+        T[] values = [-cast(T)NaN(20), -cast(T)NaN(10), -T.nan, -T.infinity,
+                      -T.max, -T.max / 2, T(-16.0), T(-1.0).nextDown,
+                      T(-1.0), T(-1.0).nextUp,
                       T(-0.5), -T.min_normal, (-T.min_normal).nextUp,
                       -2 * T.min_normal * T.epsilon,
                       -T.min_normal * T.epsilon,
@@ -7044,10 +7045,11 @@ unittest
                       T.min_normal * T.epsilon,
                       2 * T.min_normal * T.epsilon,
                       T.min_normal.nextDown, T.min_normal, T(0.5),
-                      T(1.0).nextDown, T(1.0), T(1.0).nextUp, T(16.0),
-                      T.max / 2, T.max, T.infinity, T.nan, cast(T)NaN(20)];
+                      T(1.0).nextDown, T(1.0),
+                      T(1.0).nextUp, T(16.0), T.max / 2, T.max,
+                      T.infinity, T.nan, cast(T)NaN(10), cast(T)NaN(20)];
 
-        foreach (i, x; values[0 .. $ - 1])
+        foreach (i, x; values)
         {
             foreach (y; values[i + 1 .. $])
             {

--- a/std/math.d
+++ b/std/math.d
@@ -7026,7 +7026,6 @@ unittest
 unittest
 {
     assert(cmp(NaN(10), NaN(20)) < 0);
-
     assert(cmp(-NaN(20), -NaN(10)) < 0);
 }
 

--- a/std/math.d
+++ b/std/math.d
@@ -6933,6 +6933,7 @@ int cmp(T)(const(T) x, const(T) y) @nogc @trusted pure nothrow
             }
 
         version(LittleEndian)
+        {
             if (vars[0].bits.rem < vars[1].bits.rem)
                 return -1;
             else if (vars[0].bits.rem > vars[1].bits.rem)
@@ -6943,7 +6944,9 @@ int cmp(T)(const(T) x, const(T) y) @nogc @trusted pure nothrow
                 return 1;
             else
                 return 0;
+        }
         else
+        {
             if (vars[0].bits.bulk < vars[1].bits.bulk)
                 return -1;
             else if (vars[0].bits.bulk > vars[1].bits.bulk)
@@ -6954,6 +6957,7 @@ int cmp(T)(const(T) x, const(T) y) @nogc @trusted pure nothrow
                 return 1;
             else
                 return 0;
+        }
     }
     else
     {

--- a/std/math.d
+++ b/std/math.d
@@ -6942,11 +6942,10 @@ int cmp(T)(T x, T y) @nogc @trusted pure nothrow
         int xSign = signbit(x),
             ySign = signbit(y);
 
-        if (xSign == 1)
-            if (ySign == 1)
-                return cmp(-y, -x);
-            else
-                return -1;
+        if (xSign == 1 && ySign == 1)
+            return cmp(-y, -x);
+        else if (xSign == 1)
+            return -1;
         else if (ySign == 1)
             return 1;
         else if (x < y)
@@ -6955,18 +6954,16 @@ int cmp(T)(T x, T y) @nogc @trusted pure nothrow
             return 0;
         else if (x > y)
             return 1;
-        else if (isNaN(x))
-            if (isNaN(y))
-                if (getNaNPayload(x) < getNaNPayload(y))
-                    return -1;
-                else if (getNaNPayload(x) > getNaNPayload(y))
-                    return 1;
-                else
-                    return 0;
-            else
-                return 1;
-        else // y is NaN, x is not
+        else if (isNaN(x) && !isNaN(y))
+            return 1;
+        else if (isNaN(y) && !isNaN(x))
             return -1;
+        else if (getNaNPayload(x) < getNaNPayload(y))
+            return -1;
+        else if (getNaNPayload(x) > getNaNPayload(y))
+            return 1;
+        else
+            return 0;
     }
 }
 

--- a/std/math.d
+++ b/std/math.d
@@ -6876,7 +6876,10 @@ int cmp(T)(const(T) x, const(T) y) @nogc @trusted pure nothrow
 
         enum msb = ~(UInt.max >>> 1);
 
-        Repainter[2] vars = [ { number : x }, { number : y } ];
+        import std.typecons : Tuple;
+        Tuple!(Repainter, Repainter) vars = void;
+        vars[0].number = x;
+        vars[1].number = y;
 
         foreach (ref var; vars)
             if (var.bits & msb)
@@ -6913,7 +6916,10 @@ int cmp(T)(const(T) x, const(T) y) @nogc @trusted pure nothrow
             ubyte[T.sizeof] bytes;
         }
 
-        Repainter[2] vars = [ { number : x }, { number : y }];
+        import std.typecons : Tuple;
+        Tuple!(Repainter, Repainter) vars = void;
+        vars[0].number = x;
+        vars[1].number = y;
 
         foreach (ref var; vars)
             if (var.bytes[F.SIGNPOS_BYTE] & 0x80)

--- a/std/math.d
+++ b/std/math.d
@@ -6995,14 +6995,14 @@ int cmp(T)(const(T) x, const(T) y) @nogc @trusted pure nothrow
 /// Most numbers are ordered naturally.
 unittest
 {
-    assert(cmp(-double.infinity, -double.max) == -1);
-    assert(cmp(-double.max, -100.0) == -1);
-    assert(cmp(-100.0, -0.5) == -1);
-    assert(cmp(-0.5, 0.0) == -1);
-    assert(cmp(0.0, 0.5) == -1);
-    assert(cmp(0.5, 100.0) == -1);
-    assert(cmp(100.0, double.max) == -1);
-    assert(cmp(double.max, double.infinity) == -1);
+    assert(cmp(-double.infinity, -double.max) < 0);
+    assert(cmp(-double.max, -100.0) < 0);
+    assert(cmp(-100.0, -0.5) < 0);
+    assert(cmp(-0.5, 0.0) < 0);
+    assert(cmp(0.0, 0.5) < 0);
+    assert(cmp(0.5, 100.0) < 0);
+    assert(cmp(100.0, double.max) < 0);
+    assert(cmp(double.max, double.infinity) < 0);
 
     assert(cmp(1.0, 1.0) == 0);
 }
@@ -7010,24 +7010,24 @@ unittest
 /// Positive and negative zeroes are distinct.
 unittest
 {
-    assert(cmp(-0.0, +0.0) == -1);
-    assert(cmp(+0.0, -0.0) == 1);
+    assert(cmp(-0.0, +0.0) < 0);
+    assert(cmp(+0.0, -0.0) > 0);
 }
 
 /// Depending on the sign, $(NAN)s go to either end of the spectrum.
 unittest
 {
-    assert(cmp(-double.nan, -double.infinity) == -1);
-    assert(cmp(double.infinity, double.nan) == -1);
-    assert(cmp(-double.nan, double.nan) == -1);
+    assert(cmp(-double.nan, -double.infinity) < 0);
+    assert(cmp(double.infinity, double.nan) < 0);
+    assert(cmp(-double.nan, double.nan) < 0);
 }
 
 /// $(NAN)s of the same sign are ordered by the payload.
 unittest
 {
-    assert(cmp(NaN(10), NaN(20)) == -1);
+    assert(cmp(NaN(10), NaN(20)) < 0);
 
-    assert(cmp(-NaN(20), -NaN(10)) == -1);
+    assert(cmp(-NaN(20), -NaN(10)) < 0);
 }
 
 unittest
@@ -7053,8 +7053,8 @@ unittest
         {
             foreach (y; values[i + 1 .. $])
             {
-                assert(cmp(x, y) == -1);
-                assert(cmp(y, x) == 1);
+                assert(cmp(x, y) < 0);
+                assert(cmp(y, x) > 0);
             }
             assert(cmp(x, x) == 0);
         }

--- a/std/math.d
+++ b/std/math.d
@@ -6848,8 +6848,8 @@ real yl2xp1(real x, real y) @nogc @safe pure nothrow;       // y * log2(x + 1)
  * )
  *
  * Returns:
- *      -1 if $(D x) precedes $(D y) in the order specified above;
- *      0 if $(D x) and $(D y) are identical, and 1 otherwise.
+ *      negative value if $(D x) precedes $(D y) in the order specified above;
+ *      0 if $(D x) and $(D y) are identical, and positive value otherwise.
  *
  * See_Also:
  *      $(MYREF isIdentical)

--- a/std/math.d
+++ b/std/math.d
@@ -6899,7 +6899,7 @@ int cmp(T)(T x, T y) @nogc @trusted pure nothrow
         ubyte*[2] bytes = [cast(ubyte*)&x, cast(ubyte*)&y];
 
         ulong*[2] bulk = [cast(ulong*)&x, cast(ulong*)&y];
-        RemT*[2] rem = [cast(ushort*)&x + shift, cast(ushort*)&y + shift];
+        RemT*[2] rem = [cast(RemT*)&x + shift, cast(RemT*)&y + shift];
 
         foreach (i; 0 .. 2)
             if (bytes[i][F.SIGNPOS_BYTE] & 0x80)

--- a/std/math.d
+++ b/std/math.d
@@ -7007,8 +7007,8 @@ unittest
 
 unittest
 {
-    static void test(T)()
-        if (isFloatingPoint!T)
+    import std.typetuple;
+    foreach (T; TypeTuple!(float, double, real))
     {
         T[] values = [-cast(T)NaN(20), -T.nan, -T.infinity, -T.max, -T.max / 2,
                       T(-16.0), T(-1.0).nextDown, T(-1.0), T(-1.0).nextUp,
@@ -7032,8 +7032,4 @@ unittest
             assert(cmp(x, x) == 0);
         }
     }
-
-    test!float;
-    test!double;
-    test!real;
 }

--- a/std/math.d
+++ b/std/math.d
@@ -6855,10 +6855,13 @@ real yl2xp1(real x, real y) @nogc @safe pure nothrow;       // y * log2(x + 1)
  *      $(MYREF isIdentical)
  * Standards: Conforms to IEEE 754-2008
  */
-int cmp(T)(T x, T y) @nogc @trusted pure nothrow
+int cmp(T)(const(T) x, const(T) y) @nogc @trusted pure nothrow
     if (isFloatingPoint!T)
 {
     alias F = floatTraits!T;
+
+    // mutable parameter counterparts, because they *are* mutated later in code
+    T mutX = x, mutY = y;
 
     static if (F.realFormat == RealFormat.ieeeSingle
                || F.realFormat == RealFormat.ieeeDouble)


### PR DESCRIPTION
Adds a `totalOrder` function as specified in IEEE 754-2008.

An immediate benefit is the ability to sort arrays of floating-point values and get predictable results even in presence of NaNs (see http://dpaste.dzfl.pl/1f78bc6f7d2b).