### PR TITLE
Remove std.uni.decodeGrapheme, byGrapheme, and byCodePoint from @trus…

### DIFF
--- a/std/uni.d
+++ b/std/uni.d
@@ -6470,8 +6470,6 @@ size_t graphemeStride(C)(in C[] input, size_t index)
     assert(city[first..$] == "rhus");
 }
 
-@trusted:
-
 /++
     Reads one full grapheme cluster from an input range of dchar $(D inp).
 
@@ -6698,6 +6696,8 @@ unittest
 
     assert(cpText.walkLength == text.walkLength);
 }
+
+@trusted:
 
 /++
     $(P A structure designed to effectively pack $(CHARACTERS)


### PR DESCRIPTION
…ted block

Their `@safe`-ness should depend on their template arguments.
This request removes them from global `@trusted:` block.

It may break existing code which treats them as `@safe` for unsafe template arguments.
I also remove unittests for them from `@trusted:` block but it does not break existing code.

It partially fixes [issue 13560](https://issues.dlang.org/show_bug.cgi?id=13560).
