### PR TITLE
Fix broken Phobos navbar when building 'html' target.

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -98,7 +98,7 @@ DOC_OUTPUT_DIR = $(WEBSITE_DIR)/phobos-prerelease
 BIGDOC_OUTPUT_DIR = /tmp
 SRC_DOCUMENTABLES = index.d $(addsuffix .d,$(STD_MODULES) \
 	$(EXTRA_DOCUMENTABLES))
-STDDOC = $(DOCSRC)/html.ddoc $(DOCSRC)/dlang.org.ddoc $(DOCSRC)/std_navbar-prerelease.ddoc $(DOCSRC)/std.ddoc $(DOCSRC)/macros.ddoc
+STDDOC = $(DOCSRC)/html.ddoc $(DOCSRC)/dlang.org.ddoc $(DOCSRC)/std_navbar-prerelease.ddoc $(DOCSRC)/std.ddoc $(DOCSRC)/macros.ddoc $(DOCSRC)/.generated/modlist-prerelease.ddoc
 BIGSTDDOC = $(DOCSRC)/std_consolidated.ddoc $(DOCSRC)/macros.ddoc
 # Set DDOC, the documentation generator
 DDOC=$(DMD) -conf= -m$(MODEL) -w -c -o- -version=StdDdoc \


### PR DESCRIPTION
The phobos makefile wasn't properly updated after the recent move to the fancy new phobos navbar, as a result `make -f posix.mak html` will produce html files with an empty navbar, which makes it a pain to navigate when testing documentation change PRs.

This PR adds the required navbar definition to the list of ddoc files passed to the compiler, so that it gets the correct definition.