### PR TITLE
fix, file handle must not be visible.

### DIFF
--- a/std/cstream.d
+++ b/std/cstream.d
@@ -33,7 +33,7 @@ import std.algorithm;
  * A Stream wrapper for a C file of type FILE*.
  */
 class CFile : Stream {
-  FILE* cfile;
+  protected FILE* cfile;
 
   /**
    * Create the stream wrapper for the given C file.


### PR DESCRIPTION
to change directly the handle could lead to leak the handle in `close()` because `isopen` was not defined
like it's the case when the `file()` setter is properly called.

possible breakage: no property...for class...
CFile.file() must be called instead.