### PR TITLE
Updated some missing params and return sections in the documentation.

### DIFF
--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -3191,6 +3191,7 @@ unittest
         T     = The integral type to convert the first $(D T.sizeof) bytes to.
         endianness = The endianness to write the bytes in.
         range = The range to write to.
+        value = The value to write.
         index = The index to start writing to. If index is a pointer, then it
                 is updated to the index after the bytes read.
   +/
@@ -3536,6 +3537,7 @@ unittest
         T     = The integral type to convert the first $(D T.sizeof) bytes to.
         endianness = The endianness to write the bytes in.
         range = The range to append to.
+        value = The value to append.
   +/
 void append(T, Endian endianness = Endian.bigEndian, R)(R range, T value)
     if(canSwapEndianness!T && isOutputRange!(R, ubyte))

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -3189,9 +3189,9 @@ unittest
 
     Params:
         T     = The integral type to convert the first $(D T.sizeof) bytes to.
-        endianness = The endianness to write the bytes in.
-        range = The range to write to.
-        value = The value to write.
+        endianness = The endianness to _write the bytes in.
+        range = The range to _write to.
+        value = The value to _write.
         index = The index to start writing to. If index is a pointer, then it
                 is updated to the index after the bytes read.
   +/
@@ -3536,8 +3536,8 @@ unittest
     Params:
         T     = The integral type to convert the first $(D T.sizeof) bytes to.
         endianness = The endianness to write the bytes in.
-        range = The range to append to.
-        value = The value to append.
+        range = The range to _append to.
+        value = The value to _append.
   +/
 void append(T, Endian endianness = Endian.bigEndian, R)(R range, T value)
     if(canSwapEndianness!T && isOutputRange!(R, ubyte))

--- a/std/conv.d
+++ b/std/conv.d
@@ -5280,8 +5280,8 @@ template castFrom(From)
 {
     /**
         Params:
-            To    = The type to cast to.
-            value = The value to cast. It must be of type $(D From),
+            To    = The type _to cast _to.
+            value = The value _to cast. It must be of type $(D From),
                     otherwise a compile-time error is emitted.
 
         Returns:

--- a/std/conv.d
+++ b/std/conv.d
@@ -5275,15 +5275,18 @@ unittest
     Params:
         From  = The type to cast from. The programmer must ensure it is legal
                 to make this cast.
-        To    = The type to cast to
-        value = The value to cast. It must be of type $(D From),
-                otherwise a compile-time error is emitted.
-
-    Returns:
-        the value after the cast, returned by reference if possible
  */
 template castFrom(From)
 {
+    /**
+        Params:
+            To    = The type to cast to.
+            value = The value to cast. It must be of type $(D From),
+                    otherwise a compile-time error is emitted.
+
+        Returns:
+            the value after the cast, returned by reference if possible.
+     */
     auto ref to(To, T)(auto ref T value) @system
     {
         static assert (
@@ -5299,38 +5302,38 @@ template castFrom(From)
 
         return cast(To) value;
     }
-}
 
-///
-unittest
-{
-    // Regular cast, which has been verified to be legal by the programmer:
+    ///
+    unittest
     {
-        long x;
-        auto y = cast(int) x;
-    }
+        // Regular cast, which has been verified to be legal by the programmer:
+        {
+            long x;
+            auto y = cast(int) x;
+        }
 
-    // However this will still compile if 'x' is changed to be a pointer:
-    {
-        long* x;
-        auto y = cast(int) x;
-    }
+        // However this will still compile if 'x' is changed to be a pointer:
+        {
+            long* x;
+            auto y = cast(int) x;
+        }
 
-    // castFrom provides a more reliable alternative to casting:
-    {
-        long x;
-        auto y = castFrom!long.to!int(x);
-    }
+        // castFrom provides a more reliable alternative to casting:
+        {
+            long x;
+            auto y = castFrom!long.to!int(x);
+        }
 
-    // Changing the type of 'x' will now issue a compiler error,
-    // allowing bad casts to be caught before it's too late:
-    {
-        long* x;
-        static assert (
-            !__traits(compiles, castFrom!long.to!int(x))
-        );
+        // Changing the type of 'x' will now issue a compiler error,
+        // allowing bad casts to be caught before it's too late:
+        {
+            long* x;
+            static assert (
+                !__traits(compiles, castFrom!long.to!int(x))
+            );
 
-        // if cast is still needed, must be changed to:
-        auto y = castFrom!(long*).to!int(x);
+            // if cast is still needed, must be changed to:
+            auto y = castFrom!(long*).to!int(x);
+        }
     }
 }

--- a/std/string.d
+++ b/std/string.d
@@ -1918,6 +1918,12 @@ ptrdiff_t lastIndexOfNeither(Char,Char2)(const(Char)[] haystack,
  * Returns the representation of a string, which has the same type
  * as the string except the character type is replaced by $(D ubyte),
  * $(D ushort), or $(D uint) depending on the character width.
+ *
+ * Params:
+ *     s = The string to return the representation of.
+ *
+ * Returns:
+ *     The representation of the passed string.
  */
 auto representation(Char)(Char[] s) @safe pure nothrow @nogc
     if (isSomeChar!Char)
@@ -1966,10 +1972,16 @@ auto representation(Char)(Char[] s) @safe pure nothrow @nogc
 }
 
 
-/++
-    Capitalize the first character of $(D s) and convert the rest of $(D s)
-    to lowercase.
- +/
+/**
+ * Capitalize the first character of $(D s) and convert the rest of $(D s)
+ * to lowercase.
+ *
+ * Params:
+ *     s = The string to capitalize.
+ *
+ * Returns:
+ *     The capitalized string.
+ */
 S capitalize(S)(S s) @trusted pure
     if (isSomeString!S)
 {

--- a/std/string.d
+++ b/std/string.d
@@ -1915,15 +1915,15 @@ ptrdiff_t lastIndexOfNeither(Char,Char2)(const(Char)[] haystack,
 
 
 /**
- * Returns the representation of a string, which has the same type
+ * Returns the _representation of a string, which has the same type
  * as the string except the character type is replaced by $(D ubyte),
  * $(D ushort), or $(D uint) depending on the character width.
  *
  * Params:
- *     s = The string to return the representation of.
+ *     s = The string to return the _representation of.
  *
  * Returns:
- *     The representation of the passed string.
+ *     The _representation of the passed string.
  */
 auto representation(Char)(Char[] s) @safe pure nothrow @nogc
     if (isSomeChar!Char)
@@ -1977,7 +1977,7 @@ auto representation(Char)(Char[] s) @safe pure nothrow @nogc
  * to lowercase.
  *
  * Params:
- *     s = The string to capitalize.
+ *     s = The string to _capitalize.
  *
  * Returns:
  *     The capitalized string.


### PR DESCRIPTION
Added some missing parameters and return sections to the documentation.

In `std.conv` i've moved part of the doc block and the unittest to better document the `to` function within the `castFrom` template, a'la [`std.algorithm.aggregate`](http://dlang.org/phobos/std_algorithm_iteration.html#aggregate).

All changes can be previewed here: http://nomad.so/misc/d/dlang.org/fix-ddoc-parameter-warnings/phobos-prerelease/index.html