### PR TITLE
Fix compilation of std.math.

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -2553,7 +2553,6 @@ int ilogb(real x)  @trusted nothrow @nogc
         int res;
         asm pure nothrow @nogc
         {
-            naked                       ;
             fld     real ptr [x]        ;
             fxam                        ;
             fstsw   AX                  ;


### PR DESCRIPTION
This fixes these compilation errors:
- phobos/std/math.d(2599): Error: only global variables can be referenced by identifier in naked asm
- phobos/std/math.d(2611): Error: only global variables can be referenced by identifier in naked asm
- phobos/std/math.d(2612): Error: only global variables can be referenced by identifier in naked asm