### PR TITLE
Make sure the free'd lineptr doesn't leave a dangling pointer.

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -4159,6 +4159,7 @@ private size_t readlnImpl(FILE* fps, ref char[] buf, dchar terminator, File.Orie
         {
             // Bound memory used by readln
             free(lineptr);
+            lineptr = null;
             n = 0;
         }
     }


### PR DESCRIPTION
In https://github.com/D-Programming-Language/phobos/pull/3089, a static buffer was introduced to help alleviate reallocating the getline buffer each call. However, in certain cases, the static buffer can be free'd, but not set to null. On a subsequent call to getline, realloc may be called on this invalid pointer. This PR simply nulls the pointer if it's free'd