### PR TITLE
Fix a minor typo in std.getopt

### DIFF
--- a/std/getopt.d
+++ b/std/getopt.d
@@ -570,7 +570,7 @@ private void getoptImpl(T...)(ref string[] args, ref configuration cfg,
             if (cfg.required && !optWasHandled)
             {
                 throw new GetOptException("Required option " ~ option ~
-                    "was not supplied");
+                    " was not supplied");
             }
             cfg.required = false;
 


### PR DESCRIPTION
Fixes a typo in the error message for a missing required option in std.getopt. There is a space missing between the option name and the rest of the error message.