### PR TITLE
Give std.json an opEquals

### DIFF
--- a/std/json.d
+++ b/std/json.d
@@ -528,6 +528,38 @@ struct JSONValue
         string a = ("author" in j).str;
     }
 
+    bool opEquals(const JSONValue rhs) const
+    {
+        return opEquals(rhs);
+    }
+
+    bool opEquals(ref const JSONValue rhs) const
+    {
+        // Default doesn't work well since store is a union.  Compare only
+        // what should be in store.
+        if (type_tag != rhs.type_tag) return false;
+
+        final switch (type_tag)
+        {
+        case JSON_TYPE.STRING:
+            return store.str == rhs.store.str;
+        case JSON_TYPE.INTEGER:
+            return store.integer == rhs.store.integer;
+        case JSON_TYPE.UINTEGER:
+            return store.uinteger == rhs.store.uinteger;
+        case JSON_TYPE.FLOAT:
+            return store.floating == rhs.store.floating;
+        case JSON_TYPE.OBJECT:
+            return store.object == rhs.store.object;
+        case JSON_TYPE.ARRAY:
+            return store.array == rhs.store.array;
+        case JSON_TYPE.TRUE:
+        case JSON_TYPE.FALSE:
+        case JSON_TYPE.NULL:
+            return true;
+        }
+    }
+
     /// Implements the foreach $(D opApply) interface for json arrays.
     int opApply(int delegate(size_t index, ref JSONValue) dg)
     {


### PR DESCRIPTION
Add opEquals to struct JSONValue.  Needed for correct comparison of the union used for member store.  Without this change, some std.json unittests will fail on iOS armv7.