### PR TITLE
Modify gitignore to ease building Phobos in Xamarin Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ GNUmakefile
 .DS_Store
 .*.sw*
 Makefile
+*.dproj
+bin/
+obj/
+*.html

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ GNUmakefile
 .DS_Store
 .*.sw*
 Makefile
+
+# Rules for Xamarin Studio project data/build output
 *.dproj
 bin/
 obj/


### PR DESCRIPTION
Xamarin Studio creates various directories and files for build output and for "projects." This change adds those directories and files to the ignore list.