### PR TITLE
TemplateOf example wasn't being included in ddoc because the second o…

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -3824,6 +3824,7 @@ template TemplateOf(alias T : Base!Args, alias Base, Args...)
     alias TemplateOf = Base;
 }
 
+/// ditto
 template TemplateOf(T : Base!Args, alias Base, Args...)
 {
     alias TemplateOf = Base;


### PR DESCRIPTION
…verload was not ditto'd