### PR TITLE
Add targets for Win32/COFF to win64.mak

### DIFF
--- a/win64.mak
+++ b/win64.mak
@@ -481,6 +481,14 @@ cov : $(SRC_TO_COMPILE) $(LIB)
 
 html : $(DOCS)
 
+################### Win32 COFF support #########################
+
+# default to 32-bit compiler relative to 64-bit compiler, link and lib are architecture agnostic
+CC32=$(CC)\..\..\cl
+
+phobos32mscoff:
+	$(MAKE) -f win64.mak "DMD=$(DMD)" "MAKE=$(MAKE)" MODEL=32mscoff "CC=\$(CC32)"\"" "AR=\$(AR)"\"" "VCDIR=$(VCDIR)" "SDKDIR=$(SDKDIR)"
+
 ######################################################
 
 $(ZLIB): $(SRC_ZLIB)

--- a/win64.mak
+++ b/win64.mak
@@ -10,6 +10,10 @@
 #		Delete unneeded files created by build process
 #	make unittest
 #		Build phobos64.lib, build and run unit tests
+#	make phobos32mscoff
+#		Build phobos32mscoff.lib
+#	make unittest32mscoff
+#		Build phobos32mscoff.lib, build and run unit tests
 #	make cov
 #		Build for coverage tests, run coverage tests
 #	make html
@@ -483,12 +487,15 @@ html : $(DOCS)
 
 ################### Win32 COFF support #########################
 
-# default to 32-bit compiler relative to 64-bit compiler, link and lib are architecture agnostic
+# default to 32-bit compiler relative to the location of the 64-bit compiler,
+# link and lib are architecture agnostic
 CC32=$(CC)\..\..\cl
 
+# build phobos32mscoff.lib
 phobos32mscoff:
 	$(MAKE) -f win64.mak "DMD=$(DMD)" "MAKE=$(MAKE)" MODEL=32mscoff "CC=\$(CC32)"\"" "AR=\$(AR)"\"" "VCDIR=$(VCDIR)" "SDKDIR=$(SDKDIR)"
 
+# run unittests for 32-bit COFF version
 unittest32mscoff:
 	$(MAKE) -f win64.mak "DMD=$(DMD)" "MAKE=$(MAKE)" MODEL=32mscoff "CC=\$(CC32)"\"" "AR=\$(AR)"\"" "VCDIR=$(VCDIR)" "SDKDIR=$(SDKDIR)" unittest
 

--- a/win64.mak
+++ b/win64.mak
@@ -489,6 +489,9 @@ CC32=$(CC)\..\..\cl
 phobos32mscoff:
 	$(MAKE) -f win64.mak "DMD=$(DMD)" "MAKE=$(MAKE)" MODEL=32mscoff "CC=\$(CC32)"\"" "AR=\$(AR)"\"" "VCDIR=$(VCDIR)" "SDKDIR=$(SDKDIR)"
 
+unittest32mscoff:
+	$(MAKE) -f win64.mak "DMD=$(DMD)" "MAKE=$(MAKE)" MODEL=32mscoff "CC=\$(CC32)"\"" "AR=\$(AR)"\"" "VCDIR=$(VCDIR)" "SDKDIR=$(SDKDIR)" unittest
+
 ######################################################
 
 $(ZLIB): $(SRC_ZLIB)


### PR DESCRIPTION
This adds targets `phobos32mscoff` and `unittest32mscoff` to win64.mak.

The 32-bit compiler is derived from the setting for the 64-bit compiler, but can be overwritten on the make command line with `CC32=`

The usual conditions for `VCDIR` and `SDKDIR` apply, ~~though the default is improved by using `$(ProgramFiles)`~~. As for Win64 since the `-conf=` setting, it is necessary to set `LINKCMD`and `LIB` in the environment to link the unittests.