### PR TITLE
Unmark BitArray.this() for deprecation

### DIFF
--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -1260,7 +1260,6 @@ public:
      * these will be set to 0.
      *
      * This is the inverse of $(D opCast).
-     * $(RED Will be deprecated in 2.068. Please use the constructor instead.)
      */
     this(void[] v, size_t numbits) pure nothrow
     in


### PR DESCRIPTION
25ac0482acb2887d03c23b9c644c2d8a5463f005 should do either of
* change init to this
* announce deprecation of init
but actually did both.
