### PR TITLE
Fix BigInt.toString with "%x"

### DIFF
--- a/std/bigint.d
+++ b/std/bigint.d
@@ -720,6 +720,13 @@ public:
                 : data.toDecimalString(0);
         assert(buff.length > 0);
 
+        if (f.spec == 'x')
+        {
+            import std.uni : toLowerInPlace;
+
+            toLowerInPlace(buff);
+        }
+
         char signChar = isNegative() ? '-' : 0;
         auto minw = buff.length + (signChar ? 1 : 0);
 
@@ -770,6 +777,7 @@ public:
         x *= 12345;
 
         assert(format("%d", x) == "12345000000");
+        assert(format("%x", x) == "2_dfd1c040");
         assert(format("%X", x) == "2_DFD1C040");
     }
 
@@ -883,14 +891,14 @@ Params:
 
 Returns:
     A $(D string) that represents the $(D BigInt) as a hexadecimal (base 16)
-    number.
+    number in upper case.
 
 */
 string toHex(const(BigInt) x)
 {
     string outbuff="";
     void sink(const(char)[] s) { outbuff ~= s; }
-    x.toString(&sink, "%x");
+    x.toString(&sink, "%X");
     return outbuff;
 }
 
@@ -1121,6 +1129,57 @@ unittest
         assert(w1.data == entry[2]);
         w1.clear();
         w2.clear();
+    }
+}
+
+unittest
+{
+    import std.array;
+    import std.format;
+
+    immutable string[][] table = [
+    /*  fmt,        +10     -10 */
+        ["%x",      "a",    "-a"],
+        ["%+x",     "a",    "-a"],
+        ["%-x",     "a",    "-a"],
+        ["%+-x",    "a",    "-a"],
+
+        ["%4x",     "   a", "  -a"],
+        ["%+4x",    "   a", "  -a"],
+        ["%-4x",    "a   ", "-a  "],
+        ["%+-4x",   "a   ", "-a  "],
+
+        ["%04x",    "000a", "-00a"],
+        ["%+04x",   "000a", "-00a"],
+        ["%-04x",   "a   ", "-a  "],
+        ["%+-04x",  "a   ", "-a  "],
+
+        ["% 04x",   "000a", "-00a"],
+        ["%+ 04x",  "000a", "-00a"],
+        ["%- 04x",  "a   ", "-a  "],
+        ["%+- 04x", "a   ", "-a  "],
+    ];
+
+    auto w1 = appender!(char[])();
+    auto w2 = appender!(char[])();
+
+    foreach (entry; table)
+    {
+        immutable fmt = entry[0];
+
+        formattedWrite(w1, fmt, BigInt(10));
+        formattedWrite(w2, fmt, 10);
+        assert(w1.data == w2.data);     // Equal only positive BigInt
+        assert(w1.data == entry[1]);
+        w1.clear();
+        w2.clear();
+
+        formattedWrite(w1, fmt, BigInt(-10));
+        //formattedWrite(w2, fmt, -10);
+        //assert(w1.data == w2.data);
+        assert(w1.data == entry[2]);
+        w1.clear();
+        //w2.clear();
     }
 }
 

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -715,12 +715,19 @@ public:
         if (!(f.spec == 's' || f.spec == 'd' || hex))
             throw new FormatException("Format specifier not understood: %" ~ f.spec);
 
-        char[] buff =
-            f.spec == 'X' ?
-                data.toHexString(0, '_', 0, f.flZero ? '0' : ' ', LetterCase.upper) :
-            f.spec == 'x' ?
-                data.toHexString(0, '_', 0, f.flZero ? '0' : ' ', LetterCase.lower) :
-                data.toDecimalString(0);
+        char[] buff;
+        if (f.spec == 'X')
+        {
+            buff = data.toHexString(0, '_', 0, f.flZero ? '0' : ' ', LetterCase.upper);
+        }
+        else if (f.spec == 'x')
+        {
+            buff = data.toHexString(0, '_', 0, f.flZero ? '0' : ' ', LetterCase.lower);
+        }
+        else
+        {
+            buff = data.toDecimalString(0);
+        }
         assert(buff.length > 0);
 
         char signChar = isNegative() ? '-' : 0;

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -716,16 +716,12 @@ public:
             throw new FormatException("Format specifier not understood: %" ~ f.spec);
 
         char[] buff =
-            hex ? data.toHexString(0, '_', 0, f.flZero ? '0' : ' ')
-                : data.toDecimalString(0);
+            f.spec == 'X' ?
+                data.toHexString(0, '_', 0, f.flZero ? '0' : ' ', LetterCase.upper) :
+            f.spec == 'x' ?
+                data.toHexString(0, '_', 0, f.flZero ? '0' : ' ', LetterCase.lower) :
+                data.toDecimalString(0);
         assert(buff.length > 0);
-
-        if (f.spec == 'x')
-        {
-            import std.uni : toLowerInPlace;
-
-            toLowerInPlace(buff);
-        }
 
         char signChar = isNegative() ? '-' : 0;
         auto minw = buff.length + (signChar ? 1 : 0);

--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -48,6 +48,7 @@ alias multibyteSub = multibyteAddSub!('-');
 
 private import core.cpuid;
 private import std.traits : Unqual;
+public import std.ascii : LetterCase;
 
 shared static this()
 {
@@ -282,7 +283,8 @@ public:
      *  Separator characters do not contribute to the minPadding.
      */
     char [] toHexString(int frontExtraBytes, char separator = 0,
-            int minPadding=0, char padChar = '0') const pure nothrow @safe
+            int minPadding=0, char padChar = '0',
+            LetterCase letterCase = LetterCase.upper) const pure nothrow @safe
     {
         // Calculate number of extra padding bytes
         size_t extraPad = (minPadding > data.length * 2 * BigDigit.sizeof)
@@ -296,7 +298,7 @@ public:
         size_t totalSeparatorBytes = separator ? ((extraPad + lenBytes + 7) / 8) - 1: 0;
 
         char [] buff = new char[lenBytes + extraPad + totalSeparatorBytes + frontExtraBytes];
-        biguintToHex(buff[$ - lenBytes - mainSeparatorBytes .. $], data, separator);
+        biguintToHex(buff[$ - lenBytes - mainSeparatorBytes .. $], data, separator, letterCase);
         if (extraPad > 0)
         {
             if (separator)
@@ -1002,7 +1004,28 @@ pure unittest
     assert(r.toHexString(0, '_', 7, ' ') == "      0");
     assert(r.toHexString(0, '#', 9) == "0#00000000");
     assert(r.toHexString(0, 0, 9) == "000000000");
+}
 
+//
+@safe pure unittest
+{
+    BigUint r;
+    r.fromHexString("1_E1178E81_00000000");
+    assert(r.toHexString(0, '_', 0, '0', LetterCase.lower) == "1_e1178e81_00000000");
+    assert(r.toHexString(0, '_', 20, '0', LetterCase.lower) == "0001_e1178e81_00000000");
+    assert(r.toHexString(0, '_', 16+8, '0', LetterCase.lower) == "00000001_e1178e81_00000000");
+    assert(r.toHexString(0, '_', 16+9, '0', LetterCase.lower) == "0_00000001_e1178e81_00000000");
+    assert(r.toHexString(0, '_', 16+8+8, '0', LetterCase.lower) ==   "00000000_00000001_e1178e81_00000000");
+    assert(r.toHexString(0, '_', 16+8+8+1, '0', LetterCase.lower) == "0_00000000_00000001_e1178e81_00000000");
+    assert(r.toHexString(0, '_', 16+8+8+1, ' ', LetterCase.lower) == "                  1_e1178e81_00000000");
+    assert(r.toHexString(0, 0, 16+8+8+1, '0', LetterCase.lower) == "00000000000000001e1178e8100000000");
+    r = 0UL;
+    assert(r.toHexString(0, '_', 0, '0', LetterCase.lower) == "0");
+    assert(r.toHexString(0, '_', 7, '0', LetterCase.lower) == "0000000");
+    assert(r.toHexString(0, '_', 7, ' ', LetterCase.lower) == "      0");
+    assert(r.toHexString(0, '#', 9, '0', LetterCase.lower) == "0#00000000");
+    assert(r.toHexString(0, 'Z', 9, '0', LetterCase.lower) == "0Z00000000");
+    assert(r.toHexString(0, 0, 9, '0', LetterCase.lower) == "000000000");
 }
 
 
@@ -1510,13 +1533,13 @@ private:
 // every 8 digits.
 // buff.length must be data.length*8 if separator is zero,
 // or data.length*9 if separator is non-zero. It will be completely filled.
-char [] biguintToHex(char [] buff, const BigDigit [] data, char separator=0)
-    pure nothrow @safe
+char [] biguintToHex(char [] buff, const BigDigit [] data, char separator=0,
+        LetterCase letterCase = LetterCase.upper) pure nothrow @safe
 {
     int x=0;
     for (ptrdiff_t i=data.length - 1; i>=0; --i)
     {
-        toHexZeroPadded(buff[x..x+8], data[i]);
+        toHexZeroPadded(buff[x..x+8], data[i], letterCase);
         x+=8;
         if (separator)
         {
@@ -2150,13 +2173,22 @@ void itoaZeroPadded(char[] output, uint value, int radix = 10)
     }
 }
 
-void toHexZeroPadded(char[] output, uint value) pure nothrow @safe
+void toHexZeroPadded(char[] output, uint value,
+        LetterCase letterCase = LetterCase.upper) pure nothrow @safe
 {
     ptrdiff_t x = output.length - 1;
-    static immutable string hexDigits = "0123456789ABCDEF";
+    static immutable string upperHexDigits = "0123456789ABCDEF";
+    static immutable string lowerHexDigits = "0123456789abcdef";
     for( ; x>=0; --x)
     {
-        output[x] = hexDigits[value & 0xF];
+        if (letterCase == LetterCase.upper)
+        {
+            output[x] = upperHexDigits[value & 0xF];
+        }
+        else
+        {
+            output[x] = lowerHexDigits[value & 0xF];
+        }
         value >>= 4;
     }
 }


### PR DESCRIPTION
Partial fix for https://issues.dlang.org/show_bug.cgi?id=14503.

Make `BigInt.toString()` distinguish between "%x" and "%X".
In addition, make `toHex()` return explicitly in upper case, for compatibility.