### PR TITLE
Add missing EXPBIAS value for 128bit floats.

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -326,6 +326,7 @@ template floatTraits(T)
     {
         // Quadruple precision float
         enum ushort EXPMASK = 0x7FFF;
+        enum ushort EXPBIAS = 0x3FFF;
         enum realFormat = RealFormat.ieeeQuadruple;
         version(LittleEndian)
         {


### PR DESCRIPTION
Found this source for the value: http://en.wikipedia.org/wiki/Quadruple-precision_floating-point_format