### PR TITLE
remove "@trusted:" from std.variant

### DIFF
--- a/std/variant.d
+++ b/std/variant.d
@@ -68,8 +68,6 @@ module std.variant;
 import core.stdc.string, std.conv, std.exception, std.traits, std.typecons,
     std.typetuple;
 
-@trusted:
-
 /++
     Gives the $(D sizeof) the largest type given.
   +/
@@ -2566,3 +2564,12 @@ unittest
     assertThrown!VariantException(v.length);
 }
 
+unittest
+{
+    // Bugzilla 13534
+    static assert(!__traits(compiles, () @safe {
+        auto foo() @system { return 3; }
+        auto v = Variant(&foo);
+        v(); // foo is called in safe code!?
+    }));
+}


### PR DESCRIPTION
It's too broad.

This fixes issue 13534 - std.variant can violate memory safety.

https://issues.dlang.org/show_bug.cgi?id=13534