### PR TITLE
fix Issue 14197 - replace was removed from std.string

### DIFF
--- a/std/string.d
+++ b/std/string.d
@@ -96,6 +96,8 @@ $(LEADINGROW Publicly imported functions)
     $(TR $(TD std.array)
         $(TD
          $(SHORTXREF array, join)
+         $(SHORTXREF array, replace)
+         $(SHORTXREF array, replaceInPlace)
          $(SHORTXREF array, split)
     ))
     $(TR $(TD std.format)
@@ -167,7 +169,7 @@ import std.typetuple;
 
 //public imports for backward compatibility
 public import std.algorithm : startsWith, endsWith, cmp, count;
-public import std.array : join, split;
+public import std.array : join, replace, replaceInPlace, split;
 
 /* ************* Exceptions *************** */
 


### PR DESCRIPTION
- add public aliases to std.array.replace/replaceInPlace
- std.string should at least cover any basic string
  manipulation needs

[Issue 14197 – "replace" was moved from std.string without alias added](https://issues.dlang.org/show_bug.cgi?id=14197)