### PR TITLE
[Windows] Fix a range error in std.socket.SocketSet.add()

### DIFF
--- a/std/socket.d
+++ b/std/socket.d
@@ -2236,7 +2236,8 @@ public:
                 set.length *= 2;
                 set.length = set.capacity;
             }
-            fds[count++] = s;
+            ++count;
+            fds[$-1] = s;
         }
         else
         {


### PR DESCRIPTION
`fds()` returns a slice of length `count()`, and since fds() is invoked before evaluating the index expression (incl. increasing the count), its length is the old count, so we cannot assign to the element at index = old count, that's 1 past the end.