### PR TITLE
hasLength ulong to size_t

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -4159,7 +4159,7 @@ body
 
     alias Value = CommonType!(Unqual!B, Unqual!E);
     alias StepType = Unqual!S;
-    alias IndexType = typeof(unsigned((end - begin) / step));
+    alias IndexType = size_t;
 
     static struct Result
     {
@@ -4223,11 +4223,11 @@ body
         {
             if (step > 0)
             {
-                return unsigned((pastLast - current) / step);
+                return cast(size_t)unsigned((pastLast - current) / step);
             }
             else
             {
-                return unsigned((current - pastLast) / -step);
+                return cast(size_t)unsigned((current - pastLast) / -step);
             }
         }
 
@@ -4251,7 +4251,7 @@ if (isIntegral!(CommonType!(B, E)) || isPointer!(CommonType!(B, E)))
     import std.conv : unsigned;
 
     alias Value = CommonType!(Unqual!B, Unqual!E);
-    alias IndexType = typeof(unsigned(end - begin));
+    alias IndexType = size_t;
 
     static struct Result
     {
@@ -4298,7 +4298,7 @@ if (isIntegral!(CommonType!(B, E)) || isPointer!(CommonType!(B, E)))
         }
         @property IndexType length() const
         {
-            return unsigned(pastLast - current);
+            return cast(size_t)unsigned(pastLast - current);
         }
 
         alias opDollar = length;
@@ -4448,6 +4448,7 @@ unittest
     import std.algorithm : count, equal;
 
     static assert(hasLength!(typeof(iota(0, 2))));
+    static assert(hasLength!(typeof(iota(0L, 2L))));
     auto r = iota(0, 10, 1);
     assert(r[$ - 1] == 9);
     assert(equal(r, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9][]));

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -1328,7 +1328,7 @@ template hasLvalueElements(R)
 
 /**
 Returns $(D true) if $(D R) has a $(D length) member that returns an
-integral type. $(D R) does not have to be a range. Note that $(D
+$(D size_t) type. $(D R) does not have to be a range. Note that $(D
 length) is an optional primitive as no range must implement it. Some
 ranges do not store their length explicitly, some cannot compute it
 without actually exhausting the range (e.g. socket streams), and some
@@ -1347,7 +1347,7 @@ template hasLength(R)
     (inout int = 0)
     {
         R r = R.init;
-        static assert(is(typeof(r.length) : ulong));
+        static assert(is(typeof(r.length) : size_t));
     }));
 }
 
@@ -1358,7 +1358,7 @@ template hasLength(R)
     static assert( hasLength!(int[]));
     static assert( hasLength!(inout(int)[]));
 
-    struct A { ulong length; }
+    struct A { ubyte length; }
     struct B { size_t length() { return 0; } }
     struct C { @property size_t length() { return 0; } }
     static assert( hasLength!(A));


### PR DESCRIPTION
hasLength did required ulong's which let to code like

```d
alias IndexType = typeof(unsigned(_input.length));
```

size_t looks more natural