### PR TITLE
Fix 14611 - socket.localAddress fails on Unix sockets with longer path (> 13 characters)

### DIFF
--- a/std/socket.d
+++ b/std/socket.d
@@ -3407,9 +3407,12 @@ public:
         Address result;
         switch(_family)
         {
-        case AddressFamily.UNIX:
-            result = new UnixAddress;
-            break;
+        static if (is(sockaddr_un))
+        {
+            case AddressFamily.UNIX:
+                result = new UnixAddress;
+                break;
+        }
 
         case AddressFamily.INET:
             result = new InternetAddress;

--- a/std/socket.d
+++ b/std/socket.d
@@ -1921,10 +1921,11 @@ static if (is(sockaddr_un))
     class UnixAddress: Address
     {
     protected:
-        union
+        struct
         {
+        align (1):
             sockaddr_un sun;
-            void[sockaddr_un.sizeof + 1] buf;
+            char unused; // placeholder for a terminating '\0'
         }
 
         this() pure nothrow @nogc

--- a/std/socket.d
+++ b/std/socket.d
@@ -50,7 +50,7 @@ import core.stdc.stdint, core.stdc.string, std.string, core.stdc.stdlib, std.con
 
 import core.stdc.config;
 import core.time : dur, Duration;
-import std.algorithm : max, uninitializedFill;
+import std.algorithm : max;
 import std.exception : assumeUnique, enforce, collectException;
 
 import std.internal.cstring;
@@ -1925,13 +1925,13 @@ static if (is(sockaddr_un))
         {
         align (1):
             sockaddr_un sun;
-            char unused; // placeholder for a terminating '\0'
+            char unused = '\0'; // placeholder for a terminating '\0'
         }
 
         this() pure nothrow @nogc
         {
             sun.sun_family = AF_UNIX;
-            sun.sun_path[].uninitializedFill('?');
+            sun.sun_path = '?';
         }
 
     public:


### PR DESCRIPTION
See https://issues.dlang.org/show_bug.cgi?id=14611