### PR TITLE
Fix ddoc for Option.required

### DIFF
--- a/std/getopt.d
+++ b/std/getopt.d
@@ -499,8 +499,7 @@ struct Option {
     string optShort; /// The short symbol for this option
     string optLong; /// The long symbol for this option
     string help; /// The description of this option
-    bool required; /// If a option is required, not passing it will result in
-                   /// an error.
+    bool required; /// If a option is required, not passing it will result in an error
 }
 
 private pure Option splitAndGet(string opt) @trusted nothrow


### PR DESCRIPTION
DDoc did not consider that this second comment was connected to the first, leading to part of the comment being missing at http://dlang.org/phobos/std_getopt.html#.Option