### PR TITLE
Mark std.uni.MultiArray.length as @safe pure nothrow @nogc

### DIFF
--- a/std/uni.d
+++ b/std/uni.d
@@ -844,7 +844,7 @@ struct MultiArray(Types...)
 
     template length(size_t n)
     {
-        @property size_t length()const{ return sz[n]; }
+        @property size_t length()const @safe pure nothrow @nogc{ return sz[n]; }
 
         @property void length(size_t new_size)
         {


### PR DESCRIPTION
It does not contains any unsafe, impure, throwable, and GC-related operations.

Note: It may throw `RangeError` when `n >= sz.length` but it does not affect `nothrow`-ness
because `RangeError` is an error, not an exception.