### PR TITLE
Fix Issue 14368 - rawRead performance

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -725,7 +725,8 @@ $(D rawRead) always reads in binary mode on Windows.
     {
         import std.exception : enforce, errnoEnforce;
 
-        enforce(buffer.length, "rawRead must take a non-empty buffer");
+        if (!buffer.length)
+            enforce(false, "rawRead must take a non-empty buffer");
         version(Windows)
         {
             immutable fd = ._fileno(_p.handle);
@@ -741,10 +742,13 @@ $(D rawRead) always reads in binary mode on Windows.
                 scope(exit) __fhnd_info[fd] = info;
             }
         }
-        immutable result =
+        immutable fread_result =
             fread(buffer.ptr, T.sizeof, buffer.length, _p.handle);
+        immutable fread_success = (fread_result == buffer.length);
+        if (fread_success)
+            return buffer;
         errnoEnforce(!error);
-        return result ? buffer[0 .. result] : null;
+        return buffer[0 .. fread_result];
     }
 
     unittest

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -742,13 +742,15 @@ $(D rawRead) always reads in binary mode on Windows.
                 scope(exit) __fhnd_info[fd] = info;
             }
         }
-        immutable fread_result =
+        immutable freadResult =
             fread(buffer.ptr, T.sizeof, buffer.length, _p.handle);
-        immutable fread_success = (fread_result == buffer.length);
-        if (fread_success)
-            return buffer;
-        errnoEnforce(!error);
-        return buffer[0 .. fread_result];
+        assert (freadResult <= buffer.length); // fread return guarantee
+        if (freadResult != buffer.length) // error or eof
+        {
+            errnoEnforce(!error);
+            return buffer[0 .. freadResult];
+        }
+        return buffer;
     }
 
     unittest

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -723,10 +723,10 @@ $(D rawRead) always reads in binary mode on Windows.
  */
     T[] rawRead(T)(T[] buffer)
     {
-        import std.exception : enforce, errnoEnforce;
+        import std.exception : Exception, errnoEnforce;
 
         if (!buffer.length)
-            enforce(false, "rawRead must take a non-empty buffer");
+            throw new Exception("rawRead must take a non-empty buffer");
         version(Windows)
         {
             immutable fd = ._fileno(_p.handle);


### PR DESCRIPTION
reduce performance gap between fread and rawRead
https://issues.dlang.org/show_bug.cgi?id=14368

Currently std.stdio rawRead is much slower than cstdio fread. Benchmark indicates that rawRead is roughly 2.5x slower than directly calling fread in a tight loop (not counting time in syscalls). The overhead comes from the compiler failing to inline calls to std.exception.enforce, calling errnoEnforce even when fread's return indicates success, and from buffer slicing overhead.

This patch fast paths the ordinary (no error) case, reducing the overhead to almost nil when compiled with gdc and about 1.35x when compiled with dmd.