### PR TITLE
Remove a unittest which checks removed clear method

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -3383,12 +3383,6 @@ unittest
     assert(reference[] == arr[]);
 }
 
-unittest // check against .clear UFCS hijacking
-{
-    Appender!string app;
-    static assert(!__traits(compiles, app.clear()));
-}
-
 unittest
 {
     static struct D//dynamic


### PR DESCRIPTION
Now `Object.clear` method was removed (See D-Programming-Language/druntime#1202)
and this unittest should be removed according to the error message.
