### PR TITLE
Revert "make flags are automatically communicated to sub-make"

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -287,7 +287,7 @@ unittest : $(addsuffix .d,$(addprefix unittest/,$(D_MODULES)))
 else
 unittest : unittest-debug unittest-release
 unittest-%:
-	$(MAKE) -f $(MAKEFILE) unittest BUILD=$*
+	$(MAKE) -f $(MAKEFILE) $(MAKEFLAGS) unittest OS=$(OS) MODEL=$(MODEL) DMD=$(DMD) BUILD=$*
 endif
 
 depend: $(addprefix $(ROOT)/unittest/,$(addsuffix .deps,$(D_MODULES)))


### PR DESCRIPTION
Reverts D-Programming-Language/phobos#3006. Refer to discussion in there for the rationale. cc @MartinNowak - thanks.