### PR TITLE
Enable std.json.parseJSON to parse nan/inf.

### DIFF
--- a/std/json.d
+++ b/std/json.d
@@ -57,7 +57,6 @@ import std.conv;
 import std.range.primitives;
 import std.array;
 import std.traits;
-import std.typecons : Flag;
 
 /**
 String literals used to represent special float values within JSON strings.


### PR DESCRIPTION
`JSONValue.toString` outputs 'nan', 'inf', or '-inf', when it has type
`JSON_TYPE.FLOAT` and value double.nan/double.infinity/-double.infinity.

However, `parseJSON` would fail on encountering these values in a string.
This patch enables `parseJSON` to read special float values.

I submitted this as issue #14399 a bit ago and then decided to take a shot at fixing it.

To be clear: this does not change the output of `std.json.toString`, which was already outputting special values for nan/inf. It simply allows `std.json` to read the special values that it outputs.