### PR TITLE
Remove unit test that checks for the removal of object.clear

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -3392,8 +3392,8 @@ unittest // check against .clear UFCS hijacking
 {
     Appender!string app;
     static assert(!__traits(compiles, app.clear()));
-    static assert(__traits(compiles, clear(app)),
-        "Remove me when object.clear is removed!");
+    /*static assert(__traits(compiles, clear(app)),
+        "Remove me when object.clear is removed!");*/
 }
 
 unittest


### PR DESCRIPTION
After this pull, and https://github.com/D-Programming-Language/druntime/pull/1202 is pulled, I will remove the `@disable clear` section of Appender.