### PR TITLE
fix Issue 14198 - [REG2.067a] Link failure with Variant

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -105,13 +105,20 @@ private
     T toStr(T, S)(S src)
         if (isSomeString!T)
     {
-        import std.format : FormatSpec, formatValue;
-        import std.array : appender;
+        static if (is(S == bool) && is(typeof({ T s = "string"; })))
+        {
+            return src ? "true" : "false";
+        }
+        else
+        {
+            import std.format : FormatSpec, formatValue;
+            import std.array : appender;
 
-        auto w = appender!T();
-        FormatSpec!(ElementEncodingType!T) f;
-        formatValue(w, src, f);
-        return w.data;
+            auto w = appender!T();
+            FormatSpec!(ElementEncodingType!T) f;
+            formatValue(w, src, f);
+            return w.data;
+        }
     }
 
     template isExactSomeString(T)

--- a/std/variant.d
+++ b/std/variant.d
@@ -1299,6 +1299,12 @@ unittest
     assert(aa["b"] == 3);
 }
 
+// Issue #14198
+unittest
+{
+    Variant a = true;
+}
+
 // Issue #14233
 unittest
 {


### PR DESCRIPTION
This was caused by the format functions recursively calling `to!string`, resulting in it not being inferred properly as pure. A specialization fixes it.