### PR TITLE
fix Issue 14553: The return types of std.array.array for narrow strin…

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -188,10 +188,37 @@ This is handled as a special case and always returns a $(D dchar[]),
 $(D const(dchar)[]), or $(D immutable(dchar)[]) depending on the constness of
 the input.
 */
-ElementType!String[] array(String)(String str) if (isNarrowString!String)
+auto array(String)(String str) if (isNarrowString!String)
 {
     import std.utf : toUTF32;
-    return cast(typeof(return)) str.toUTF32;
+
+    static if (is(ElementEncodingType!String == char) ||
+               is(ElementEncodingType!String == wchar))
+    {
+        alias ReturnType = dchar[];
+    }
+    else static if (is(ElementEncodingType!String == const(char)) ||
+                    is(ElementEncodingType!String == const(wchar)))
+    {
+        alias ReturnType = const(dchar)[];
+    }
+    else
+    {
+        alias ReturnType = immutable(dchar)[];
+    }
+
+    return cast(ReturnType) str.toUTF32;
+}
+
+unittest
+{
+    // Issue 14553
+    foreach(T; TypeTuple!(char, wchar))
+    {
+        assert(is(ReturnType!(array!(T[])) == dchar[]));
+        assert(is(ReturnType!(array!(const(T)[])) == const(dchar)[]));
+        assert(is(ReturnType!(array!(immutable(T)[])) == immutable(dchar)[]));
+    }
 }
 
 unittest


### PR DESCRIPTION
…gs conflicts with its documentation

https://issues.dlang.org/show_bug.cgi?id=14553

The reason why it always returns `dchar[]` is that `ElementType!String` always returns `dchar` instead of qualified `dchar`.

I also added a unittest for this issue.