### PR TITLE
[Trivial] One-word addition to descriptions for generateAssertTrap and generateEmptyFunction

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -3413,7 +3413,7 @@ private static:
 
 
 /**
-Predefined how-policies for $(D AutoImplement).  These templates are used by
+Predefined how-policies for $(D AutoImplement).  These templates are also used by
 $(D BlackHole) and $(D WhiteHole), respectively.
  */
 template generateEmptyFunction(C, func.../+[BUG 4217]+/)


### PR DESCRIPTION
Add 'also' to make it clear that these two templates can be used for `AutoImplement` as well as `WhiteHole` and `BlackHole`.