### PR TITLE
[REG2.067b2] Issue 14233 - Can't build Algebraic!(This[]) anymore

### DIFF
--- a/std/variant.d
+++ b/std/variant.d
@@ -481,7 +481,7 @@ private:
             static if (!is(Unqual!(typeof((*zis)[0])) == void) && is(typeof((*zis)[0])) && is(typeof((*zis) ~= *zis)))
             {
                 // array type; parm is the element to append
-                auto arg = cast(VariantN*) parm;
+                auto arg = cast(Variant*) parm;
                 alias E = typeof((*zis)[0]);
                 if (arg[0].convertsTo!(E))
                 {
@@ -1107,7 +1107,7 @@ public:
     ///ditto
     VariantN opCatAssign(T)(T rhs)
     {
-        auto toAppend = VariantN(rhs);
+        auto toAppend = Variant(rhs);
         fptr(OpID.catAssign, &store, &toAppend) == 0 || assert(false);
         return this;
     }
@@ -1297,6 +1297,15 @@ unittest
     assert(aa["b"] == 2);
     aa["b"] = 3;
     assert(aa["b"] == 3);
+}
+
+// Issue #14233
+unittest
+{
+    alias Atom = Algebraic!(string, This[]);
+
+    Atom[] values = [];
+    auto a = Atom(values);
 }
 
 pure nothrow @nogc


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14233

In pull #2453, VariantN.opIndex has been changed to return `Variant`.
It affects to OpID.catAssign case in handler(A), because it's using `alias E = typeof((*zis)[0]);` to determine concatenated element type.