### PR TITLE
Remove std.uni.graphemeStride and its unittest from @trusted block

### DIFF
--- a/std/uni.d
+++ b/std/uni.d
@@ -6422,7 +6422,6 @@ template genericDecodeGrapheme(bool getValue)
 
 }
 
-@trusted:
 public: // Public API continues
 
 /++
@@ -6470,6 +6469,8 @@ size_t graphemeStride(C)(in C[] input, size_t index)
     assert(city[0..first] == "A\u030A");
     assert(city[first..$] == "rhus");
 }
+
+@trusted:
 
 /++
     Reads one full grapheme cluster from an input range of dchar $(D inp).


### PR DESCRIPTION
Currently `graphemeStride` is in global `@trusted:` block but its `@safe`-ness depends on its template argument.

It will break existing code which treats `graphemeStride` as `@safe` for unsafe template argument
but we should avoid to mark unsafe functions as `@safe` or `@trusted`.

This request partially solves [issue 13560](https://issues.dlang.org/show_bug.cgi?id=13560).