### PR TITLE
Fix macro expansion for format()

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -6542,7 +6542,7 @@ unittest
 /*****************************************************
  * Format arguments into a string.
  *
- * Params: fmt  = Format string. For detailed specification, see $(XREF format,formattedWrite).
+ * Params: fmt  = Format string. For detailed specification, see $(XREF _format,formattedWrite).
  *         args = Variadic list of arguments to format into returned string.
  */
 string format(Char, Args...)(in Char[] fmt, Args args)


### PR DESCRIPTION
The HTML at http://dlang.org/phobos/std_format.html#.format is malformed because one of the arguments to the XREF macro is the same as the name of the symbol being documented.