### PR TITLE
Cleanup for Issue 7648: std.stdio expects file names to be encoded in CP_ACP on Windows instead of UTF-8

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -3544,13 +3544,6 @@ Example:
 // double.
 auto a = slurp!(int, double)("filename", "%s, %s");
 ----
-
-Bugs:
-$(D slurp) expects file names to be encoded in $(B CP_ACP) on $(I Windows)
-instead of UTF-8 (as it internally uses $(XREF stdio, File),
-see $(BUGZILLA 7648)) thus must not be used in $(I Windows)
-or cross-platform applications other than with an immediate ASCII string as
-a file name to prevent accidental changes to result in incorrect behavior.
  */
 Select!(Types.length == 1, Types[0][], Tuple!(Types)[])
 slurp(Types...)(string filename, in char[] format)

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -311,14 +311,6 @@ manner, such that as soon as the last $(D File) variable bound to a
 given $(D FILE*) goes out of scope, the underlying $(D FILE*) is
 automatically closed.
 
-Bugs:
-$(D File) expects file names to be encoded in $(B CP_ACP) on $(I Windows)
-instead of UTF-8 ($(BUGZILLA 7648)) thus must not be used in $(I Windows)
-or cross-platform applications other than with an immediate ASCII string as
-a file name to prevent accidental changes to result in incorrect behavior.
-One can use $(XREF file, read)/$(XREF file, write)/$(XREF stream, _File)
-instead.
-
 Example:
 ----
 // test.d
@@ -4563,11 +4555,6 @@ version(unittest) string testFilename(string file = __FILE__, size_t line = __LI
     import std.file : deleteme;
     import std.path : baseName;
 
-    // Non-ASCII characters can't be used because of snn.lib @@@BUG8643@@@
-    version(DIGITAL_MARS_STDIO)
-        return text("deleteme-.", baseName(file), ".", line);
-    else
-
-        // filename intentionally contains non-ASCII (Russian) characters
-        return text(deleteme, "-детка.", baseName(file), ".", line);
+    // filename intentionally contains non-ASCII (Russian) characters for test Issue 7648
+    return text("deleteme-детка.", baseName(file), ".", line);
 }


### PR DESCRIPTION
Continue of [phobos#3138](https://github.com/D-Programming-Language/phobos/pull/3138). [Issue 7648](https://issues.dlang.org/show_bug.cgi?id=7648) was [fixed](https://github.com/D-Programming-Language/phobos/pull/3138#issuecomment-103371633) in DMC runtime.
This PR removes Issue 7648 from bugs list in docs. And add Non-ASCII characters in filename for unittests.