### PR TITLE
Prefer std.typecons.Flag over booleans for some Phobos arguments

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -2601,7 +2601,7 @@ void rmdirRecurse(ref DirEntry de)
     else
     {
         // all children, recursively depth-first
-        foreach(DirEntry e; dirEntries(de.name, SpanMode.depth, false))
+        foreach(DirEntry e; dirEntries(de.name, SpanMode.depth, FollowSymlink.no))
         {
             attrIsDir(e.linkAttributes) ? rmdir(e.name) : remove(e.name);
         }
@@ -2913,6 +2913,9 @@ public:
     void popFront(){ impl.popFront(); }
 
 }
+
+alias FollowSymlink = Flag!"FollowSymlink";
+
 /++
     Returns an input range of DirEntry that lazily iterates a given directory,
     also provides two ways of foreach iteration. The iteration variable can be of
@@ -2963,9 +2966,17 @@ foreach(d; parallel(dFiles, 1)) //passes by 1 file to each thread
 }
 --------------------
  +/
-auto dirEntries(string path, SpanMode mode, bool followSymlink = true)
+auto dirEntries(string path, SpanMode mode,
+                FollowSymlink followSymlink = FollowSymlink.yes)
 {
     return DirIterator(path, mode, followSymlink);
+}
+
+deprecated("Please use dirEntries(string, SpanMode, FollowSymlink) "
+           "with FollowSymlink.yes or FollowSymlink.no instead.")
+auto dirEntries(string path, SpanMode mode, bool followSymlink = true)
+{
+    return dirEntries(path, mode, cast(FollowSymlink)followSymlink);
 }
 
 /// Duplicate functionality of D1's $(D std.file.listdir()):

--- a/std/file.d
+++ b/std/file.d
@@ -2914,7 +2914,8 @@ public:
 
 }
 
-alias FollowSymlink = Flag!"FollowSymlink";
+/// Flag to specify whether or not $(D dirEntries) should follow symbolic links
+alias FollowSymlink = Flag!"followSymlink";
 
 /++
     Returns an input range of DirEntry that lazily iterates a given directory,

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -907,6 +907,7 @@ private auto _decodeContent(T)(ubyte[] content, string encoding)
 }
 
 alias KeepTerminator = Flag!"keepTerminator";
+
 /+
 struct ByLineBuffer(Char)
 {
@@ -3720,15 +3721,23 @@ struct Curl
         this.handle = null;
     }
 
-    /**
-       Pausing and continuing transfers.
-    */
-    void pause(bool sendingPaused, bool receivingPaused)
+    alias PauseSending = Flag!"PauseSending";
+    alias PauseReceiving = Flag!"PauseReceiving";
+
+    /// Pause and continue transfers.
+    void pause(PauseSending pauseSending, PauseReceiving pauseReceiving)
     {
         throwOnStopped();
         _check(curl_easy_pause(this.handle,
-                               (sendingPaused ? CurlPause.send_cont : CurlPause.send) |
-                               (receivingPaused ? CurlPause.recv_cont : CurlPause.recv)));
+                               (pauseSending ? CurlPause.send_cont : CurlPause.send) |
+                               (pauseReceiving ? CurlPause.recv_cont : CurlPause.recv)));
+    }
+
+    deprecated("Use pause(PauseSending, PauseReceiving) with flags instead of booleans.")
+    void pause(bool pauseSending, bool pauseReceiving)
+    {
+        pause(cast(PauseSending)pauseSending,
+              cast(PauseReceiving)pauseReceiving);
     }
 
     /**

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -906,6 +906,7 @@ private auto _decodeContent(T)(ubyte[] content, string encoding)
     }
 }
 
+/// Flag to specify whether or not $(D byLine) should provide line terminators
 alias KeepTerminator = Flag!"keepTerminator";
 
 /+
@@ -3721,8 +3722,13 @@ struct Curl
         this.handle = null;
     }
 
-    alias PauseSending = Flag!"PauseSending";
-    alias PauseReceiving = Flag!"PauseReceiving";
+    /// Flag to specify whether or not $(D pause) should pause or continue
+    /// sending during a transfer
+    alias PauseSending = Flag!"pauseSending";
+
+    /// Flag to specify whether or not $(D pause) should pause or continue
+    /// receiving during a transfer
+    alias PauseReceiving = Flag!"pauseReceiving";
 
     /// Pause and continue transfers.
     void pause(PauseSending pauseSending, PauseReceiving pauseReceiving)

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -416,6 +416,10 @@ private struct AbstractTask
     }
 }
 
+/// Used for $(D Task.finish)
+alias Blocking = Flag!"blocking";
+
+
 /**
 $(D Task) represents the fundamental unit of work.  A $(D Task) may be
 executed in parallel with any other $(D Task).  Using this struct directly
@@ -3110,7 +3114,7 @@ public:
               thread that is a member of the same $(D TaskPool) that
               $(D finish) is being called on will result in a deadlock.
      */
-    void finish(bool blocking = false) @trusted
+    void finish(Blocking blocking = Blocking.no) @trusted
     {
         {
             queueLock();
@@ -3138,6 +3142,12 @@ public:
                 t.join();
             }
         }
+    }
+
+    deprecated("Please use Blocking.yes or Blocking.no instead of a boolean.")
+    void finish(bool blocking = false) @trusted
+    {
+        finish(cast(Blocking)blocking);
     }
 
     /// Returns the number of worker threads in the pool.
@@ -4122,14 +4132,14 @@ unittest
         auto pool2 = new TaskPool();
         auto tSlow2 = task!slowFun();
         pool2.put(tSlow2);
-        pool2.finish(true); // blocking
+        pool2.finish(Blocking.yes);
         assert(tSlow2.done);
 
         // Test fix for Bug 8582 by making pool size zero.
         auto pool3 = new TaskPool(0);
         auto tSlow3 = task!slowFun();
         pool3.put(tSlow3);
-        pool3.finish(true); // blocking
+        pool3.finish(Blocking.yes);
         assert(tSlow3.done);
 
         // This is correct because no thread will terminate unless pool2.status

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -416,7 +416,7 @@ private struct AbstractTask
     }
 }
 
-/// Used for $(D Task.finish)
+/// Flag to specify whether or not $(D Task.finish) should block
 alias Blocking = Flag!"blocking";
 
 


### PR DESCRIPTION
This PR uses `std.typecons.Flag` for several boolean arguments in the standard library, similar to `std.stdio.byLine` and its `KeepTerminator`. The boolean versions are deprecated and encourage users to switch to the `Flag` versions.

For rationale, see the docs for [`Flag`](http://dlang.org/phobos/std_typecons.html#.Flag) as well as ["The boolean parameter trap" section](https://wiki.qt.io/API_Design_Principles#Avoiding_Common_Traps) of Qt's API design guidelines. To wit, boolean arguments are often a mistake and make it simple to forget or invert their meaning. Since `std.typecons.Flag` exists for this very reason, it should be used more in the standard library.