### PR TITLE
Mark a unittest for std.uni.decodeGrapheme as @system

### DIFF
--- a/std/uni.d
+++ b/std/uni.d
@@ -6486,7 +6486,7 @@ Grapheme decodeGrapheme(Input)(ref Input inp)
     return genericDecodeGrapheme!true(inp);
 }
 
-unittest
+@system unittest
 {
     Grapheme gr;
     string s = " \u0020\u0308 ";


### PR DESCRIPTION
It should be `@system` because `Grapheme.opSlice` is `@system` but
currently it is accidentally marked as `@trusted` because of global `@trusted:` block. 
This request fixes this issue.