### PR TITLE
fix Issue 14301 - private symbol Cache conflicts with client code

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -135,14 +135,14 @@ trait also checks for random access).
 auto cache(Range)(Range range)
 if (isInputRange!Range)
 {
-    return Cache!(Range, false)(range);
+    return _Cache!(Range, false)(range);
 }
 
 /// ditto
 auto cacheBidirectional(Range)(Range range)
 if (isBidirectionalRange!Range)
 {
-    return Cache!(Range, true)(range);
+    return _Cache!(Range, true)(range);
 }
 
 ///
@@ -287,7 +287,7 @@ same cost or side effects.
     assert(r.source.initialized == true);
 }
 
-private struct Cache(R, bool bidir)
+private struct _Cache(R, bool bidir)
 {
     import core.exception : RangeError;
 
@@ -4186,4 +4186,3 @@ private struct UniqResult(alias pred, Range)
         }
     }
 }
-


### PR DESCRIPTION
Cache is a too prominent type name to use it for a private __visible__ symbol.

[Issue 14301 – [2.067-rc1] Private symbols of module conflicts with public from another](https://issues.dlang.org/show_bug.cgi?id=14301)