### PR TITLE
Further changes to std.typecons.Unique

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -84,7 +84,7 @@ else
     ---
     */
     this(U)(Unique!U u)
-    if (is(u.RefT:RefT))
+        if (is(u.RefT : RefT))
     {
         debug(Unique) writeln("Unique constructor converting from ", U.stringof);
         _p = u._p;
@@ -93,7 +93,7 @@ else
 
     /// Transfer ownership from a $(D Unique) of a type that is convertible to our type.
     void opAssign(U)(Unique!U u)
-    if (is(u.RefT:RefT))
+        if (is(u.RefT : RefT))
     {
         debug(Unique) writeln("Unique opAssign converting from ", U.stringof);
         // first delete any resource we own
@@ -107,7 +107,7 @@ else
     {
         import core.stdc.stdlib : free;
 
-        debug(Unique) writeln("Unique destructor of ", (_p is null)? null: _p);
+        debug(Unique) writeln("Unique destructor of ", _p is null? null : _p);
         if (_p !is null)
         {
             destroy(_p);
@@ -234,10 +234,10 @@ Unique!T unique(T, A...)(auto ref A args)
     if (!rawMemory)
         onOutOfMemoryError();
 
-    static if (is(T == class)) {
+    static if (is(T == class))
         u._p = emplace!T(rawMemory[0 .. allocSize], args);
-    }
-    else {
+    else
+    {
         u._p = cast(T*)rawMemory;
         emplace!T(u._p, args);
     }
@@ -349,7 +349,7 @@ unittest
         int val() const { return 4; }
     }
 
-    alias UBar = Unique!(Bar);
+    alias UBar = Unique!Bar;
 
     UBar g(UBar u)
     {

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -57,9 +57,16 @@ a $(D Unique) maintains sole ownership of a given resource of type $(D T) until
 ownership is transferred or the $(D Unique) falls out of scope.
 Such a transfer can be explicit, using
 $(LINK2 http://dlang.org/phobos/std_algorithm_mutation.html#.move, $(D std.algorithm.move)),
-or implicit, when returning Unique from a function that created it.
+or implicit, when returning $(D Unique) from a function that created it.
 The resource can be a polymorphic class object,
-in which case Unique behaves polymorphically too.
+in which case $(D Unique) behaves polymorphically too.
+
+Note: Nested classes and structs cannot be created at present time,
+      as there is no way to transfer the closure's frame pointer
+      into this function.
+
+Params:
+    args = Arguments to pass to $(D T)'s constructor.
 */
 struct Unique(T)
 {
@@ -70,18 +77,10 @@ else
     alias RefT = T*;
 
     /**
-    Constructor that takes a $(D Unique) of a type that is convertible to our type.
+    Construct $(D Unique) from a type that is convertible to our type.
 
     Typically used to transfer a $(D Unique) rvalue of derived type to
     a $(D Unique) of base type.
-
-    Example:
-    ---
-    class C : Object { }
-
-    Unique!C uc = unique!C();
-    Unique!Object uo = move(uc);
-    ---
     */
     this(U)(Unique!U u)
         if (is(u.RefT : RefT))
@@ -137,7 +136,12 @@ else
     }
 
     /**
-    Returns a reference to the underlying $(D RefT) for use by non-owning code.
+    Returns a reference to the underlying $(D T) for use by non-owning code.
+
+    When $(D T) is a class or interface type and this $(D Unique) reference
+    is uninitialized or invalidated by an explicit move, get returns $(D null).
+    For all other types, get is illegal on an uninitialized or invalidated
+    reference.
 
     The holder of a $(D Unique!T) is the $(I owner) of that $(D T).
     For code that does not own the resource (and therefore does not affect
@@ -173,52 +177,26 @@ else
     /// that of $(D Unique.empty)
     bool opCast(T : bool)() const { return !empty; }
 
-    /// Forwards the underlying $(D RefT)
+    /// $(D Unique!T) is a subtype of $(D T).
     alias get this;
 
-    /// Postblit operator is undefined to prevent the cloning of $(D Unique) objects.
+    /// $(D Unique) references cannot be copied.
     @disable this(this);
 
 private:
     RefT _p;
 }
 
-unittest
-{
-    // Ditto...
-    import std.algorithm;
-
-    static class C : Object { }
-
-    Unique!C uc = unique!C();
-    Unique!Object uo = move(uc);
-}
-
-
-/**
-Allows safe construction of $(D Unique). It creates the resource and
-guarantees unique ownership of it (unless $(D T) publishes aliases of
-$(D this)).
-
-Note: Nested classes and structs cannot be created at present time,
-      as there is no way to transfer the closure's frame pointer
-      into this function.
-
-Params:
-    args = Arguments to pass to $(D T)'s constructor.
-
-*/
+/// Ditto
 Unique!T unique(T, A...)(auto ref A args)
     if (__traits(compiles, new T(args)))
 {
-    debug(Unique) writeln("Unique.create for ", T.stringof);
-
     import core.memory : GC;
     import core.stdc.stdlib : malloc;
     import std.conv : emplace;
     import core.exception : onOutOfMemoryError;
 
-    debug(Unique) writeln("Unique.create for ", T.stringof);
+    debug(Unique) writeln("unique() for ", T.stringof);
     Unique!T u;
 
     // TODO: May need to fix alignment?
@@ -248,12 +226,45 @@ Unique!T unique(T, A...)(auto ref A args)
     return u;
 }
 
-///
+/// Use unique to construct _unique resources:
 unittest
 {
-    struct S { }
-    auto u = unique!S();
-    assert(!u.empty());
+    struct S
+    {
+        int i;
+        this(int i) { this.i = i; }
+    }
+
+    auto u = unique!S(42);
+    assert(u);
+    assert(u.i == 42);
+}
+
+/// $(D Unique!T) supports the subtype conversions of $(D T):
+unittest
+{
+    import std.algorithm : move;
+
+    static interface I {}
+    static class Base : I {}
+    static class Derived : Base {}
+
+    Unique!Derived d = unique!Derived();
+    Unique!Base b = move(d);
+    Unique!I i = move(b);
+}
+
+/// Use $(D cast(bool)) to check if a reference is valid:
+unittest
+{
+    import std.algorithm.mutation : move;
+    Unique!Object u;
+    assert(!u); // uninitialized
+    u = unique!Object();
+    assert(u);
+    Unique!Object newOwner = move(u);
+    assert(!u); // invalidated by the move
+    assert(newOwner);
 }
 
 unittest
@@ -339,9 +350,6 @@ unittest
 
 unittest
 {
-    // FIXME: Isn't this a bit redundant?
-    // I believe all of these bases are covered in the tests above.
-
     debug(Unique) writeln("Unique class");
     static class Bar
     {


### PR DESCRIPTION
Follow-up to #3139.

* Documentation fixes and improvements
* Added examples
* A fix for destruction of held non-class values
* Deprecated `empty` in favour of `cast(bool)`
* Initialization is now a precondition for `get`ing non-class values, to support `nothrow`

`get` is still a template with two overloads because it's the only way to make the documentation show them both, as far as I can tell.

### Deprecation of `empty`

Currently there are two ways to check the validity of a `Unique` reference, `empty` and `cast(bool)`. I think we should only have one, and that is `cast(bool)`: `empty` is not only a bad name as it implies a range or container, but is highly likely to hijack `T.empty` in user code, which could conceivably cause hard to catch bugs ("why does it claim my unique container/range is never empty??").

### Initialization now a precondition for `get`ing non-class values

This is required to support `nothrow`. I plan on working on other attributes, particularly `@safe`, once #3031 is ready and merged.

---

What do you guys think?

edit:

BTW, what's up with deprecations not showing up in documentation?