### PR TITLE
Struct Returned findSplit*() with implicit bool conversion

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1376,17 +1376,11 @@ unittest
     Returns:
         true if `T` is a `Tuple` type, false otherwise.
  */
-template isTuple(T)
-{
-    static if (is(Unqual!T Unused : Tuple!Specs, Specs...))
-    {
-        enum isTuple = true;
-    }
-    else
-    {
-        enum isTuple = false;
-    }
-}
+enum isTuple(T) = __traits(compiles,
+                           {
+                               void f(Specs...)(Tuple!Specs tup) {}
+                               f(T.init);
+                           } );
 
 ///
 unittest
@@ -6843,4 +6837,3 @@ unittest
         int, float, RefFun1, RefFun2,
     );
 }
-


### PR DESCRIPTION
This enables the following useful syntax:

```D
if (const split = line.findSplit(`-`))
{
    // do something with split
}
```

instead of current

```D
const split = line.findSplit(`-`)
if (!split[1].empty)
{
}
```

for the Phobos algorithms `findSplit`, `findSplitBefore` and `findSplitAfter`.

See also discussion at: http://forum.dlang.org/thread/etttlwazcguwpaltyrps@forum.dlang.org#post-tbnvyqawcqmccvociwrr:40forum.dlang.org