### PR TITLE
Add workaround in std.datetime unit tests for bug in FreeBSD 9+.

### DIFF
--- a/std/datetime.d
+++ b/std/datetime.d
@@ -26966,8 +26966,16 @@ public:
         {
             scope(exit) clearTZEnvVar();
 
-            setTZEnvVar("America/Los_Angeles");
-            assert(LocalTime().dstName == "PDT");
+            version(FreeBSD)
+            {
+                // A bug on FreeBSD 9+ makes it so that this test fails.
+                // https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=168862
+            }
+            else
+            {
+                setTZEnvVar("America/Los_Angeles");
+                assert(LocalTime().dstName == "PDT");
+            }
 
             setTZEnvVar("America/New_York");
             assert(LocalTime().dstName == "EDT");


### PR DESCRIPTION
The std.datetime unit tests currently fail on FreeBSD 9+ because of a
bug in FreeBSD itself (which it looks like Martin reported):

https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=168862

tzname[] is set incorrectly in many time zones - including
America/Los_Angeles, which is what's causing the unit test failures in
std.datetime.

Sadly, the bug report has been around for almost 3 years without the bug
getting fixed (with the report including a patch no less), so I don't
know how long it will take them, and it just seems better to version out
the test in FreeBSD for now, since it's potentially a blocker for anyone
developing Phobos on FreeBSD.

The autotester doesn't exhibit the problem, because it's using FreeBSD
8.x.