### PR TITLE
Undo change from "Windows" to "Win32"

### DIFF
--- a/std/path.d
+++ b/std/path.d
@@ -2744,7 +2744,7 @@ unittest
         $(LI If $(D path) starts with $(D `\\?\`) (long UNC path), the
             only requirement for the rest of the string is that it does
             not contain the null character.)
-        $(LI If $(D path) starts with $(D `\\.\`) (Windows device namespace)
+        $(LI If $(D path) starts with $(D `\\.\`) (Win32 device namespace)
             this function returns $(D false); such paths are beyond the scope
             of this module.)
     )


### PR DESCRIPTION
This was changed in pull request #3185, for reasons unknown.  The [correct term](https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx#namespaces) is "Win32 device namespace".