### PR TITLE
Mark std.uni.MultiArray.slice and MultiArray.ptr as @nogc

### DIFF
--- a/std/uni.d
+++ b/std/uni.d
@@ -830,13 +830,13 @@ struct MultiArray(Types...)
         storage = data;
     }
 
-    @property auto slice(size_t n)()inout pure nothrow
+    @property auto slice(size_t n)()inout pure nothrow @nogc
     {
         auto ptr = raw_ptr!n;
         return packedArrayView!(Types[n])(ptr, sz[n]);
     }
 
-    @property auto ptr(size_t n)()inout pure nothrow
+    @property auto ptr(size_t n)()inout pure nothrow @nogc
     {
         auto ptr = raw_ptr!n;
         return inout(PackedPtr!(Types[n]))(ptr);


### PR DESCRIPTION
`MultiArray` is a template struct but it does not affect the attributes of its method because
it only uses the sizes of the types in `Types`.

`MultiArray.slice` and `ptr` are template methods but their template arguments do not affect their `@nogc`-ness.
