### PR TITLE
fix Issue 14396 - compile error std.conv.parse!int with input range (dmd...

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -1989,7 +1989,7 @@ Target parse(Target, Source)(ref Source s)
             Target v = cast(Target)c;
             while (!s.empty)
             {
-                c = s.front - '0';
+                c = cast(typeof(c)) (s.front - '0');
                 if (c > 9)
                     break;
 
@@ -2204,6 +2204,22 @@ Lerr:
 
     assertThrown!ConvOverflowException("-21474836480".to!int());
     assertThrown!ConvOverflowException("-92233720368547758080".to!long());
+}
+
+// Issue 14396
+@safe pure unittest
+{
+    struct StrInputRange
+    {
+        this (string s) { str = s; }
+        char front() const @property { return str[front_index]; }
+        char popFront() { return str[front_index++]; }
+        bool empty() const @property { return str.length <= front_index; }
+        string str;
+        size_t front_index = 0;
+    }
+    auto input = StrInputRange("777");
+    assert(parse!int(input) == 777);
 }
 
 /// ditto


### PR DESCRIPTION
...2.067)

Was #3140. Now targetting the stable branch.

https://issues.dlang.org/show_bug.cgi?id=14396