### PR TITLE
Fix 14616 - ddoc shows std.socket.UnixAddress as "abstract" 

### DIFF
--- a/std/socket.d
+++ b/std/socket.d
@@ -1913,6 +1913,10 @@ version(StdDdoc)
 
         /// ditto
         override string toString() const { return null; }
+
+        override @property sockaddr* name() { return null; }
+        override @property const(sockaddr)* name() const { return 0; }
+        override @property socklen_t nameLen() const { return 0; }
     }
 }
 else

--- a/std/socket.d
+++ b/std/socket.d
@@ -1906,13 +1906,13 @@ version(StdDdoc)
     class UnixAddress: Address
     {
         /// Construct a new $(D UnixAddress) from the specified path.
-        this(in char[] path);
+        this(in char[] path) { }
 
         /// Get the underlying _path.
-        @property string path() const;
+        @property string path() const { return null; }
 
         /// ditto
-        override string toString() const;
+        override string toString() const { return null; }
     }
 }
 else


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14616