### PR TITLE
fix Issue 14342 - [REG] std.algorithm.internal omitted from posix.mak

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -208,7 +208,7 @@ STD_MODULES = $(addprefix std/, \
   	kickstart tests thompson)) \
   signals socket socketstream stdint stdio stdiobase stream \
   string syserror system traits typecons typetuple uni uri utf uuid variant \
-  xml zip zlib $(addprefix algorithm/,comparison iteration \
+  xml zip zlib $(addprefix algorithm/,comparison internal iteration \
     mutation searching setops sorting))
 
 # OS-specific D modules


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14342

I don't know how this passed the autotester.