### PR TITLE
fix attributes for synchronized (mtx)

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -1792,10 +1792,8 @@ private
             }
         }
 
-
-        /*
-         *
-         */
+        ///
+        deprecated("isClosed can't be used with a const MessageBox")
         final @property bool isClosed() const
         {
             synchronized( m_lock )
@@ -1804,6 +1802,14 @@ private
             }
         }
 
+        ///
+        final @property bool isClosed()
+        {
+            synchronized( m_lock )
+            {
+                return m_closed;
+            }
+        }
 
         /*
          * Sets a limit on the maximum number of user messages allowed in the

--- a/std/experimental/logger/core.d
+++ b/std/experimental/logger/core.d
@@ -890,7 +890,7 @@ abstract class Logger
 
     By default an $(D Error) will be thrown.
     */
-    @property final void delegate() fatalHandler() const pure @safe @nogc
+    @property final void delegate() fatalHandler() pure @safe @nogc
     {
         synchronized (mutex) return this.fatalHandler_;
     }

--- a/std/experimental/logger/core.d
+++ b/std/experimental/logger/core.d
@@ -880,7 +880,7 @@ abstract class Logger
     }
 
     /// Ditto
-    @property final void logLevel(const LogLevel lv) pure @safe @nogc
+    @property final void logLevel(const LogLevel lv) @safe @nogc
     {
         synchronized (mutex) this.logLevel_ = lv;
     }
@@ -890,13 +890,13 @@ abstract class Logger
 
     By default an $(D Error) will be thrown.
     */
-    @property final void delegate() fatalHandler() pure @safe @nogc
+    @property final void delegate() fatalHandler() @safe @nogc
     {
         synchronized (mutex) return this.fatalHandler_;
     }
 
     /// Ditto
-    @property final void fatalHandler(void delegate() @safe fh) pure @safe @nogc
+    @property final void fatalHandler(void delegate() @safe fh) @safe @nogc
     {
         synchronized (mutex) this.fatalHandler_ = fh;
     }


### PR DESCRIPTION
- synchronized (mtx) is neither pure not const

- the compiler currently doesn't check attributes
  for synchronized statements