### PR TITLE
fix Issue 14422 - std.process: Pipes do not append to files on Win64

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -908,6 +908,19 @@ unittest // Reopening the standard streams (issue 13258)
     assert(lines == ["foo", "bar"]);
 }
 
+version (Windows)
+unittest // MSVCRT workaround (issue 14422)
+{
+    auto fn = uniqueTempPath();
+    std.file.write(fn, "AAAAAAAAAA");
+
+    auto f = File(fn, "a");
+    spawnProcess(["cmd", "/c", "echo BBBBB"], std.stdio.stdin, f).wait();
+
+    auto data = readText(fn);
+    assert(data == "AAAAAAAAAABBBBB\r\n", data);
+}
+
 /**
 A variation on $(LREF spawnProcess) that runs the given _command through
 the current user's preferred _command interpreter (aka. shell).

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -386,6 +386,20 @@ Throws: $(D ErrnoException) if the file could not be opened.
                         text("Cannot open file `", name, "' in mode `",
                                 stdioOpenmode, "'")),
                 name);
+
+        // MSVCRT workaround (issue 14422)
+        version (MICROSOFT_STDIO)
+        {
+            bool append, update;
+            foreach (c; stdioOpenmode)
+                if (c == 'a')
+                    append = true;
+                else
+                if (c == '+')
+                    update = true;
+            if (append && !update)
+                seek(size);
+        }
     }
 
     ~this() @safe


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14422

I'm not 100% sure about this one - we're avoiding a Microsoft process bug by adding a workaround in std.stdio. CC @schveiguy @kyllingstad

Interesting observation - http://www.cplusplus.com/reference/cstdio/fopen/ says:

> Repositioning operations (fseek, fsetpos, rewind) are ignored. 

But here we exactly need a repositioning operation to fix the problem.
