### PR TITLE
[minor] Missing Ddoc parenthesis in std.random docs

### DIFF
--- a/std/random.d
+++ b/std/random.d
@@ -32,7 +32,7 @@ distribution in various ways. So far the uniform distribution for
 integers and real numbers have been implemented.
 
 Upgrading:
-        $(WEB digitalmars.com/d/1.0/phobos/std_random.html#rand Phobos D1 $(D rand()) can
+        $(WEB digitalmars.com/d/1.0/phobos/std_random.html#rand Phobos D1 $(D rand())) can
         be replaced with $(D uniform!uint()).
 
 Source:    $(PHOBOSSRC std/_random.d)


### PR DESCRIPTION
@JakobOvrum [spotted this in my original change](https://github.com/D-Programming-Language/phobos/pull/3126#discussion_r27450427).