### PR TITLE
Fixes 14457 (VariantN assignment from subset VariantN)

### DIFF
--- a/std/variant.d
+++ b/std/variant.d
@@ -668,7 +668,7 @@ public:
     }
 
     // Allow assignment from another variant which is a subset of this one
-    VariantN opAssign(T : VariantN!(Tsize, Types), size_t Tsize, Types...)(T rhs)
+    VariantN opAssign(T : VariantN!(tsize, Types), size_t tsize, Types...)(T rhs)
         if (!is(T : VariantN) && Types.length > 0 && allSatisfy!(allowed, Types))
     {
         // discover which type rhs is actually storing

--- a/std/variant.d
+++ b/std/variant.d
@@ -581,12 +581,12 @@ public:
         opAssign(value);
     }
 
-	/// Allows assignment from a subset algebraic type
-	this(T : VariantN!(tsize, Types), size_t tsize, Types...)(T value)
+    /// Allows assignment from a subset algebraic type
+    this(T : VariantN!(tsize, Types), size_t tsize, Types...)(T value)
         if (!is(T : VariantN) && Types.length > 0 && allSatisfy!(allowed, Types))
-	{
-		opAssign(value);
-	}
+    {
+        opAssign(value);
+    }
 
     static if (!AllowedTypes.length || anySatisfy!(hasElaborateCopyConstructor, AllowedTypes))
     {

--- a/std/variant.d
+++ b/std/variant.d
@@ -581,6 +581,13 @@ public:
         opAssign(value);
     }
 
+	/// Allows assignment from a subset algebraic type
+	this(T : VariantN!(tsize, Types), size_t tsize, Types...)(T value)
+        if (!is(T : VariantN) && Types.length > 0 && allSatisfy!(allowed, Types))
+	{
+		opAssign(value);
+	}
+
     static if (!AllowedTypes.length || anySatisfy!(hasElaborateCopyConstructor, AllowedTypes))
     {
         this(this)


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14457

Currently VariantN allows assignment from its allowed types and from a an instance of the exact same type.  This expands that functionality to allow assignment from another VariantN that has a strict subset of allowed types.  Implements an opAssign overload that specializes on VariantN instantations that are not the current VariantN but whose AllowedTypes are a subset of the current variant's.

The new overload has an explanatory comment, but does not have a documentation comment as the original opAssign is not documented.

Adds an accompanying unittest.

Fix Issue 14457