### PR TITLE
comment not supposed to be ddoc

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -907,7 +907,7 @@ private auto _decodeContent(T)(ubyte[] content, string encoding)
 }
 
 alias KeepTerminator = Flag!"keepTerminator";
-/++
+/+
 struct ByLineBuffer(Char)
 {
     bool linePresent;


### PR DESCRIPTION
It's showing up in the documentation for the subsequent function as a result. I don't know why it's there to begin with.