### PR TITLE
Improve std.typecons.Unique

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -83,7 +83,7 @@ public:
         import core.memory : GC;
         import core.stdc.stdlib : malloc;
         import std.conv : emplace;
-        import std.exception : enforce;
+        import core.exception : onOutOfMemoryError;
 
         debug(Unique) writeln("Unique.create for ", T.stringof);
         Unique!T u;

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -159,8 +159,7 @@ else
     bool opCast(T : bool)() const { return !empty; }
 
     /**
-    Allows you to dereference the underlying $(D RefT)
-    and treat it like a $(D RefT) in other ways (such as comparing to null)
+    Allows you to reference the underlying $(D RefT)
     */
     alias get this;
 
@@ -265,6 +264,7 @@ unittest
 
     auto i = unique!int(25);
     assert(i.get() == 25);
+    assert(i == 25);
 
     // opAssign still kicks in, preventing this from compiling:
     // i = null;
@@ -304,7 +304,7 @@ unittest
 
     void consume(Unique!S u2)
     {
-        assert(u2.i == 7);
+        assert(u2.i == 8);
         // Resource automatically deleted here
     }
 
@@ -314,7 +314,9 @@ unittest
     increment(u1);
     assert(u1.i == 6);
     correctIncrement(u1.get());
-    assert(u1.i == 7);
+    // yay alias this
+    correctIncrement(u1);
+    assert(u1.i == 8);
 
     // consume(u1); // Error: u1 is not copyable
 

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -142,19 +142,22 @@ else
     For code that does not own the resource (and therefore does not affect
     its life cycle), pass a plain old reference.
     */
-    ref T get() return
+    ref T get() return @safe
+        if (!is(T == class))
     {
         import std.exception : enforce;
-
-        enforce(!empty, "You cannot get anything from an empty Unique");
-
-        static if (is(T == class))
-            return _p;
-        else
-            return *_p;
+        enforce(!empty, "You cannot get a struct reference from an empty Unique");
+        return *_p;
     }
 
-    // Ditto
+    /// Ditto
+    /// Note that getting a reference for a class is currently unsafe
+    /// as there is currently no way to stop escaping class pointers (see DIP69)
+    T get() @system
+        if (is(T == class))
+    {
+        return _p;
+    }
 
     @property bool empty() const
     {

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -234,7 +234,7 @@ Unique!T unique(T, A...)(auto ref A args)
     }
     else {
         u._p = cast(T*)rawMemory;
-        emplace!T(rawMemory, args);
+        emplace!T(u._p, args);
     }
 
     static if (hasIndirections!T)

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -230,10 +230,8 @@ Unique!T unique(T, A...)(auto ref A args)
         u._p = emplace!T(rawMemory[0 .. allocSize], args);
     }
     else {
-        import std.algorithm : move;
-        auto temp = T(args);
         u._p = cast(T*)rawMemory;
-        *u._p = move(temp);
+        emplace!T(rawMemory, args);
     }
 
     static if (hasIndirections!T)

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -200,7 +200,9 @@ Allows safe construction of $(D Unique). It creates the resource and
 guarantees unique ownership of it (unless $(D T) publishes aliases of
 $(D this)).
 
-Note: Nested classes cannot be created at present time.
+Note: Nested classes and structs cannot be created at present time,
+      as there is no way to transfer the closure's frame pointer
+      into this function.
 
 Params:
     args = Arguments to pass to $(D T)'s constructor.

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -102,6 +102,7 @@ else
         u._p = null;
     }
 
+    /// Destroying a $(D Unique) frees the underlying resource.
     ~this()
     {
         import core.stdc.stdlib : free;
@@ -122,7 +123,7 @@ else
         }
     }
 
-    /** Transfer ownership to a $(D Unique) rvalue. Nullifies the current contents. */
+    /// Transfer ownership to a $(D Unique) rvalue.
     deprecated("Please use std.algorithm.move to transfer ownership.")
     Unique release()
     {
@@ -142,7 +143,7 @@ else
     For code that does not own the resource (and therefore does not affect
     its life cycle), pass a plain old reference.
     */
-    ref T get() return @safe
+    ref T get()() return @safe
         if (!is(T == class))
     {
         import std.exception : enforce;
@@ -150,30 +151,32 @@ else
         return *_p;
     }
 
-    /// Ditto
-    /// Note that getting a reference for a class is currently unsafe
-    /// as there is currently no way to stop escaping class pointers (see DIP69)
-    T get() @system
+    /**
+    Returns a the underlying $(D T) for use by non-owning code.
+
+    Note that getting a class reference is currently unsafe
+    as there is currently no way to stop it from escaping. (see DIP69)
+    */
+    T get()() @system
         if (is(T == class))
     {
         return _p;
     }
 
+    /// Returns true if the $(D Unique) currently owns an underlying $(D T)
     @property bool empty() const
     {
         return _p is null;
     }
 
+    /// Allows the $(D Unique) to cast to a boolean value matching
+    /// that of $(D Unique.empty)
     bool opCast(T : bool)() const { return !empty; }
 
-    /**
-    Allows you to reference the underlying $(D RefT)
-    */
+    /// Forwards the underlying $(D RefT)
     alias get this;
 
-    /**
-    Postblit operator is undefined to prevent the cloning of $(D Unique) objects.
-    */
+    /// Postblit operator is undefined to prevent the cloning of $(D Unique) objects.
     @disable this(this);
 
 private:

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -104,17 +104,9 @@ else
 
     ~this()
     {
-        debug(Unique) writeln("Unique destructor of ", (_p is null)? null: _p);
-        release();
-    }
-
-    /** Frees the underlying $(D RefT) and nulls it */
-    void release()
-    {
         import core.stdc.stdlib : free;
 
-        debug(Unique) writeln("Release");
-
+        debug(Unique) writeln("Unique destructor of ", (_p is null)? null: _p);
         if (_p !is null)
         {
             destroy(_p);
@@ -128,6 +120,19 @@ else
             free(cast(void*)_p);
             _p = null;
         }
+    }
+
+    /** Transfer ownership to a $(D Unique) rvalue. Nullifies the current contents. */
+    deprecated("Please use std.algorithm.move to transfer ownership.")
+    Unique release()
+    {
+        import std.algorithm : move;
+
+        debug(Unique) writeln("Release");
+        Unique u = move(this);
+        assert(_p is null);
+        debug(Unique) writeln("return from Release");
+        return u;
     }
 
     /**

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -97,7 +97,10 @@ public:
         else
             immutable size_t allocSize = T.sizeof;
 
-        void* rawMemory = enforce(malloc(allocSize), "malloc returned null");
+        void* rawMemory = malloc(allocSize);
+        if (!rawMemory)
+            onOutOfMemoryError();
+
         u._p = cast(RefT)rawMemory;
 
         static if (is(T == class)) {


### PR DESCRIPTION
Whenever D is brought up to the general programming public, the garbage collector is quickly raised as a point of contention. Regardless of how legitimate or well-informed these concerns are or are not, it would be a massive public relations boon — and great for the language, to boot — if we could trot out a solid set of RAII-based smart pointers for those who prefer to use them. We have a solid start in `std.typecons.Unique` and `std.typecons.RefCounted`. Unfortunately, these seem to be victims of bit rot and compiler bugs of days long gone.

This is the first of several pull requests that attempt to clean these up. An overview of the changes in this request is as follows (updated 2015-04-21):

- `Unique` uses `malloc` and `free` instead of the GC for backing memory storage. Unfortunately this rules out nested types for the time being (as `emplace` cannot set the frame pointer for closures).

- `std.algorithm.move` is used instead of a special `release` member function. Whether by design or by happy accident, `move` transfers ownership between `Unique` pointers in a very similar manner to C++'s `std::move` with `std::unique_ptr`. Along with being a familiar paradigm to C++ users, using `move` to transfer ownership makes more intuitive sense and builds consistency with the rest of Phobos.

- With `std.algorithm.move` transferring ownership, `release` is deprecated.

- `Unique.create` has transformed into a freestanding `unique` function. Regardless of whether or not there is language support for checking uniqueness, a utility function that creates a `Unique`, taking the same arguments as the underlying type's constructor, is extremely useful, as demonstrated by the addition of `make_unique` to C++14.

- Constructors taking a pointer have been removed, since we now control allocation ourselves.

- A new method, `get`, returns the underlying pointer, for use in functions and code that do not play a role in the life cycle of the object. Smart pointers are as much about ownership semantics as they are about allocating and freeing memory, and non-owning code should continue to refer to data using a raw pointer or a reference.

This pull request is not meant to be merged _prima facie_, but to initiate a dialogue. I strongly believe this is a good step in the right direction and would love to hear commentary from the core devs. Perhaps some of the implementation details need to be hashed out some more, but we can all agree that a stronger showing from the smart pointers in `std.typecons` will only bolster D and Phobos.