### PR TITLE
Declare fromStringz @nogc nothrow

### DIFF
--- a/std/string.d
+++ b/std/string.d
@@ -200,7 +200,7 @@ class StringException : Exception
     The original data is not changed and not copied.
 +/
 
-inout(char)[] fromStringz(inout(char)* cString) @system pure {
+inout(char)[] fromStringz(inout(char)* cString) @nogc @system pure nothrow {
     import core.stdc.string : strlen;
     return cString ? cString[0 .. strlen(cString)] : null;
 }


### PR DESCRIPTION
fromStringz wasn't declared `@nogc nothrow`, but it can easily take on those attributes. This will make it usable in `@nogc nothrow` functions. This was so trivial I just did it directly through GitHub again.