### PR TITLE
Fix 14477, Nullable on struct with @disable this()

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1759,7 +1759,8 @@ Practically $(D Nullable!T) stores a $(D T) and a $(D bool).
  */
 struct Nullable(T)
 {
-    private T _value;
+    // Explicitly initialize in case T has a @disable this();
+    private T _value = T.init;
     private bool _isNull = true;
 
 /**
@@ -1825,6 +1826,7 @@ This function is also called for the implicit conversion to $(D T).
         assert(!isNull, message);
         return _value;
     }
+
 
 /**
 Implicitly converts to $(D T).
@@ -2113,6 +2115,45 @@ unittest
     }
     Nullable!TestToString ntts = new TestToString(2.5);
     assert(ntts.to!string() == "2.5");
+}
+
+unittest
+{
+    // Bugzilla 14477 (@disabled this)
+    struct Foo {
+        int x;
+        @disable this();
+        this(int n){ x = n; }
+    }
+    Nullable!Foo foo;
+    foo.nullify();
+    foo = Foo(1);
+    assert(foo.get == Foo(1));
+    foo.nullify();
+
+    // what if it has indirections?
+    struct Bar {
+        Object x;
+        @disable this();
+        this(Object o){ x = o; }
+    }
+    Nullable!Bar bar;
+    bar.nullify();
+    auto obj = new Object;
+    bar = Bar(obj);
+    assert(bar.get == Bar(obj));
+    bar.nullify();
+}
+
+@safe unittest
+{
+    // ensure that Nullable usable in safe code
+    struct Foo { Object o; }
+    Nullable!Foo foo;
+    assert(foo.isNull);
+    foo = Foo(new Object);
+    auto o = foo.get.o;
+    assert(!foo.isNull);
 }
 
 /**


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14477

Simple change to initialize Nullable's internal value to void, allowing structs with disabled default constructors to be stored.  This is desirable because Nullable is the obvious tool for wrapping such structs such that they can be default initialized.

Adds unittest.

Fix 14477