### PR TITLE
Mark std.uni.PackedPtrImpl.this as @safe and @nogc

### DIFF
--- a/std/uni.d
+++ b/std/uni.d
@@ -1110,7 +1110,7 @@ template PackedPtr(T)
 pure nothrow:
     static assert(isPowerOf2(bits));
 
-    this(inout(size_t)* ptr)inout
+    this(inout(size_t)* ptr)inout @safe @nogc
     {
         origin = ptr;
     }


### PR DESCRIPTION
`PackedPtrImpl` is a template struct but `T` and `size_t` does not affect its `@safe`-ness and `@nogc`-ness and
`this` does not contain any unsafe and GC-related operations.

Note: `PackedPtrImpl` is already marked as `@trusted` but I think it is better to use `@safe` or `@trusted` for narrower scope such as methods or functions.