### PR TITLE
Fix Issue 14223 - TimSort algorithm is incorrect

### DIFF
--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1225,17 +1225,16 @@ private template TimSortImpl(alias pred, R)
             // STACK is | ... e1 e2 e3 >
             while (stackLen > 1)
             {
-                immutable run1 = stackLen - 4;
-                immutable run2 = stackLen - 3;
-                immutable run3 = stackLen - 2;
                 immutable run4 = stackLen - 1;
+                immutable run3 = stackLen - 2;
+                immutable run2 = stackLen - 3;
+                immutable run1 = stackLen - 4;
                 
-                if (stackLen > 2 && stack[run2].length <= stack[run3].length + stack[run4].length || 
-                    stackLen > 3 && stack[run1].length <= stack[run3].length + stack[run2].length )
+                if ( (stackLen > 2 && stack[run2].length <= stack[run3].length + stack[run4].length) || 
+                     (stackLen > 3 && stack[run1].length <= stack[run3].length + stack[run2].length) )
                 {
                     immutable at = stack[run2].length < stack[run4].length ? run2 : run3;
                     mergeAt(range, stack[0 .. stackLen], at, minGallop, temp);
-                    
                 }
                 else if (stack[run3].length > stack[run4].length) break;
                 else mergeAt(range, stack[0 .. stackLen], run3, minGallop, temp);
@@ -1244,13 +1243,16 @@ private template TimSortImpl(alias pred, R)
             }
             
             // Assert that the code above established the invariant correctly
-            debug
+            version (assert)
             {
                 if (stackLen == 2) assert(stack[0].length > stack[1].length);
-                else if (stackLen > 2) foreach(k; 2 .. stackLen)
+                else if (stackLen > 2)
                 {
-                    assert(stack[k - 2].length > stack[k - 1].length + stack[k].length);
-                    assert(stack[k - 1].length > stack[k].length);
+                    foreach(k; 2 .. stackLen)
+                    {
+                        assert(stack[k - 2].length > stack[k - 1].length + stack[k].length);
+                        assert(stack[k - 1].length > stack[k].length);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This fixes the issue described in [this article](http://envisage-project.eu/proving-android-java-and-python-sorting-algorithm-is-broken-and-how-to-fix-it/) which found most implementations of Timsort are incorrect. I took the fix provided in that article and adapted it to the Phobos implementation.

I don't have a formal proof that my fix is correct. However, I added a check to debug builds which traverses the stack and confirms that the invariant of the stack is preserved. I also found a few test cases which broke the invariant on the old implementation but work correctly with this new fix. I added a unittest for the simplest of these cases.

A few other minor changes:
* The comment describing the invariant was wrong so I corrected that.
* uninitializedArray now works correctly in CTFE so there's no more need for the __ctfe check.
* I corrected a few cases of unsigned integer underflow, e.g. `at == stack.length - 2`.