### PR TITLE
Fix issue 14340

### DIFF
--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -832,6 +832,19 @@ private void optimisticInsertionSort(alias less, Range)(Range r)
     assert(isSorted(a));
 }
 
+// Issue 14340
+@safe unittest
+{
+    import std.algorithm.searching : count;
+
+    debug(std_algorithm) scope(success)
+        writeln("unittest @", __FILE__, ":", __LINE__, " done.");
+
+    int[] a = [0, 2, 1, 0];
+    optimisticInsertionSort!((x, y) => a.count(x) < a.count(y), int[])(a);
+    assert(isSorted!((x, y) => a.count(x) < a.count(y), int[])(a));
+}
+
 // sort
 /**
 Sorts a random-access range according to the predicate $(D less). Performs

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -796,14 +796,19 @@ private void optimisticInsertionSort(alias less, Range)(Range r)
 
         static if (hasAssignableElements!Range)
         {
-            auto temp = r[i];
+            for (; j < maxJ && pred(r[j + 1], r[i]); ++j) {}
 
-            for (; j < maxJ && pred(r[j + 1], temp); ++j)
+            if (i != j)
             {
-                r[j] = r[j + 1];
-            }
+                auto temp = r[i];
 
-            r[j] = temp;
+                for (size_t k = i; k < j; ++k)
+                {
+                    r[k] = r[k + 1];
+                }
+
+                r[j] = temp;
+            }
         }
         else
         {


### PR DESCRIPTION
This is a fix for [issue 14340](https://issues.dlang.org/show_bug.cgi?id=14340) (AssertError in std.algorithm.sorting: unstable sort fails to sort an array with a custom predicate).

A concern is that sorting gets a bit slower: for a 10^6-length array of random int-s, the slowdown is about 4% locally.

There may be other, better, ways to fix this, I would be happy if someone looks into it and suggests a better fix.

Benchmark code used:

    import std.algorithm, std.datetime, std.random, std.range, std.stdio;
    immutable int MAX_LEN = 10 ^^ 6, STEPS = 100;
    int[] a;
    void f() {auto b = a.dup; sort(b);}
    void main() {
        rndGen.seed(12345);
        foreach (i; 0..MAX_LEN) {a ~= uniform(int.min, int.max);}
        auto r = benchmark!(f)(STEPS);
        writefln("Milliseconds: %s", r[0].msecs);
    }
