### PR TITLE
Mark std.uni.MuliArray.raw_ptr as pure, nothrow and @nogc

### DIFF
--- a/std/uni.d
+++ b/std/uni.d
@@ -912,7 +912,7 @@ struct MultiArray(Types...)
     }
 
 private:
-    @property auto raw_ptr(size_t n)()inout
+    @property auto raw_ptr(size_t n)()inout pure nothrow @nogc
     {
         static if(n == 0)
             return storage.ptr;


### PR DESCRIPTION
It is a template function but it only takes `size_t` as a template argument.
It does not contain any impure, throwable, and GC-related operations.

BTW, the expression `storage.ptr+offset[n]` seems  to implicitly assume that `starage.length > offsets[n]` always holds.
Is it correct?

It seems to be equivalent to `&storage[offset[n]]` and it is completely safe operation in the assumption.
If such assumption is correct, can I add an assert `starage.length > offsets[n]`, replace `storage.ptr+offset[n]` with `&storage[offset[n]]` and mark this method as `@safe`?

