### PR TITLE
fix Issue 14282 - executeShell should use sh and ignore the SHELL env variable

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -2203,8 +2203,8 @@ $(D "/bin/sh").
 @property string userShell() @safe
 {
     version (Windows)      return environment.get("COMSPEC", "cmd.exe");
-    else version (Android) return environment.get("SHELL", "/system/bin/sh");
-    else version (Posix)   return environment.get("SHELL", "/bin/sh");
+    else version (Android) return "/system/bin/sh";
+    else version (Posix)   return "/bin/sh";
 }
 
 


### PR DESCRIPTION
[Issue 14282 – executeShell should use sh and ignore the SHELL env variable](https://issues.dlang.org/show_bug.cgi?id=14282)