### PR TITLE
[TRIVIAL] Pass the makefile name along in recursive invocations

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -388,7 +388,7 @@ unittest/%.run : $(ROOT)/unittest/test_runner
 # Target for quickly unittesting all modules and packages within a package,
 # transitively. For example: "make std/algorithm.test"
 %.test : $(LIB)
-	$(MAKE) $(addsuffix .test,$(patsubst %.d,%,$(wildcard $*/*)))
+	$(MAKE) -f $(MAKEFILE) $(addsuffix .test,$(patsubst %.d,%,$(wildcard $*/*)))
 
 ################################################################################
 # More stuff
@@ -479,7 +479,7 @@ rsync-prerelease : html
 html_consolidated :
 	$(DDOC) -Df$(DOCSRC)/std_consolidated_header.html $(DOCSRC)/std_consolidated_header.dd
 	$(DDOC) -Df$(DOCSRC)/std_consolidated_footer.html $(DOCSRC)/std_consolidated_footer.dd
-	$(MAKE) DOC_OUTPUT_DIR=$(BIGDOC_OUTPUT_DIR) STDDOC=$(BIGSTDDOC) html -j 8
+	$(MAKE) -f $(MAKEFILE) DOC_OUTPUT_DIR=$(BIGDOC_OUTPUT_DIR) STDDOC=$(BIGSTDDOC) html -j 8
 	cat $(DOCSRC)/std_consolidated_header.html $(BIGHTMLS)	\
 	$(DOCSRC)/std_consolidated_footer.html > $(DOC_OUTPUT_DIR)/std_consolidated.html
 


### PR DESCRIPTION
I have an alias for posix.mak as GNUmakefile, so I didn't detect this until I moved code to another machine.