### PR TITLE
Supplemental fix for issue 14290

### DIFF
--- a/std/variant.d
+++ b/std/variant.d
@@ -930,7 +930,7 @@ public:
 
     private VariantN opArithmetic(T, string op)(T other)
     {
-        static if (isInstanceOf!(VariantN, T))
+        static if (isInstanceOf!(.VariantN, T))
         {
             string tryUseType(string tp)
             {


### PR DESCRIPTION
Required by: https://github.com/D-Programming-Language/dmd/pull/4499

In `opArithmetic` member function, `VariantN` is instantiated struct type, not template identifier.