### PR TITLE
[Minor] Fix last `std.numeric.findRoot` overload without tolerance delegate.

### DIFF
--- a/std/numeric.d
+++ b/std/numeric.d
@@ -1163,7 +1163,7 @@ whileloop:
 }
 
 ///ditto
-Tuple!(T, T, R, R) findRoot(T, R, DF, DT)(scope DF f, in T ax, in T bx, in R fax, in R fbx)
+Tuple!(T, T, R, R) findRoot(T, R, DF)(scope DF f, in T ax, in T bx, in R fax, in R fbx)
 {
     return findRoot(f, ax, bx, fax, fbx, (T a, T b) => false);
 }


### PR DESCRIPTION
Fixes trivial copy-paste error.