### PR TITLE
Automatic linking against libcurl for non-windows systems too

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -199,7 +199,7 @@ version(unittest)
 }
 version(StdDdoc) import std.stdio;
 
-version (Windows) pragma(lib, "curl");
+pragma(lib, "curl");
 extern (C) void exit(int);
 
 // Default data timeout for Protocols


### PR DESCRIPTION
Automatic linking is done for windows only so linux users have to explicitely
link against libcurl. No explicite linking should be needed to use phobos
modules.