### PR TITLE
Fix comment in unittest for std.array.Appender

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -3383,7 +3383,7 @@ unittest
     assert(reference[] == arr[]);
 }
 
-unittest // check against .clear UFCS hijacking
+unittest // clear method is supported only for mutable element types
 {
     Appender!string app;
     static assert(!__traits(compiles, app.clear()));


### PR DESCRIPTION
This unittest originally checks the UFCS hijacking problem between `object.clear` function and `Appender.clear` method but the former was removed in D-Programming-Language/druntime#1202.

Now it only checks that `Appender.clear` is not supported for immutable and const element types.
