### PR TITLE
Make std.array.replicate for most cases @safe

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -1355,7 +1355,7 @@ ElementEncodingType!S[] replicate(S)(S s, size_t n) if (isDynamicArray!S)
             r[i .. i + len] = s[];
         }
     }
-    return cast(RetType) r;
+    return r;
 }
 
 /// ditto


### PR DESCRIPTION
Thanks to the concept of [unique object](http://dlang.org/changelog.html#uniqueinference), we can remove unsafe cast from `replicate`.

This request makes `std.array.replicate` for dynamic arrays `@safe` for most cases.
That is, it will be unsafe only if `ElementEncodingType!S` has unsafe `opAssign`.
