### PR TITLE
fix compile times for regex tests

### DIFF
--- a/std/regex/internal/tests.d
+++ b/std/regex/internal/tests.d
@@ -66,7 +66,7 @@ unittest
         string flags;
     }
 
-    enum TestVectors[] tv = [
+    static immutable TestVectors[] tv = [
         TestVectors(  "a\\b",       "a",  "y",    "$&",    "a" ),
         TestVectors(  "(a)b\\1",   "abaab","y",    "$&",    "aba" ),
         TestVectors(  "()b\\1",     "aaab", "y",    "$&",    "b" ),
@@ -354,7 +354,7 @@ unittest
             }
             Regex!(Char) r;
             foreach(a, tvd; tv)
-            (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
+            {
                 uint c = tvd.result[0];
                 debug(std_regex_test) writeln(" Test #", a, " pattern: ", tvd.pattern, " with Char = ", Char.stringof);
                 try
@@ -383,7 +383,7 @@ unittest
                                     tvd.replace, " vs ", result));
                     }
                 }
-            }();
+            }
         }();
         debug(std_regex_test) writeln("!!! FReD bulk test done "~matchFn.stringof~" !!!");
     }
@@ -459,19 +459,34 @@ unittest
     assert(bmatch("abc",cr).hit == "abc");
     auto cr2 = ctRegex!("ab*c");
     assert(bmatch("abbbbc",cr2).hit == "abbbbc");
+}
+unittest
+{
     auto cr3 = ctRegex!("^abc$");
     assert(bmatch("abc",cr3).hit == "abc");
     auto cr4 = ctRegex!(`\b(a\B[a-z]b)\b`);
     assert(array(match("azb",cr4).captures) == ["azb", "azb"]);
+}
+
+unittest
+{
     auto cr5 = ctRegex!("(?:a{2,4}b{1,3}){1,2}");
     assert(bmatch("aaabaaaabbb", cr5).hit == "aaabaaaabbb");
     auto cr6 = ctRegex!("(?:a{2,4}b{1,3}){1,2}?"w);
     assert(bmatch("aaabaaaabbb"w,  cr6).hit == "aaab"w);
+}
+
+unittest
+{
     auto cr7 = ctRegex!(`\r.*?$`,"sm");
     assert(bmatch("abc\r\nxy",  cr7).hit == "\r\nxy");
     auto greed =  ctRegex!("<packet.*?/packet>");
     assert(bmatch("<packet>text</packet><packet>text</packet>", greed).hit
             == "<packet>text</packet>");
+}
+
+unittest
+{
     auto cr8 = ctRegex!("^(a)(b)?(c*)");
     auto m8 = bmatch("abcc",cr8);
     assert(m8);
@@ -482,7 +497,10 @@ unittest
     auto m9 = match("xxqababqyy",cr9);
     assert(m9);
     assert(equal(bmatch("xxqababqyy",cr9).captures, ["qababq", "b"]));
+}
 
+unittest
+{
     auto rtr = regex("a|b|c");
     enum ctr = regex("a|b|c");
     assert(equal(rtr.ir,ctr.ir));
@@ -732,12 +750,12 @@ unittest
 unittest
 {// bugzilla 7679
     foreach(S; TypeTuple!(string, wstring, dstring))
-    {
+    (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
         enum re = ctRegex!(to!S(r"\."));
         auto str = to!S("a.b");
         assert(equal(std.regex.splitter(str, re), [to!S("a"), to!S("b")]));
         assert(split(str, re) == [to!S("a"), to!S("b")]);
-    }
+    }();
 }
 unittest
 {//bugzilla 8203


### PR DESCRIPTION
[Issue 7157 – Optimiser is O(n^2) w.r.t. function length](https://issues.dlang.org/show_bug.cgi?id=7157)