### PR TITLE
Decode-free std.regex

### DIFF
--- a/std/regex/internal/backtracking.d
+++ b/std/regex/internal/backtracking.d
@@ -272,18 +272,18 @@ template BacktrackingMatcher(bool CTregex)
                         //at start & end of input
                         if(atStart)
                         {
-                            if(!atEnd && !wordTrie[s.peek])
+                            if(!atEnd && !s.testWordClass())
                                 goto L_backtrack;
                         }
                         else if(atEnd)
                         {
-                            if(!wordTrie[s.loopBack(s._index).peek])
+                            if(!s.loopBack(s._index).testWordClass())
                                 goto L_backtrack;
                         }
                         else
                         {
-                            bool af = wordTrie[s.peek];
-                            bool ab = wordTrie[s.loopBack(s._index).peek];
+                            bool af = s.testWordClass();
+                            bool ab = s.loopBack(s._index).testWordClass();
                             if((af ^ ab) == false)
                                 goto L_backtrack;
                         }
@@ -293,18 +293,18 @@ template BacktrackingMatcher(bool CTregex)
                         //at start & end of input
                         if(atStart)
                         {
-                            if(atEnd || wordTrie[s.peek])
+                            if(atEnd || s.testWordClass())
                                 goto L_backtrack;
                         }
                         else if(atEnd)
                         {
-                            if(wordTrie[s.loopBack(s._index).peek])
+                            if(s.loopBack(s._index).testWordClass())
                                 goto L_backtrack;
                         }
                         else
                         {
-                            bool af = wordTrie[s.peek];
-                            bool ab = wordTrie[s.loopBack(s._index).peek];
+                            bool af = s.testWordClass();
+                            bool ab = s.loopBack(s._index).testWordClass();
                             if((af ^ ab) == true)
                                 goto L_backtrack;
                         }
@@ -318,7 +318,7 @@ template BacktrackingMatcher(bool CTregex)
                         }
                         else if(re.flags & RegexOption.multiline)
                         {
-                            bool seenNl = !atEnd && s.peek == '\n';
+                            bool seenNl = !atEnd && s.front == '\n';
                             if(startOfLine(s.loopBack(s._index), seenNl))
                             {
                                 pc += IRL!(IR.Eol);
@@ -335,7 +335,7 @@ template BacktrackingMatcher(bool CTregex)
                         }
                         else if(re.flags & RegexOption.multiline)
                         {
-                            bool seenCr = !atStart && s.loopBack(s._index).peek == '\r';
+                            bool seenCr = !atStart && s.loopBack(s._index).front == '\r';
                             if(endOfLine(s, seenCr))
                             {
                                 pc += IRL!(IR.Eol);
@@ -1203,18 +1203,18 @@ struct CtContext
             code ~= ctSub( `
                     if(atStart)
                     {
-                        if(!atEnd && !wordTrie[s.peek])
+                        if(!atEnd && !s.testWordClass())
                             $$
                     }
                     else if(atEnd)
                     {
-                        if(!wordTrie[s.loopBack(s._index).peek])
+                        if(!s.loopBack(s._index).testWordClass())
                             $$
                     }
                     else
                     {
-                        bool af = wordTrie[s.peek];
-                        bool ab = wordTrie[s.loopBack(s._index).peek];
+                        bool af = s.testWordClass();
+                        bool ab = s.loopBack(s._index).testWordClass();
                         if((af ^ ab) == false)
                             $$
                     }
@@ -1225,18 +1225,18 @@ struct CtContext
             code ~= ctSub( `
                     if(atStart)
                     {
-                        if(atEnd || wordTrie[s.peek])
+                        if(atEnd || s.testWordClass())
                             $$
                     }
                     else if(atEnd)
                     {
-                        if(wordTrie[s.loopBack(s._index).peek])
+                        if(s.loopBack(s._index).testWordClass())
                             $$
                     }
                     else
                     {
-                        bool af = wordTrie[s.peek];
-                        bool ab = wordTrie[s.loopBack(s._index).peek];
+                        bool af = s.testWordClass();
+                        bool ab = s.loopBack(s._index).testWordClass();
                         if((af ^ ab) == true)
                             $$
                     }
@@ -1252,7 +1252,7 @@ struct CtContext
                     }
                     else if(re.flags & RegexOption.multiline)
                     {
-                        bool seenNl = !atEnd && s.peek == '\n';
+                        bool seenNl = !atEnd && s.front == '\n';
                         if(startOfLine(s.loopBack(s._index), seenNl))
                         {
                             $$
@@ -1269,7 +1269,7 @@ struct CtContext
                     }
                     else if(re.flags & RegexOption.multiline)
                     {
-                        bool seenCr = !atStart && s.loopBack(s._index).peek == '\r';
+                        bool seenCr = !atStart && s.loopBack(s._index).front == '\r';
                         if(endOfLine(s, seenCr))
                         {
                             $$

--- a/std/regex/internal/backtracking.d
+++ b/std/regex/internal/backtracking.d
@@ -35,8 +35,6 @@ template BacktrackingMatcher(bool CTregex)
             MatchFn nativeFn; //native code for that program
         //Stream state
         Stream s;
-        DataIndex index;
-        dchar front;
         bool exhausted;
         //backtracking machine state
         uint pc, counter;
@@ -66,27 +64,16 @@ template BacktrackingMatcher(bool CTregex)
             return initialStack*(stateSize + re.ngroup*(Group!DataIndex).sizeof/size_t.sizeof)+1;
         }
 
-        @property bool atStart(){ return index == 0; }
+        @property bool atStart(){ return s._index == 0; }
 
-        @property bool atEnd(){ return index == s.lastIndex && s.atEnd; }
-
-        void next()
-        {
-            if(!s.nextChar(front, index))
-                index = s.lastIndex;
-        }
+        @property bool atEnd(){ return s.atEnd; }
 
         void search()
         {
             static if(kicked)
-            {
-                if(!s.search(re.kickstart, front, index))
-                {
-                    index = s.lastIndex;
-                }
-            }
+                s._index = re.kickstart.search(s._origin, s._index);
             else
-                next();
+                s.skipChar();
         }
 
         //
@@ -121,48 +108,40 @@ template BacktrackingMatcher(bool CTregex)
             return tmp;
         }
 
-        this(ref RegEx program, Stream stream, void[] memBlock, dchar ch, DataIndex idx)
-        {
-            initialize(program, stream, memBlock);
-            front = ch;
-            index = idx;
-        }
-
         this(ref RegEx program, Stream stream, void[] memBlock)
         {
             initialize(program, stream, memBlock);
-            next();
         }
 
         auto fwdMatcher(ref BacktrackingMatcher matcher, void[] memBlock)
         {
             alias BackMatcherTempl = .BacktrackingMatcher!(CTregex);
             alias BackMatcher = BackMatcherTempl!(Char, Stream);
-            auto fwdMatcher = BackMatcher(matcher.re, s, memBlock, front, index);
+            auto fwdMatcher = BackMatcher(matcher.re, s, memBlock);
             return fwdMatcher;
         }
 
         auto bwdMatcher(ref BacktrackingMatcher matcher, void[] memBlock)
         {
             alias BackMatcherTempl = .BacktrackingMatcher!(CTregex);
-            alias BackMatcher = BackMatcherTempl!(Char, typeof(s.loopBack(index)));
+            alias BackMatcher = BackMatcherTempl!(Char, typeof(s.loopBack(s._index)));
             auto fwdMatcher =
-                BackMatcher(matcher.re, s.loopBack(index), memBlock);
+                BackMatcher(matcher.re, s.loopBack(s._index), memBlock);
             return fwdMatcher;
         }
 
         //
         bool matchFinalize()
         {
-            size_t start = index;
+            size_t start = s._index;
             if(matchImpl())
             {//stream is updated here
                 matches[0].begin = start;
-                matches[0].end = index;
+                matches[0].end = s._index;
                 if(!(re.flags & RegexOption.global) || atEnd)
                     exhausted = true;
-                if(start == index)//empty match advances input
-                    next();
+                if(start == s._index && !s.atEnd)//empty match advances input
+                    s.skipChar();
                 return true;
             }
             else
@@ -182,12 +161,12 @@ template BacktrackingMatcher(bool CTregex)
             if(re.flags & RegexInfo.oneShot)
             {
                 exhausted = true;
-                DataIndex start = index;
+                DataIndex start = s._index;
                 auto m = matchImpl();
                 if(m)
                 {
                     matches[0].begin = start;
-                    matches[0].end = index;
+                    matches[0].end = s._index;
                 }
                 return m;
             }
@@ -197,23 +176,13 @@ template BacktrackingMatcher(bool CTregex)
                 {
                     for(;;)
                     {
-
+                        search();
+                        if(atEnd) // non-empty kickstart => no match at end of input
+                            break;
                         if(matchFinalize())
                             return true;
-                        else
-                        {
-                            if(atEnd)
-                                break;
-                            search();
-                            if(atEnd)
-                            {
-                                exhausted = true;
-                                return matchFinalize();
-                            }
-                        }
+                        s.skipChar();
                     }
-                    exhausted = true;
-                    return false; //early return
                 }
             }
             //no search available - skip a char at a time
@@ -225,7 +194,7 @@ template BacktrackingMatcher(bool CTregex)
                 {
                     if(atEnd)
                         break;
-                    next();
+                    s.skipChar();
                     if(atEnd)
                     {
                         exhausted = true;
@@ -245,7 +214,7 @@ template BacktrackingMatcher(bool CTregex)
         {
             static if(CTregex && is(typeof(nativeFn(this))))
             {
-                    debug(std_regex_ctr) writeln("using C-T matcher");
+                debug(std_regex_ctr) writeln("using C-T matcher");
                 return nativeFn(this);
             }
             else
@@ -256,13 +225,14 @@ template BacktrackingMatcher(bool CTregex)
                 infiniteNesting = -1;//intentional
                 auto start = s._index;
                 debug(std_regex_matcher)
-                    writeln("Try match starting at ", s[index..s.lastIndex]);
+                    writeln("Try match starting at ", s.slice(s._index, s.lastIndex),
+                         is(typeof(s) == Input!Char) ? " " : " backwards");
                 for(;;)
                 {
                     debug(std_regex_matcher)
-                        writefln("PC: %s\tCNT: %s\t%s \tfront: %s src: %s",
+                        writefln("PC: %s\tCNT: %s\t%s \t src: %s",
                             pc, counter, disassemble(re.ir, pc, re.dict),
-                            front, s._index);
+                            s.slice(s._index, s.lastIndex));
                     switch(re.ir[pc].code)
                     {
                     case IR.OrChar://assumes IRL!(OrChar) == 1
@@ -270,123 +240,118 @@ template BacktrackingMatcher(bool CTregex)
                             goto L_backtrack;
                         uint len = re.ir[pc].sequence;
                         uint end = pc + len;
-                        if(re.ir[pc].data != front && re.ir[pc+1].data != front)
+                        if(!s.matchDChar(re.ir[pc].data) && !s.matchDChar(re.ir[pc+1].data))
                         {
                             for(pc = pc+2; pc < end; pc++)
-                                if(re.ir[pc].data == front)
+                                if(s.matchDChar(re.ir[pc].data))
                                     break;
                             if(pc == end)
                                 goto L_backtrack;
                         }
                         pc = end;
-                        next();
                         break;
                     case IR.Char:
-                        if(atEnd || front != re.ir[pc].data)
+                        if(atEnd || !s.matchDChar(re.ir[pc].data))
                             goto L_backtrack;
                         pc += IRL!(IR.Char);
-                        next();
                     break;
                     case IR.Any:
                         if(atEnd || (!(re.flags & RegexOption.singleline)
-                                && (front == '\r' || front == '\n')))
+                                && (s.front == '\r' || s.front == '\n')))
                             goto L_backtrack;
+                        s.skipChar();
                         pc += IRL!(IR.Any);
-                        next();
                         break;
                     case IR.CodepointSet:
-                        if(atEnd || !re.charsets[re.ir[pc].data].scanFor(front))
-                            goto L_backtrack;
-                        next();
-                        pc += IRL!(IR.CodepointSet);
-                        break;
                     case IR.Trie:
-                        if(atEnd || !re.tries[re.ir[pc].data][front])
+                        if(atEnd || !s.matchClass(re.matchers[re.ir[pc].data]))
                             goto L_backtrack;
-                        next();
                         pc += IRL!(IR.Trie);
                         break;
                     case IR.Wordboundary:
-                        dchar back;
-                        DataIndex bi;
                         //at start & end of input
-                        if(atStart && wordTrie[front])
+                        if(atStart)
                         {
-                            pc += IRL!(IR.Wordboundary);
-                            break;
+                            if(!atEnd && !wordTrie[s.peek])
+                                goto L_backtrack;
                         }
-                        else if(atEnd && s.loopBack(index).nextChar(back, bi)
-                                && wordTrie[back])
+                        else if(atEnd)
                         {
-                            pc += IRL!(IR.Wordboundary);
-                            break;
+                            if(!wordTrie[s.loopBack(s._index).peek])
+                                goto L_backtrack;
                         }
-                        else if(s.loopBack(index).nextChar(back, bi))
+                        else
                         {
-                            bool af = wordTrie[front];
-                            bool ab = wordTrie[back];
-                            if(af ^ ab)
-                            {
-                                pc += IRL!(IR.Wordboundary);
-                                break;
-                            }
+                            bool af = wordTrie[s.peek];
+                            bool ab = wordTrie[s.loopBack(s._index).peek];
+                            if((af ^ ab) == false)
+                                goto L_backtrack;
                         }
-                        goto L_backtrack;
+                        pc += IRL!(IR.Wordboundary);
+                        break;
                     case IR.Notwordboundary:
-                        dchar back;
-                        DataIndex bi;
                         //at start & end of input
-                        if(atStart && wordTrie[front])
-                            goto L_backtrack;
-                        else if(atEnd && s.loopBack(index).nextChar(back, bi)
-                                && wordTrie[back])
-                            goto L_backtrack;
-                        else if(s.loopBack(index).nextChar(back, bi))
+                        if(atStart)
                         {
-                            bool af = wordTrie[front];
-                            bool ab = wordTrie[back];
-                            if(af ^ ab)
+                            if(atEnd || wordTrie[s.peek])
+                                goto L_backtrack;
+                        }
+                        else if(atEnd)
+                        {
+                            if(wordTrie[s.loopBack(s._index).peek])
+                                goto L_backtrack;
+                        }
+                        else
+                        {
+                            bool af = wordTrie[s.peek];
+                            bool ab = wordTrie[s.loopBack(s._index).peek];
+                            if((af ^ ab) == true)
                                 goto L_backtrack;
                         }
                         pc += IRL!(IR.Wordboundary);
                         break;
                     case IR.Bol:
-                        dchar back;
-                        DataIndex bi;
                         if(atStart)
-                            pc += IRL!(IR.Bol);
-                        else if((re.flags & RegexOption.multiline)
-                            && s.loopBack(index).nextChar(back,bi)
-                            && endOfLine(back, front == '\n'))
                         {
                             pc += IRL!(IR.Bol);
+                            break;
                         }
-                        else
-                            goto L_backtrack;
-                        break;
+                        else if(re.flags & RegexOption.multiline)
+                        {
+                            bool seenNl = !atEnd && s.peek == '\n';
+                            if(startOfLine(s.loopBack(s._index), seenNl))
+                            {
+                                pc += IRL!(IR.Eol);
+                                break;
+                            }
+                        }
+                        goto L_backtrack;
                     case IR.Eol:
-                        dchar back;
-                        DataIndex bi;
-                        debug(std_regex_matcher) writefln("EOL (front 0x%x) %s", front, s[index..s.lastIndex]);
                         //no matching inside \r\n
-                        if(atEnd || ((re.flags & RegexOption.multiline)
-                            && endOfLine(front, s.loopBack(index).nextChar(back,bi)
-                                && back == '\r')))
+                        if(atEnd)
                         {
                             pc += IRL!(IR.Eol);
+                            break;
                         }
-                        else
-                            goto L_backtrack;
-                        break;
+                        else if(re.flags & RegexOption.multiline)
+                        {
+                            bool seenCr = !atStart && s.loopBack(s._index).peek == '\r';
+                            if(endOfLine(s, seenCr))
+                            {
+                                pc += IRL!(IR.Eol);
+                                break;
+                            }
+                        }
+                        goto L_backtrack;
                     case IR.InfiniteStart, IR.InfiniteQStart:
-                        trackers[infiniteNesting+1] = index;
+                        trackers[infiniteNesting+1] = s._index;
                         pc += re.ir[pc].data + IRL!(IR.InfiniteStart);
                         //now pc is at end IR.Infininite(Q)End
                         uint len = re.ir[pc].data;
                         int test;
                         if(re.ir[pc].code == IR.InfiniteEnd)
                         {
-                            test = quickTestFwd(pc+IRL!(IR.InfiniteEnd), front, re);
+                            test = quickTestNonDec(pc+IRL!(IR.InfiniteEnd), s, re);
                             if(test >= 0)
                                 pushState(pc+IRL!(IR.InfiniteEnd), counter);
                             infiniteNesting++;
@@ -394,7 +359,7 @@ template BacktrackingMatcher(bool CTregex)
                         }
                         else
                         {
-                            test = quickTestFwd(pc - len, front, re);
+                            test = quickTestNonDec(pc - len, s, re);
                             if(test >= 0)
                             {
                                 infiniteNesting++;
@@ -446,18 +411,18 @@ template BacktrackingMatcher(bool CTregex)
                         debug(std_regex_matcher) writeln("Infinited nesting:", infiniteNesting);
                         assert(infiniteNesting < trackers.length);
 
-                        if(trackers[infiniteNesting] == index)
+                        if(trackers[infiniteNesting] == s._index)
                         {//source not consumed
                             pc += IRL!(IR.InfiniteEnd);
                             infiniteNesting--;
                             break;
                         }
                         else
-                            trackers[infiniteNesting] = index;
+                            trackers[infiniteNesting] = s._index;
                         int test;
                         if(re.ir[pc].code == IR.InfiniteEnd)
                         {
-                            test = quickTestFwd(pc+IRL!(IR.InfiniteEnd), front, re);
+                            test = quickTestNonDec(pc+IRL!(IR.InfiniteEnd), s, re);
                             if(test >= 0)
                             {
                                 infiniteNesting--;
@@ -468,7 +433,7 @@ template BacktrackingMatcher(bool CTregex)
                         }
                         else
                         {
-                            test = quickTestFwd(pc-len, front, re);
+                            test = quickTestNonDec(pc-len, s, re);
                             if(test >= 0)
                                 pushState(pc-len, counter);
                             pc += IRL!(IR.InfiniteEnd);
@@ -494,20 +459,20 @@ template BacktrackingMatcher(bool CTregex)
                         break;
                     case IR.GroupStart:
                         uint n = re.ir[pc].data;
-                        matches[n].begin = index;
-                        debug(std_regex_matcher)  writefln("IR group #%u starts at %u", n, index);
+                        matches[n].begin = s._index;
+                        debug(std_regex_matcher)  writefln("IR group #%u starts at %u", n, s._index);
                         pc += IRL!(IR.GroupStart);
                         break;
                     case IR.GroupEnd:
                         uint n = re.ir[pc].data;
-                        matches[n].end = index;
-                        debug(std_regex_matcher) writefln("IR group #%u ends at %u", n, index);
+                        matches[n].end = s._index;
+                        debug(std_regex_matcher) writefln("IR group #%u ends at %u", n, s._index);
                         pc += IRL!(IR.GroupEnd);
                         break;
                     case IR.LookaheadStart:
                     case IR.NeglookaheadStart:
                         uint len = re.ir[pc].data;
-                        auto save = index;
+                        auto save = s._index;
                         uint ms = re.ir[pc+1].raw, me = re.ir[pc+2].raw;
                         auto mem = malloc(initialMemory(re))[0..initialMemory(re)];
                         scope(exit) free(mem.ptr);
@@ -523,8 +488,7 @@ template BacktrackingMatcher(bool CTregex)
                         matcher.backrefed = backrefed.empty ? matches : backrefed;
                         matcher.re.ir = re.ir[pc+IRL!(IR.LookaheadStart) .. pc+IRL!(IR.LookaheadStart)+len+IRL!(IR.LookaheadEnd)];
                         bool match = matcher.matchImpl() ^ (re.ir[pc].code == IR.NeglookaheadStart);
-                        s.reset(save);
-                        next();
+                        s._index = save;
                         if(!match)
                             goto L_backtrack;
                         else
@@ -541,12 +505,12 @@ template BacktrackingMatcher(bool CTregex)
                         static if(Stream.isLoopback)
                         {
                             alias Matcher = BacktrackingMatcher!(Char, Stream);
-                            auto matcher = Matcher(re, s, mem, front, index);
+                            auto matcher = Matcher(re, s, mem);
                         }
                         else
                         {
-                            alias Matcher = BacktrackingMatcher!(Char, typeof(s.loopBack(index)));
-                            auto matcher = Matcher(re, s.loopBack(index), mem);
+                            alias Matcher = BacktrackingMatcher!(Char, typeof(s.loopBack(s._index)));
+                            auto matcher = Matcher(re, s.loopBack(s._index), mem);
                         }
                         matcher.matches = matches[ms .. me];
                         matcher.re.ir = re.ir[pc + IRL!(IR.LookbehindStart) .. pc + IRL!(IR.LookbehindStart) + len + IRL!(IR.LookbehindEnd)];
@@ -562,19 +526,26 @@ template BacktrackingMatcher(bool CTregex)
                     case IR.Backref:
                         uint n = re.ir[pc].data;
                         auto referenced = re.ir[pc].localRef
-                                ? s[matches[n].begin .. matches[n].end]
-                                : s[backrefed[n].begin .. backrefed[n].end];
-                        while(!atEnd && !referenced.empty && front == referenced.front)
+                                ? s.slice(matches[n].begin, matches[n].end)
+                                : s.slice(backrefed[n].begin, backrefed[n].end);
+                        import std.string, std.algorithm;
+                        static if(Stream.isLoopback)
                         {
-                            next();
-                            referenced.popFront();
+                            import std.range;
+                            if(skipOver(s, referenced.representation.retro))
+                                pc++;
+                            else
+                                goto L_backtrack;
                         }
-                        if(referenced.empty)
-                            pc++;
                         else
-                            goto L_backtrack;
+                        {
+                            if(skipOver(s, referenced.representation))
+                                pc++;
+                            else
+                                goto L_backtrack;
+                        }
                         break;
-                        case IR.Nop:
+                    case IR.Nop:
                         pc += IRL!(IR.Nop);
                         break;
                     case IR.LookaheadEnd:
@@ -666,7 +637,7 @@ template BacktrackingMatcher(bool CTregex)
                     lastState = 0;
                 }
                 *cast(State*)&memory[lastState] =
-                    State(index, pc, counter, infiniteNesting);
+                    State(s._index, pc, counter, infiniteNesting);
                 lastState += stateSize;
                 memory[lastState .. lastState + 2 * matches.length] = (cast(size_t[])matches)[];
                 lastState += 2*matches.length;
@@ -676,8 +647,8 @@ template BacktrackingMatcher(bool CTregex)
                     lastState += trackers.length;
                 }
                 debug(std_regex_matcher)
-                    writefln("Saved(pc=%s) front: %s src: %s",
-                        pc, front, s[index..s.lastIndex]);
+                    writefln("Saved(pc=%s) src: %s",
+                        pc,  s.slice(s._index, s.lastIndex));
             }
 
             //helper function, restores engine state
@@ -695,21 +666,19 @@ template BacktrackingMatcher(bool CTregex)
                 pm[] = memory[lastState .. lastState + 2 * matches.length];
                 lastState -= stateSize;
                 State* state = cast(State*)&memory[lastState];
-                index = state.index;
+                s._index = state.index;
                 pc = state.pc;
                 counter = state.counter;
                 infiniteNesting = state.infiniteNesting;
                 debug(std_regex_matcher)
                 {
-                    writefln("Restored matches", front, s[index .. s.lastIndex]);
+                    writefln("Restored matches", s.slice(s._index, s.lastIndex));
                     foreach(i, m; matches)
                         writefln("Sub(%d) : %s..%s", i, m.begin, m.end);
                 }
-                s.reset(index);
-                next();
                 debug(std_regex_matcher)
-                    writefln("Backtracked (pc=%s) front: %s src: %s",
-                        pc, front, s[index..s.lastIndex]);
+                    writefln("Backtracked (pc=%s) src: %s",
+                        pc, s.slice(s._index, s.lastIndex));
                 return true;
             }
         }
@@ -834,7 +803,7 @@ struct CtContext
         text ~= counter ? ctSub("
                     stackPush($$);", count_expr) : "";
         text ~= ctSub("
-                    stackPush(index); stackPush($$); \n", pc);
+                    stackPush(s._index); stackPush($$); \n", pc);
         return text;
     }
 
@@ -921,7 +890,7 @@ struct CtContext
                         $$
                         //(neg)lookaround piece ends
                     }
-                    auto save = index;
+                    auto save = s._index;
                     auto mem = malloc(initialMemory(re))[0..initialMemory(re)];
                     scope(exit) free(mem.ptr);
                     static if(typeof(matcher.s).isLoopback)
@@ -932,8 +901,7 @@ struct CtContext
                     lookaround.backrefed = backrefed.empty ? matches : backrefed;
                     lookaround.nativeFn = &matcher_$$; //hookup closure's binary code
                     bool match = $$;
-                    s.reset(save);
-                    next();
+                    s._index = save;
                     if(match)
                         $$
                     else
@@ -1023,11 +991,11 @@ struct CtContext
         case IR.InfiniteEnd:
             testCode = ctQuickTest(ir[IRL!(IR.InfiniteEnd) .. $],addr + 1);
             r ~= ctSub( `
-                    if(trackers[$$] == index)
+                    if(trackers[$$] == s._index)
                     {//source not consumed
                         goto case $$;
                     }
-                    trackers[$$] = index;
+                    trackers[$$] = s._index;
 
                     $$
                     {
@@ -1045,11 +1013,11 @@ struct CtContext
             testCode = ctQuickTest(ir[IRL!(IR.InfiniteEnd) .. $],addr + 1);
             auto altCode = testCode.length ? ctSub("else goto case $$;", fixup) : "";
             r ~= ctSub( `
-                    if(trackers[$$] == index)
+                    if(trackers[$$] == s._index)
                     {//source not consumed
                         goto case $$;
                     }
-                    trackers[$$] = index;
+                    trackers[$$] = s._index;
 
                     $$
                     {
@@ -1148,7 +1116,7 @@ struct CtContext
                 break;
             else
             {
-                auto code = ctAtomCode(ir[pc..$], -1);
+                string code = ctAtomCode(ir[pc..$], -1);
                 return ctSub(`
                     int test_$$()
                     {
@@ -1174,171 +1142,164 @@ struct CtContext
     //D code for atom at ir using address addr, addr < 0 means quickTest
     string ctAtomCode(Bytecode[] ir, int addr)
     {
-        string code;
+        string load, code;
         string bailOut, nextInstr;
         if(addr < 0)
         {
+            load = "if(atEnd) return -1;";
             bailOut = "return -1;";
             nextInstr = "return 0;";
         }
         else
         {
+            load = "if(atEnd) goto L_backtrack;";
             bailOut = "goto L_backtrack;";
             nextInstr = ctSub("goto case $$;", addr+1);
             code ~=  ctSub( `
-                 case $$: debug(std_regex_matcher) writeln("#$$");
-                    `, addr, addr);
+                 case $$: debug(std_regex_matcher) writefln("#$$ $$ src: %s",
+                    s.slice(s._index, s.lastIndex));
+                `, addr, addr, ir[0].mnemonic);
         }
         switch(ir[0].code)
         {
         case IR.OrChar://assumes IRL!(OrChar) == 1
-            code ~=  ctSub(`
-                    if(atEnd)
-                        $$`, bailOut);
+            code ~= load;
             uint len = ir[0].sequence;
             for(uint i = 0; i < len; i++)
             {
                 code ~= ctSub( `
-                    if(front == $$)
-                    {
+                    if(s.$$DChar($$))
                         $$
-                        $$
-                    }`,   ir[i].data, addr >= 0 ? "next();" :"", nextInstr);
+                    `,  addr < 0 ? "test" : "match", ir[i].data, nextInstr);
             }
             code ~= ctSub( `
-                $$`, bailOut);
+                    $$`, bailOut);
             break;
         case IR.Char:
+            code ~= load;
             code ~= ctSub( `
-                    if(atEnd || front != $$)
+                    if(!s.$$DChar($$))
                         $$
-                    $$
-                    $$`, ir[0].data, bailOut, addr >= 0 ? "next();" :"", nextInstr);
+                    $$`, addr < 0 ? "test" : "match", ir[0].data, bailOut, nextInstr);
             break;
         case IR.Any:
-            code ~= ctSub( `
-                    if(atEnd || (!(re.flags & RegexOption.singleline)
-                                && (front == '\r' || front == '\n')))
+            code ~= load;
+            code ~= ctSub(`
+                    if(!(re.flags & RegexOption.singleline)
+                                && (s.front == '\r' || s.front == '\n'))
                         $$
                     $$
-                    $$`, bailOut, addr >= 0 ? "next();" :"",nextInstr);
+                    $$`, bailOut, addr < 0 ? "" : "s.skipChar();", nextInstr);
             break;
         case IR.CodepointSet:
-            code ~= ctSub( `
-                    if(atEnd || !re.charsets[$$].scanFor(front))
-                        $$
-                    $$
-                $$`, ir[0].data, bailOut, addr >= 0 ? "next();" :"", nextInstr);
-            break;
         case IR.Trie:
+            code ~= load;
             code ~= ctSub( `
-                    if(atEnd || !re.tries[$$][front])
+                    if(!$$Class(s, re.matchers[$$]))
                         $$
-                    $$
-                $$`, ir[0].data, bailOut, addr >= 0 ? "next();" :"", nextInstr);
+                    $$`,  addr < 0 ? "test" : "match", ir[0].data, bailOut, nextInstr);
             break;
         case IR.Wordboundary:
             code ~= ctSub( `
-                    dchar back;
-                    DataIndex bi;
-                    if(atStart && wordTrie[front])
+                    if(atStart)
                     {
-                        $$
-                    }
-                    else if(atEnd && s.loopBack(index).nextChar(back, bi)
-                            && wordTrie[back])
-                    {
-                        $$
-                    }
-                    else if(s.loopBack(index).nextChar(back, bi))
-                    {
-                        bool af = wordTrie[front];
-                        bool ab = wordTrie[back];
-                        if(af ^ ab)
-                        {
+                        if(!atEnd && !wordTrie[s.peek])
                             $$
-                        }
                     }
-                    $$`, nextInstr, nextInstr, nextInstr, bailOut);
+                    else if(atEnd)
+                    {
+                        if(!wordTrie[s.loopBack(s._index).peek])
+                            $$
+                    }
+                    else
+                    {
+                        bool af = wordTrie[s.peek];
+                        bool ab = wordTrie[s.loopBack(s._index).peek];
+                        if((af ^ ab) == false)
+                            $$
+                    }
+                    $$
+                    `, bailOut, bailOut, bailOut, nextInstr);
             break;
         case IR.Notwordboundary:
             code ~= ctSub( `
-                    dchar back;
-                    DataIndex bi;
-                    //at start & end of input
-                    if(atStart && wordTrie[front])
-                        $$
-                    else if(atEnd && s.loopBack(index).nextChar(back, bi)
-                            && wordTrie[back])
-                        $$
-                    else if(s.loopBack(index).nextChar(back, bi))
+                    if(atStart)
                     {
-                        bool af = wordTrie[front];
-                        bool ab = wordTrie[back];
-                        if(af ^ ab)
+                        if(atEnd || wordTrie[s.peek])
                             $$
                     }
-                    $$`, bailOut, bailOut, bailOut, nextInstr);
+                    else if(atEnd)
+                    {
+                        if(wordTrie[s.loopBack(s._index).peek])
+                            $$
+                    }
+                    else
+                    {
+                        bool af = wordTrie[s.peek];
+                        bool ab = wordTrie[s.loopBack(s._index).peek];
+                        if((af ^ ab) == true)
+                            $$
+                    }
+                    $$
+                    `, bailOut, bailOut, bailOut, nextInstr);
 
             break;
         case IR.Bol:
             code ~= ctSub(`
-                    dchar back;
-                    DataIndex bi;
-                    if(atStart || ((re.flags & RegexOption.multiline)
-                        && s.loopBack(index).nextChar(back,bi)
-                        && endOfLine(back, front == '\n')))
+                    if(atStart)
                     {
-                        debug(std_regex_matcher) writeln("BOL matched");
                         $$
                     }
-                    else
-                        $$`, nextInstr, bailOut);
+                    else if(re.flags & RegexOption.multiline)
+                    {
+                        bool seenNl = !atEnd && s.peek == '\n';
+                        if(startOfLine(s.loopBack(s._index), seenNl))
+                        {
+                            $$
+                        }
+                    }
+                    $$`, nextInstr, nextInstr, bailOut);
 
             break;
         case IR.Eol:
             code ~= ctSub(`
-                    dchar back;
-                    DataIndex bi;
-                    debug(std_regex_matcher) writefln("EOL (front 0x%x) %s", front, s[index..s.lastIndex]);
-                    //no matching inside \r\n
-                    if(atEnd || ((re.flags & RegexOption.multiline)
-                            && endOfLine(front, s.loopBack(index).nextChar(back,bi)
-                             && back == '\r')))
+                    if(atEnd)
                     {
-                        debug(std_regex_matcher) writeln("EOL matched");
                         $$
                     }
-                    else
-                        $$`, nextInstr, bailOut);
+                    else if(re.flags & RegexOption.multiline)
+                    {
+                        bool seenCr = !atStart && s.loopBack(s._index).peek == '\r';
+                        if(endOfLine(s, seenCr))
+                        {
+                            $$
+                        }
+                    }
+                    $$`, nextInstr, nextInstr, bailOut);
 
             break;
         case IR.GroupStart:
             code ~= ctSub(`
-                    matches[$$].begin = index;
+                    matches[$$].begin = s._index;
                     $$`, ir[0].data, nextInstr);
             match = ir[0].data+1;
             break;
         case IR.GroupEnd:
             code ~= ctSub(`
-                    matches[$$].end = index;
+                    matches[$$].end = s._index;
                     $$`, ir[0].data, nextInstr);
             break;
         case IR.Backref:
             string mStr = "auto referenced = ";
             mStr ~= ir[0].localRef
-                ? ctSub("s[matches[$$].begin .. matches[$$].end];",
+                ? ctSub("s.slice(matches[$$].begin, matches[$$].end);",
                     ir[0].data, ir[0].data)
-                : ctSub("s[backrefed[$$].begin .. backrefed[$$].end];",
+                : ctSub("s.slice(backrefed[$$].begin, backrefed[$$].end);",
                     ir[0].data, ir[0].data);
             code ~= ctSub( `
                     $$
-                    while(!atEnd && !referenced.empty && front == referenced.front)
-                    {
-                        next();
-                        referenced.popFront();
-                    }
-                    if(referenced.empty)
+                    import std.string, std.algorithm;
+                    if(skipOver(s, referenced.representation))
                         $$
                     else
                         $$`, mStr, nextInstr, bailOut);
@@ -1366,14 +1327,12 @@ struct CtContext
             auto start = s._index;`;
         r ~= `
             goto StartLoop;
-            debug(std_regex_matcher) writeln("Try CT matching  starting at ",s[index..s.lastIndex]);
+            debug(std_regex_matcher) writeln("Try CT matching  starting at ", s.slice(s._index, s.lastIndex));
         L_backtrack:
             if(lastState || prevStack())
             {
                 stackPop(pc);
-                stackPop(index);
-                s.reset(index);
-                next();
+                stackPop(s._index);
             }
             else
             {

--- a/std/regex/internal/ir.d
+++ b/std/regex/internal/ir.d
@@ -589,16 +589,6 @@ struct Input(Char)
         _index += std.utf.stride(_origin, _index);
     }
 
-    //codepoint at current stream position
-    bool nextChar(ref dchar res, ref size_t pos)
-    {
-        pos = _index;
-        if(_index == _origin.length)
-            return false;
-        res = std.utf.decode(_origin, _index);
-        return true;
-    }
-
     @property bool atEnd()
     {
         return _index == _origin.length;
@@ -656,18 +646,6 @@ struct Input(Char)
             _index -= std.utf.strideBack(_origin, _index);
         }
 
-        @trusted bool nextChar(ref dchar res,ref size_t pos)
-        {
-            pos = _index;
-            if(_index == 0)
-                return false;
-
-            res = _origin[0.._index].back;
-            _index -= std.utf.strideBack(_origin, _index);
-
-            return true;
-        }
-
         @property atEnd(){ return _index == 0; }
         auto loopBack(size_t index){   return Input(_origin, index); }
 
@@ -683,16 +661,6 @@ struct Input(Char)
     auto loopBack(size_t index){   return BackLooper(this, index); }
 }
 
-//transitional helper
-dchar peek(Stream)(auto ref Stream s)
-{
-    dchar ch;
-    size_t dummy;
-    auto i = s._index;
-    s.nextChar(ch, dummy);
-    s._index = i;
-    return ch;
-}
 
 unittest
 {

--- a/std/regex/internal/ir.d
+++ b/std/regex/internal/ir.d
@@ -17,32 +17,9 @@ alias BasicElementOf(Range) = Unqual!(ElementEncodingType!Range);
 // heuristic value determines maximum CodepointSet length suitable for linear search
 enum maxCharsetUsed = 6;
 
-// another variable to tweak behavior of caching generated Tries for character classes
-enum maxCachedTries = 8;
-
 alias Trie = CodepointSetTrie!(13, 8);
 alias makeTrie = codepointSetTrie!(13, 8);
 
-Trie[CodepointSet] trieCache;
-
-//accessor with caching
-@trusted Trie getTrie(CodepointSet set)
-{// @@@BUG@@@ 6357 almost all properties of AA are not @safe
-    if(__ctfe || maxCachedTries == 0)
-        return makeTrie(set);
-    else
-    {
-        auto p = set in trieCache;
-        if(p)
-            return *p;
-        if(trieCache.length == maxCachedTries)
-        {
-            // flush entries in trieCache
-            trieCache = null;
-        }
-        return (trieCache[set] = makeTrie(set));
-    }
-}
 
 @trusted auto memoizeExpr(string expr)()
 {
@@ -435,7 +412,7 @@ struct Group(DataIndex)
     This is an intended form for caching and storage of frequently
     used regular expressions.
 +/
-struct Regex(Char)
+public struct Regex(Char)
 {
     //temporary workaround for identifier lookup
     CodepointSet[] charsets; //
@@ -497,7 +474,7 @@ package(std.regex):
     uint hotspotTableSize; //number of entries in merge table
     uint threadCount;
     uint flags;         //global regex flags
-    public const(Trie)[]  tries; //
+    public UtfMatcher!Char[] matchers; //
     uint[] backrefed; //bit array of backreferenced submatches
     Kickstart!Char kickstart;
 
@@ -577,12 +554,34 @@ struct Input(Char)
     alias String = const(Char)[];
     String _origin;
     size_t _index;
-
+    pure nothrow
+    {
     //constructs Input object out of plain string
     this(String input, size_t idx = 0)
     {
         _origin = input;
         _index = idx;
+    }
+
+        //make it range of Char
+        @property bool empty(){ return _index == _origin.length; }
+        @property auto front(){ return _origin[_index]; }
+        void popFront(){  _index++; }
+        void popFrontN(size_t n){  _index += n; }
+        //back direction is not really used - it's just to qualify as RA
+        @property auto back(){ return _origin[$-1]; }
+        void popBack(){ _origin = _origin[0..$-1]; }
+        @property auto save(){ return this; }
+        ref opIndex(size_t ofs){ return _origin[_index+ofs]; }
+        //hackish
+        auto opSlice(size_t s, size_t e){ return Input(_origin[0..$], _index+s); }
+        @property size_t length(){ return _origin.length - _index; }
+        alias opDollar = length;
+    }
+
+    void skipChar()
+    {
+        _index += std.utf.stride(_origin, _index);
     }
 
     //codepoint at current stream position
@@ -594,23 +593,22 @@ struct Input(Char)
         res = std.utf.decode(_origin, _index);
         return true;
     }
-    @property bool atEnd(){
-        return _index == _origin.length;
-    }
-    bool search(Kickstart)(ref Kickstart kick, ref dchar res, ref size_t pos)
+
+    @property bool atEnd()
     {
-        size_t idx = kick.search(_origin, _index);
-        _index = idx;
-        return nextChar(res, pos);
+        return _index == _origin.length;
     }
 
     //index of at End position
     @property size_t lastIndex(){   return _origin.length; }
 
+    auto stride() { return std.utf.stride(_origin, _index); }
+
     //support for backtracker engine, might not be present
     void reset(size_t index){   _index = index;  }
 
-    String opSlice(size_t start, size_t end){   return _origin[start..end]; }
+    //slice using global offsets
+    String slice(size_t start, size_t end){   return _origin[start..end]; }
 
     struct BackLooper
     {
@@ -618,11 +616,41 @@ struct Input(Char)
         enum { isLoopback = true };
         String _origin;
         size_t _index;
+        pure nothrow
+        {
         this(Input input, size_t index)
         {
             _origin = input._origin;
             _index = index;
         }
+            this(String input, size_t index)
+            {
+                _origin = input;
+                _index = index;
+            }
+            //make it range of Char
+            @property bool empty(){ return _index == 0; }
+            @property auto front(){ return _origin[_index-1]; }
+            void popFront(){  _index--; }
+            void popFrontN(size_t n){  _index -= n; }
+            //back direction is not really used - it's just to qualify as RA
+            @property auto back(){ return _origin[0]; }
+            void popBack(){ _origin = _origin[1..$]; }
+            @property auto save(){ return this; }
+            ref opIndex(size_t ofs){ return _origin[_index-1-ofs]; }
+            //hackish
+            auto opSlice(size_t s, size_t e){ return BackLooper(_origin, _index-s); }
+            @property size_t length(){ return _index; }
+            alias opDollar = length;
+        }
+
+        auto stride() { return std.utf.strideBack(_origin, _index); }
+
+        void skipChar()
+        {
+            _index -= std.utf.strideBack(_origin, _index);
+        }
+
         @trusted bool nextChar(ref dchar res,ref size_t pos)
         {
             pos = _index;
@@ -634,20 +662,153 @@ struct Input(Char)
 
             return true;
         }
-        @property atEnd(){ return _index == 0 || _index == std.utf.strideBack(_origin, _index); }
+
+        @property atEnd(){ return _index == 0; }
         auto loopBack(size_t index){   return Input(_origin, index); }
 
         //support for backtracker engine, might not be present
-        //void reset(size_t index){   _index = index ? index-std.utf.strideBack(_origin, index) : 0;  }
         void reset(size_t index){   _index = index;  }
 
-        String opSlice(size_t start, size_t end){   return _origin[end..start]; }
+        //slice using global offsets
+        String slice(size_t start, size_t end){  return _origin[start..end]; }
+
         //index of at End position
         @property size_t lastIndex(){   return 0; }
     }
     auto loopBack(size_t index){   return BackLooper(this, index); }
 }
 
+//transitional helper
+dchar peek(Stream)(auto ref Stream s)
+{
+    dchar ch;
+    size_t dummy;
+    auto i = s._index;
+    s.nextChar(ch, dummy);
+    s._index = i;
+    return ch;
+}
+
+unittest
+{
+    import std.range;
+    static assert(isRandomAccessRange!(Input!char));
+    static assert(isRandomAccessRange!(Input!char.BackLooper));
+}
+
+bool matchDChar(Stream)(ref Stream s, dchar ch)
+{
+    alias Char = Unqual!(typeof(s.front));
+    static if(is(Char == dchar))
+    {
+        if(ch == s.front)
+        {
+            s.popFront();
+            return true;
+        }
+        return false;
+    }
+    else
+    {
+        if(ch <= 0x7F)
+        {
+            if(s.front == ch)
+            {
+                s.popFront();
+                return true;
+            }
+            return false;
+        }
+        Char[dchar.sizeof/Char.sizeof] buf;
+        size_t cnt = std.utf.encode(buf, ch);
+        if(s.length < cnt)
+            return false;
+        static if(Stream.isLoopback) // look at UTF array backwards
+            for(size_t i=0; i<cnt; i++)
+            {
+                if(s[i] != buf[cnt-1-i])
+                    return false;
+            }
+        else
+            for(size_t i=0; i<cnt; i++)
+            {
+                if(s[i] != buf[i])
+                    return false;
+            }
+        s.popFrontN(cnt);
+        return true;
+    }
+}
+
+bool testDChar(Stream)(ref Stream s, dchar ch)
+{
+    alias Char = Unqual!(typeof(s.front));
+    static if(is(Char == dchar))
+        return ch == s.front;
+    else
+        return ch <= 0x7F ? s.front == ch : slowTestDChar(s, ch);
+}
+
+bool slowTestDChar(Stream)(ref Stream s, dchar ch)
+{
+    alias Char = Unqual!(typeof(s.front));
+    Char[dchar.sizeof/Char.sizeof] buf=void;
+    size_t cnt = std.utf.encode(buf, ch);
+    if(s.length < cnt)
+        return false;
+     static if(Stream.isLoopback) // look at UTF array backwards
+            for(size_t i=0; i<cnt; i++)
+            {
+                if(s[i] != buf[cnt-1-i])
+                    return false;
+            }
+        else
+            for(size_t i=0; i<cnt; i++)
+            {
+                if(s[i] != buf[i])
+                    return false;
+            }
+    return true;
+}
+
+bool matchClass(Stream, Matcher)(ref Stream s, ref Matcher m)
+{
+    static if(!Stream.isLoopback)
+    {
+        return m.skip(s);
+    }
+    else
+    {
+        //TODO: backward matchers ?
+        alias C = typeof(s.front);
+        Unqual!C[dchar.sizeof/C.sizeof] buf=void;
+        uint step = s.stride;
+        foreach(i; 0..step)
+            buf[step-1-i] = s[i];
+        s.popFrontN(step);
+        C[] r = buf[0..step];
+        return m.test(r);
+    }
+}
+
+bool testClass(Stream, Matcher)(ref Stream s, ref Matcher m)
+{
+    static if(!Stream.isLoopback)
+    {
+        return m.test(s);
+    }
+    else
+    {
+        //TODO: backward matchers ?
+        alias C = typeof(s.front);
+        Unqual!C[dchar.sizeof/C.sizeof] buf=void;
+        uint step = s.stride;
+        foreach(i; 0..step)
+            buf[step-1-i] = s[i];
+        C[] r = buf[0..step];
+        return m.test(r);
+    }
+}
 
 //both helpers below are internal, on its own are quite "explosive"
 //unsafe, no initialization of elements
@@ -665,71 +826,128 @@ struct Input(Char)
     return ret;
 }
 
+//ditto, class instance
+@system T allocateInChunk(T, Args...)(ref void[] chunk, Args args)
+    if(is(T == class))
+{
+    import std.conv: emplace;
+    enum len = __traits(classInstanceSize, T);
+    auto ret = emplace!T(chunk, args);
+    chunk = chunk[len .. $];
+    return ret;
+}
+
+//ditto, structs
+@system T* allocateInChunk(T, Args...)(ref void[] chunk, Args args)
+        if(is(T == struct))
+{
+    import std.conv: emplace;
+    enum len = T.sizeof;
+    auto ret = emplace!T(chunk, args);
+    chunk = chunk[len .. $];
+    return ret;
+}
+
 //
 @trusted uint lookupNamedGroup(String)(NamedGroup[] dict, String name)
 {//equal is @system?
-    import std.conv;
-    import std.algorithm : map, equal;
-
+    import std.conv, std.algorithm.iteration, std.algorithm.comparison;
     auto fnd = assumeSorted!"cmp(a,b) < 0"(map!"a.name"(dict)).lowerBound(name).length;
     enforce(fnd < dict.length && equal(dict[fnd].name, name),
         text("no submatch named ", name));
     return dict[fnd].group;
 }
 
-//whether ch is one of unicode newline sequences
-//0-arg template due to @@@BUG@@@ 10985
-bool endOfLine()(dchar front, bool seenCr)
+
+// match extended new line characters > 0x80
+bool matchExtNl(Stream)(Stream s)
 {
-    return ((front == '\n') ^ seenCr) || front == '\r'
-    || front == NEL || front == LS || front == PS;
+    immutable c = s.front;
+    static if(is(ElementType!Stream : char))
+    {
+        static if(Stream.isLoopback)
+        {
+            if(c == 133) // NEL
+                return s.length > 1 && s[1] == 194;
+            else if(c == 168) // LS
+                return s.length > 2 && s[1] == 128 && s[2] == 226;
+            else if(c == 169) // PS
+                return s.length > 2 && s[1] == 128 && s[2] == 226;
+        }
+        else
+        {
+            if(c == 194) // NEL
+                return s.length > 1 && s[1] == 133;
+            else if(c == 226) // LS and PS
+            {
+                if(s.length > 2 && s[1] == 128)
+                    return s[2] == 168 || s[2] == 169;
+            }
+        }
+        return false;
+    }
+    else // fits in UTF-16/UTF-32
+        return c == NEL || c == LS || c == PS;
 }
 
-//
+//whether stream s is at one of unicode newline sequences
+// ('s' is looking forward, seenCr - have we just skipped '\r')
 //0-arg template due to @@@BUG@@@ 10985
-bool startOfLine()(dchar back, bool seenNl)
+bool endOfLine(Stream)(Stream s, bool seenCr)
 {
-    return ((back == '\r') ^ seenNl) || back == '\n'
-    || back == NEL || back == LS || back == PS;
+    immutable c = s.front;
+    if(((c == '\n') ^ seenCr) || c == '\r')
+        return true;
+    else
+        return matchExtNl(s);
+}
+
+//whether stream is at start of new line
+// ('s' is looking back, seenNl is - do we see '\n' at current position)
+//0-arg template due to @@@BUG@@@ 10985
+bool startOfLine(Stream)(Stream s, bool seenNl)
+{
+    immutable c = s.front;
+    if(((c == '\r') ^ seenNl) || c == '\n')
+        return true;
+    else
+        return matchExtNl(s);
 }
 
 //Test if bytecode starting at pc in program 're' can match given codepoint
 //Returns: 0 - can't tell, -1 if doesn't match
-int quickTestFwd(RegEx)(uint pc, dchar front, const ref RegEx re)
+int quickTestNonDec(RegEx, Stream)(uint pc, ref Stream s, const ref RegEx re)
 {
-    static assert(IRL!(IR.OrChar) == 1);//used in code processing IR.OrChar
     for(;;)
         switch(re.ir[pc].code)
         {
         case IR.OrChar:
+            if(s.atEnd)
+                return -1;
             uint len = re.ir[pc].sequence;
             uint end = pc + len;
-            if(re.ir[pc].data != front && re.ir[pc+1].data != front)
+            if(!s.testDChar(re.ir[pc].data) && !s.testDChar(re.ir[pc+1].data))
             {
                 for(pc = pc+2; pc < end; pc++)
-                    if(re.ir[pc].data == front)
+                    if(s.testDChar(re.ir[pc].data))
                         break;
                 if(pc == end)
                     return -1;
             }
             return 0;
         case IR.Char:
-            if(front == re.ir[pc].data)
+            if(!s.atEnd && s.testDChar(re.ir[pc].data))
                 return 0;
             else
                 return -1;
         case IR.Any:
-            return 0;
-        case IR.CodepointSet:
-            if(re.charsets[re.ir[pc].data].scanFor(front))
-                return 0;
-            else
-                return -1;
+            return s.atEnd ? -1 : 0;
         case IR.GroupStart, IR.GroupEnd:
             pc += IRL!(IR.GroupStart);
             break;
+        case IR.CodepointSet:
         case IR.Trie:
-            if(re.tries[re.ir[pc].data][front])
+            if(!s.atEnd && s.testClass(re.matchers[re.ir[pc].data]))
                 return 0;
             else
                 return -1;

--- a/std/regex/internal/thompson.d
+++ b/std/regex/internal/thompson.d
@@ -13,6 +13,8 @@ package(std.regex):
 import std.regex.internal.ir;
 import std.range;
 
+debug(std_regex_matcher) import std.stdio;
+
 //State of VM thread
 struct Thread(DataIndex)
 {
@@ -86,6 +88,74 @@ struct ThreadList(DataIndex)
     }
 }
 
+// What is at front of range - nothing, single code unit (<= ASCII), full codepoint ( > ASCII)
+enum InputKind { None=0, Unit, Point };
+
+// Thompson doesn't do quick test on empty input, and it knows ASCII vs non-ASCII
+int quickTestKnown(InputKind kind, RegEx, Stream)(uint pc, ref Stream s, ref RegEx re)
+{
+    for(;;)
+        switch(re.ir[pc].code) with (InputKind)
+        {
+            static if(kind == Point || is(dchar : typeof(s.front)))
+            {
+        case IR.OrChar:
+                uint len = re.ir[pc].sequence;
+                uint end = pc + len;
+                if(!s.testDChar(re.ir[pc].data) && !s.testDChar(re.ir[pc+1].data))
+                {
+                    for(pc = pc+2; pc < end; pc++)
+                        if(s.testDChar(re.ir[pc].data))
+                            break;
+                    if(pc == end)
+                        return -1;
+                }
+                return 0;
+        case IR.Char:
+                return s.testDChar(re.ir[pc].data) ? 0 : -1;
+        case IR.CodepointSet:
+        case IR.Trie:
+                if(s.testClass(re.matchers[re.ir[pc].data]))
+                    return 0;
+                else
+                    return -1;
+            }
+            else
+            {
+        case IR.OrChar:
+                uint len = re.ir[pc].sequence;
+                uint end = pc + len;
+                immutable c = s.front;
+                if(c != re.ir[pc].data && c != re.ir[pc+1].data)
+                {
+                    for(pc = pc+2; pc < end; pc++)
+                        if(c == re.ir[pc].data)
+                            break;
+                    if(pc == end)
+                        return -1;
+                }
+                return 0;
+        case IR.Char:
+                return s.front == re.ir[pc].data ? 0 : -1;
+        case IR.CodepointSet:
+        case IR.Trie:
+                if(re.matchers[re.ir[pc].data].subMatcher!1.test(s))
+                    return 0;
+                else
+                    return -1;
+            }
+        case IR.GroupStart, IR.GroupEnd:
+            pc += IRL!(IR.GroupStart);
+            break;
+
+        case IR.Any:
+        default:
+            return 0;
+        }
+    assert(0);
+}
+
+
 /+
    Thomspon matcher does all matching in lockstep,
    never looking at the same char twice
@@ -100,8 +170,6 @@ struct ThreadList(DataIndex)
     Group!DataIndex[] backrefed;
     Regex!Char re;           //regex program
     Stream s;
-    dchar front;
-    DataIndex index;
     DataIndex genCounter;    //merge trace counter, goes up on every dchar
     size_t[size_t] subCounters; //a table of gen counter per sub-engine: PC -> counter
     size_t threadSize;
@@ -127,34 +195,10 @@ struct ThreadList(DataIndex)
     }
 
     //true if it's start of input
-    @property bool atStart(){   return index == 0; }
+    @property bool atStart(){   return s._index == 0; }
 
     //true if it's end of input
-    @property bool atEnd(){  return index == s.lastIndex && s.atEnd; }
-
-    bool next()
-    {
-        if(!s.nextChar(front, index))
-        {
-            index =  s.lastIndex;
-            return false;
-        }
-        return true;
-    }
-
-    static if(kicked)
-    {
-        bool search()
-        {
-
-            if(!s.search(re.kickstart, front, index))
-            {
-                index = s.lastIndex;
-                return false;
-            }
-            return true;
-        }
-    }
+    @property bool atEnd(){  return s.atEnd; }
 
     void initExternalMemory(void[] memory)
     {
@@ -183,8 +227,6 @@ struct ThreadList(DataIndex)
         threadSize = matcher.threadSize;
         merge = matcher.merge;
         freelist = matcher.freelist;
-        front = matcher.front;
-        index = matcher.index;
     }
 
     auto fwdMatcher()(Bytecode[] piece, size_t counter)
@@ -196,10 +238,9 @@ struct ThreadList(DataIndex)
 
     auto bwdMatcher()(Bytecode[] piece, size_t counter)
     {
-        alias BackLooper = typeof(s.loopBack(index));
-        auto m = ThompsonMatcher!(Char, BackLooper)(this, piece, s.loopBack(index));
+        alias BackLooper = typeof(s.loopBack(s._index));
+        auto m = ThompsonMatcher!(Char, BackLooper)(this, piece, s.loopBack(s._index));
         m.genCounter = counter;
-        m.next();
         return m;
     }
 
@@ -209,12 +250,6 @@ struct ThreadList(DataIndex)
         tmp.initExternalMemory(memory);
         tmp.genCounter = 0;
         return tmp;
-    }
-
-    enum MatchResult{
-        NoMatch,
-        PartialMatch,
-        Match,
     }
 
     bool match(Group!DataIndex[] matches)
@@ -227,38 +262,30 @@ struct ThreadList(DataIndex)
         }
         if(re.flags & RegexInfo.oneShot)
         {
-            next();
             exhausted = true;
-            return matchOneShot(matches)==MatchResult.Match;
+            return matchOneShot(matches);
         }
         static if(kicked)
             if(!re.kickstart.empty)
-                return matchImpl!(true)(matches);
-        return matchImpl!(false)(matches);
+                return matchImpl!(true, true)(matches);
+        return matchImpl!(false, true)(matches);
     }
 
     //match the input and fill matches
-    bool matchImpl(bool withSearch)(Group!DataIndex[] matches)
+    bool matchImpl(bool withKick, bool withSearch)(Group!DataIndex[] matches)
     {
-        if(!matched && clist.empty)
-        {
-           static if(withSearch)
-                search();
-           else
-                next();
-        }
-        else//char in question is  fetched in prev call to match
-        {
-            matched = false;
-        }
-
-        if(!atEnd)//if no char
-            for(;;)
+        matched = false;
+        static if(!withSearch)
+            clist.insertBack(createStart(s._index));
+        if(!atEnd)
+            for(;;) with(InputKind)
             {
                 genCounter++;
                 debug(std_regex_matcher)
                 {
-                    writefln("Threaded matching threads at  %s", s[index..s.lastIndex]);
+                    writefln("Threaded matching threads at src: %s  %s",
+                        s.slice(s._index, s.lastIndex),
+                        is(typeof(s) == Input!Char) ? " " : " backwards");
                     foreach(t; clist[])
                     {
                         assert(t);
@@ -267,35 +294,35 @@ struct ThreadList(DataIndex)
                         writeln();
                     }
                 }
-                for(Thread!DataIndex* t = clist.fetch(); t; t = clist.fetch())
+                uint step = s.stride();
+                if(step == 1)
                 {
-                    eval!true(t, matches);
+                    if(evalAll!(Unit, withSearch)(matches))
+                    {
+                        s.popFrontN(step);
+                        break;
+                    }
                 }
-                if(!matched)//if we already have match no need to push the engine
-                    eval!true(createStart(index), matches);//new thread staring at this position
-                else if(nlist.empty)
+                else if (evalAll!(Point, withSearch)(matches))
                 {
-                    debug(std_regex_matcher) writeln("Stopped  matching before consuming full input");
-                    break;//not a partial match for sure
+                    s.popFrontN(step);
+                    break;
                 }
+                s.popFrontN(step);
                 clist = nlist;
                 nlist = (ThreadList!DataIndex).init;
                 if(clist.tip is null)
                 {
-                    static if(withSearch)
+                    static if(withKick)
                     {
-                        if(!search())
-                            break;
+                        s._index = re.kickstart.search(s._origin,
+                            s._index);
                     }
-                    else
-                    {
-                        if(!next())
-                            break;
-                    }
+                    else if(!withSearch)
+                        break;
                 }
-                else if(!next())
+                if(atEnd)
                 {
-                    if (!atEnd) return false;
                     exhausted = true;
                     break;
                 }
@@ -304,22 +331,19 @@ struct ThreadList(DataIndex)
         genCounter++; //increment also on each end
         debug(std_regex_matcher) writefln("Threaded matching threads at end");
         //try out all zero-width posibilities
-        for(Thread!DataIndex* t = clist.fetch(); t; t = clist.fetch())
-        {
-            eval!false(t, matches);
-        }
-        if(!matched)
-            eval!false(createStart(index), matches);//new thread starting at end of input
+        evalAll!(InputKind.None, withSearch)(matches);
         if(matched)
-        {//in case NFA found match along the way
-         //and last possible longer alternative ultimately failed
-            s.reset(matches[0].end);//reset to last successful match
-            next();//and reload front character
-            //--- here the exact state of stream was restored ---
-            exhausted = atEnd || !(re.flags & RegexOption.global);
-            //+ empty match advances the input
-            if(!exhausted && matches[0].begin == matches[0].end)
-                next();
+        {
+            // in case NFA found match along the way
+            // and last possible longer alternative ultimately failed
+            static if(withSearch) // no point in any of this for one-shot mode
+            {
+                s.reset(matches[0].end);// reset to last successful match
+                exhausted = atEnd || !(re.flags & RegexOption.global);
+                //+ empty match advances the input
+                if(!exhausted && matches[0].begin == matches[0].end)
+                    s.skipChar();
+            }
         }
         return matched;
     }
@@ -342,11 +366,28 @@ struct ThreadList(DataIndex)
         matched = true;
     }
 
+    bool evalAll(InputKind kind, bool spawnThread)(Group!DataIndex[] matches)
+    {
+        for(Thread!DataIndex* t = clist.fetch(); t; t = clist.fetch())
+            eval!kind(t, matches);
+        if(!matched)//if we already have match no need to push the engine
+        {
+            if(spawnThread) // should be optimized away if false
+                eval!kind(createStart(s._index), matches);//new thread staring at this position
+        }
+        else if(nlist.empty) //matched and no better threads
+        {
+            debug(std_regex_matcher) writeln("Stopped  matching before consuming full input");
+            return true;
+        }
+        return false;
+    }
+
     /+
         match thread against codepoint, cutting trough all 0-width instructions
         and taking care of control flow, then add it to nlist
     +/
-    void eval(bool withInput)(Thread!DataIndex* t, Group!DataIndex[] matches)
+    void eval(InputKind kind)(Thread!DataIndex* t, Group!DataIndex[] matches)
     {
         ThreadList!DataIndex worklist;
         debug(std_regex_matcher) writeln("---- Evaluating thread");
@@ -359,11 +400,15 @@ struct ThreadList(DataIndex)
                     writef(" %s ", x.pc);
                 writeln("]");
             }
-            switch(re.ir[t.pc].code)
+            debug(std_regex_matcher)
+                writefln("PC: %s\tCNT: %s\t%s \t src: %s",
+                    t.pc, t.counter, disassemble(re.ir, t.pc, re.dict),
+                    s.slice(s._index, s.lastIndex));
+            switch(re.ir[t.pc].code) with(InputKind)
             {
             case IR.End:
                 finish(t, matches);
-                matches[0].end = index; //fix endpoint of the whole match
+                matches[0].end = s._index; //fix endpoint of the whole match
                 recycle(t);
                 //cut off low priority threads
                 recycle(clist);
@@ -371,108 +416,80 @@ struct ThreadList(DataIndex)
                 debug(std_regex_matcher) writeln("Finished thread ", matches);
                 return;
             case IR.Wordboundary:
-                dchar back;
-                DataIndex bi;
                 //at start & end of input
-                if(atStart && wordTrie[front])
+                if(atStart)
                 {
-                    t.pc += IRL!(IR.Wordboundary);
-                    break;
+                    if(!atEnd && !wordTrie[s.peek])
+                        goto L_kill_thread;
                 }
-                else if(atEnd && s.loopBack(index).nextChar(back, bi)
-                        && wordTrie[back])
+                else if(atEnd)
                 {
-                    t.pc += IRL!(IR.Wordboundary);
-                    break;
+                    if(!wordTrie[s.loopBack(s._index).peek])
+                        goto L_kill_thread;
                 }
-                else if(s.loopBack(index).nextChar(back, bi))
+                else
                 {
-                    bool af = wordTrie[front];
-                    bool ab = wordTrie[back];
-                    if(af ^ ab)
-                    {
-                        t.pc += IRL!(IR.Wordboundary);
-                        break;
-                    }
+                    bool af = wordTrie[s.peek];
+                    bool ab = wordTrie[s.loopBack(s._index).peek];
+                    if((af ^ ab) == false)
+                        goto L_kill_thread;
                 }
-                recycle(t);
-                t = worklist.fetch();
-                if(!t)
-                    return;
+                t.pc += IRL!(IR.Wordboundary);
                 break;
             case IR.Notwordboundary:
-                dchar back;
-                DataIndex bi;
                 //at start & end of input
-                if(atStart && wordTrie[front])
+                if(atStart)
                 {
-                    recycle(t);
-                    t = worklist.fetch();
-                    if(!t)
-                        return;
-                    break;
+                    if(atEnd || wordTrie[s.peek])
+                        goto L_kill_thread;
                 }
-                else if(atEnd && s.loopBack(index).nextChar(back, bi)
-                        && wordTrie[back])
+                else if(atEnd)
                 {
-                    recycle(t);
-                    t = worklist.fetch();
-                    if(!t)
-                        return;
-                    break;
+                    if(wordTrie[s.loopBack(s._index).peek])
+                        goto L_kill_thread;
                 }
-                else if(s.loopBack(index).nextChar(back, bi))
+                else
                 {
-                    bool af = wordTrie[front];
-                    bool ab = wordTrie[back]  != 0;
-                    if(af ^ ab)
-                    {
-                        recycle(t);
-                        t = worklist.fetch();
-                        if(!t)
-                            return;
-                        break;
-                    }
+                    bool af = wordTrie[s.peek];
+                    bool ab = wordTrie[s.loopBack(s._index).peek];
+                    if((af ^ ab) == true)
+                        goto L_kill_thread;
                 }
                 t.pc += IRL!(IR.Wordboundary);
                 break;
             case IR.Bol:
-                dchar back;
-                DataIndex bi;
-                if(atStart
-                    ||( (re.flags & RegexOption.multiline)
-                    && s.loopBack(index).nextChar(back,bi)
-                    && startOfLine(back, front == '\n')))
+                if(atStart)
                 {
                     t.pc += IRL!(IR.Bol);
+                    break;
                 }
-                else
+                else if(re.flags & RegexOption.multiline)
                 {
-                    recycle(t);
-                    t = worklist.fetch();
-                    if(!t)
-                        return;
+                    bool seenNl = !atEnd && s.front == '\n';
+                    if(startOfLine(s.loopBack(s._index), seenNl))
+                    {
+                        t.pc += IRL!(IR.Eol);
+                        break;
+                    }
                 }
-                break;
+                goto L_kill_thread;
             case IR.Eol:
-                debug(std_regex_matcher) writefln("EOL (front 0x%x) %s",  front, s[index..s.lastIndex]);
-                dchar back;
-                DataIndex bi;
                 //no matching inside \r\n
-                if(atEnd || ((re.flags & RegexOption.multiline)
-                    && endOfLine(front, s.loopBack(index).nextChar(back, bi)
-                        && back == '\r')))
+                if(atEnd)
                 {
                     t.pc += IRL!(IR.Eol);
+                    break;
                 }
-                else
+                else if(re.flags & RegexOption.multiline)
                 {
-                    recycle(t);
-                    t = worklist.fetch();
-                    if(!t)
-                        return;
+                    bool seenCr = !atStart && s.loopBack(s._index).front == '\r';
+                    if(endOfLine(s, seenCr))
+                    {
+                        t.pc += IRL!(IR.Eol);
+                        break;
+                    }
                 }
-                break;
+                goto L_kill_thread;
             case IR.InfiniteStart, IR.InfiniteQStart:
                 t.pc += re.ir[t.pc].data + IRL!(IR.InfiniteStart);
                 goto case IR.InfiniteEnd; //both Q and non-Q
@@ -494,13 +511,13 @@ struct ThreadList(DataIndex)
                 if(merge[re.ir[t.pc + 1].raw+t.counter] < genCounter)
                 {
                     debug(std_regex_matcher) writefln("A thread(pc=%s) passed there : %s ; GenCounter=%s mergetab=%s",
-                                    t.pc, index, genCounter, merge[re.ir[t.pc + 1].raw+t.counter] );
+                                    t.pc, s._index, genCounter, merge[re.ir[t.pc + 1].raw+t.counter] );
                     merge[re.ir[t.pc + 1].raw+t.counter] = genCounter;
                 }
                 else
                 {
                     debug(std_regex_matcher) writefln("A thread(pc=%s) got merged there : %s ; GenCounter=%s mergetab=%s",
-                                    t.pc, index, genCounter, merge[re.ir[t.pc + 1].raw+t.counter] );
+                                    t.pc, s._index, genCounter, merge[re.ir[t.pc + 1].raw+t.counter] );
                     recycle(t);
                     t = worklist.fetch();
                     if(!t)
@@ -536,13 +553,13 @@ struct ThreadList(DataIndex)
                 if(merge[re.ir[t.pc + 1].raw+t.counter] < genCounter)
                 {
                     debug(std_regex_matcher) writefln("A thread(pc=%s) passed there : %s ; GenCounter=%s mergetab=%s",
-                                    t.pc, index, genCounter, merge[re.ir[t.pc + 1].raw+t.counter] );
+                                    t.pc, s._index, genCounter, merge[re.ir[t.pc + 1].raw+t.counter] );
                     merge[re.ir[t.pc + 1].raw+t.counter] = genCounter;
                 }
                 else
                 {
                     debug(std_regex_matcher) writefln("A thread(pc=%s) got merged there : %s ; GenCounter=%s mergetab=%s",
-                                    t.pc, index, genCounter, merge[re.ir[t.pc + 1].raw+t.counter] );
+                                    t.pc, s._index, genCounter, merge[re.ir[t.pc + 1].raw+t.counter] );
                     recycle(t);
                     t = worklist.fetch();
                     if(!t)
@@ -561,9 +578,9 @@ struct ThreadList(DataIndex)
                     pc1 = t.pc + IRL!(IR.InfiniteEnd);
                     pc2 = t.pc - len;
                 }
-                static if(withInput)
+                static if(kind)
                 {
-                    int test = quickTestFwd(pc1, front, re);
+                    int test = quickTestKnown!kind(pc1, s, re);
                     if(test >= 0)
                     {
                         worklist.insertFront(fork(t, pc2, t.counter));
@@ -582,14 +599,14 @@ struct ThreadList(DataIndex)
                 if(merge[re.ir[t.pc + 1].raw+t.counter] < genCounter)
                 {
                     debug(std_regex_matcher) writefln("A thread(pc=%s) passed there : %s ; GenCounter=%s mergetab=%s",
-                                    t.pc, s[index .. s.lastIndex], genCounter, merge[re.ir[t.pc + 1].raw + t.counter] );
+                                    t.pc, s.slice(s._index ,  s.lastIndex), genCounter, merge[re.ir[t.pc + 1].raw + t.counter] );
                     merge[re.ir[t.pc + 1].raw+t.counter] = genCounter;
                     t.pc += IRL!(IR.OrEnd);
                 }
                 else
                 {
                     debug(std_regex_matcher) writefln("A thread(pc=%s) got merged there : %s ; GenCounter=%s mergetab=%s",
-                                    t.pc, s[index .. s.lastIndex], genCounter, merge[re.ir[t.pc + 1].raw + t.counter] );
+                                    t.pc, s.slice(s._index ,  s.lastIndex), genCounter, merge[re.ir[t.pc + 1].raw + t.counter] );
                     recycle(t);
                     t = worklist.fetch();
                     if(!t)
@@ -613,12 +630,12 @@ struct ThreadList(DataIndex)
                 goto case IR.OrEnd;
             case IR.GroupStart:
                 uint n = re.ir[t.pc].data;
-                t.matches.ptr[n].begin = index;
+                t.matches.ptr[n].begin = s._index;
                 t.pc += IRL!(IR.GroupStart);
                 break;
             case IR.GroupEnd:
                 uint n = re.ir[t.pc].data;
-                t.matches.ptr[n].end = index;
+                t.matches.ptr[n].end = s._index;
                 t.pc += IRL!(IR.GroupEnd);
                 break;
             case IR.Backref:
@@ -629,25 +646,37 @@ struct ThreadList(DataIndex)
                 {
                     t.pc += IRL!(IR.Backref);
                 }
-                else static if(withInput)
-                {
+                else static if(kind)
+                { //non zero-width backref
+                    if(t.uopCounter == 0) // eager test
+                    {
+                        auto refed = s.slice(source[n].begin, source[n].end);
+                        import std.algorithm, std.string;
+                        static if(Stream.isLoopback)
+                        {
+                            if(s.length < refed.length || !s.startsWith(refed.representation.retro))
+                            {
+                                goto L_kill_thread;
+                            }
+                        }
+                        else
+                        {
+                            if(s.length < refed.length || !s.startsWith(refed.representation))
+                            {
+                                goto L_kill_thread;
+                            }
+                        }
+                    }
                     size_t idx = source[n].begin + t.uopCounter;
                     size_t end = source[n].end;
-                    if(s[idx..end].front == front)
+                    // just keep incrementing till it ends, everything is tested just once
+                    t.uopCounter += std.utf.stride(s.slice(idx, end), 0);
+                    if(t.uopCounter + source[n].begin == source[n].end) // last codepoint
                     {
-                        t.uopCounter += std.utf.stride(s[idx..end], 0);
-                        if(t.uopCounter + source[n].begin == source[n].end)
-                        {//last codepoint
-                            t.pc += IRL!(IR.Backref);
-                            t.uopCounter = 0;
-                        }
-                        nlist.insertBack(t);
+                        t.pc += IRL!(IR.Backref);
+                        t.uopCounter = 0;
                     }
-                    else
-                        recycle(t);
-                    t = worklist.fetch();
-                    if(!t)
-                        return;
+                    nlist.insertBack(t);
                     break;
                 }
                 else
@@ -666,16 +695,18 @@ struct ThreadList(DataIndex)
                 uint end = t.pc + len + IRL!(IR.LookbehindEnd) + IRL!(IR.LookbehindStart);
                 bool positive = re.ir[t.pc].code == IR.LookbehindStart;
                 static if(Stream.isLoopback)
-                    auto matcher = fwdMatcher(re.ir[t.pc .. end], subCounters.get(t.pc, 0));
+                    auto matcher = fwdMatcher(re.ir[t.pc + IRL!(IR.LookbehindStart) .. end],
+                        subCounters.get(t.pc, 0));
                 else
-                    auto matcher = bwdMatcher(re.ir[t.pc .. end], subCounters.get(t.pc, 0));
+                    auto matcher = bwdMatcher(re.ir[t.pc + IRL!(IR.LookbehindStart) .. end],
+                        subCounters.get(t.pc, 0));
                 matcher.re.ngroup = me - ms;
                 matcher.backrefed = backrefed.empty ? t.matches : backrefed;
                 //backMatch
-                auto mRes = matcher.matchOneShot(t.matches.ptr[ms .. me], IRL!(IR.LookbehindStart));
+                auto mRes = matcher.matchOneShot(t.matches.ptr[ms .. me]);
                 freelist = matcher.freelist;
                 subCounters[t.pc] = matcher.genCounter;
-                if((mRes == MatchResult.Match) ^ positive)
+                if(mRes ^ positive)
                 {
                     recycle(t);
                     t = worklist.fetch();
@@ -688,23 +719,24 @@ struct ThreadList(DataIndex)
                 break;
             case IR.LookaheadStart:
             case IR.NeglookaheadStart:
-                auto save = index;
+                auto save = s._index;
                 uint len = re.ir[t.pc].data;
                 uint ms = re.ir[t.pc+1].raw, me = re.ir[t.pc+2].raw;
                 uint end = t.pc+len+IRL!(IR.LookaheadEnd)+IRL!(IR.LookaheadStart);
                 bool positive = re.ir[t.pc].code == IR.LookaheadStart;
                 static if(Stream.isLoopback)
-                    auto matcher = bwdMatcher(re.ir[t.pc .. end], subCounters.get(t.pc, 0));
+                    auto matcher = bwdMatcher(re.ir[t.pc + IRL!(IR.LookaheadStart) .. end],
+                        subCounters.get(t.pc, 0));
                 else
-                    auto matcher = fwdMatcher(re.ir[t.pc .. end], subCounters.get(t.pc, 0));
+                    auto matcher = fwdMatcher(re.ir[t.pc + IRL!(IR.LookaheadStart) .. end],
+                        subCounters.get(t.pc, 0));
                 matcher.re.ngroup = me - ms;
                 matcher.backrefed = backrefed.empty ? t.matches : backrefed;
-                auto mRes = matcher.matchOneShot(t.matches.ptr[ms .. me], IRL!(IR.LookaheadStart));
+                auto mRes = matcher.matchOneShot(t.matches.ptr[ms .. me]);
                 freelist = matcher.freelist;
                 subCounters[t.pc] = matcher.genCounter;
-                s.reset(index);
-                next();
-                if((mRes == MatchResult.Match) ^ positive)
+                s.reset(save);
+                if(mRes ^ positive)
                 {
                     recycle(t);
                     t = worklist.fetch();
@@ -729,15 +761,23 @@ struct ThreadList(DataIndex)
                 t.pc += IRL!(IR.Nop);
                 break;
 
-                static if(withInput)
+                static if(kind)
                 {
             case IR.OrChar:
                       uint len = re.ir[t.pc].sequence;
                       uint end = t.pc + len;
                       static assert(IRL!(IR.OrChar) == 1);
                       for(; t.pc < end; t.pc++)
-                          if(re.ir[t.pc].data == front)
-                              break;
+                            static if(kind == Point)
+                            {
+                                if(s.testDChar(re.ir[t.pc].data))
+                                    break;
+                            }
+                            else
+                            {
+                                if(s.front == re.ir[t.pc].data)
+                                    break;
+                            }
                       if(t.pc != end)
                       {
                           t.pc = end;
@@ -750,7 +790,7 @@ struct ThreadList(DataIndex)
                           return;
                       break;
             case IR.Char:
-                      if(front == re.ir[t.pc].data)
+                      if(s.testDChar(re.ir[t.pc].data))
                       {
                           t.pc += IRL!(IR.Char);
                           nlist.insertBack(t);
@@ -764,7 +804,7 @@ struct ThreadList(DataIndex)
             case IR.Any:
                       t.pc += IRL!(IR.Any);
                       if(!(re.flags & RegexOption.singleline)
-                              && (front == '\r' || front == '\n'))
+                              && (s.front == '\r' || s.front == '\n'))
                           recycle(t);
                       else
                           nlist.insertBack(t);
@@ -773,28 +813,26 @@ struct ThreadList(DataIndex)
                           return;
                       break;
             case IR.CodepointSet:
-                      if(re.charsets[re.ir[t.pc].data].scanFor(front))
-                      {
-                          t.pc += IRL!(IR.CodepointSet);
-                          nlist.insertBack(t);
-                      }
-                      else
-                      {
-                          recycle(t);
-                      }
-                      t = worklist.fetch();
-                      if(!t)
-                          return;
-                      break;
             case IR.Trie:
-                      if(re.tries[re.ir[t.pc].data][front])
+                      static if(kind == Point || is(dchar : Char))
                       {
-                          t.pc += IRL!(IR.Trie);
-                          nlist.insertBack(t);
+                          if(s.testClass(re.matchers[re.ir[t.pc].data]))
+                          {
+                              t.pc += IRL!(IR.Trie);
+                              nlist.insertBack(t);
+                          }
+                          else
+                              recycle(t);
                       }
                       else
                       {
-                          recycle(t);
+                          if(re.matchers[re.ir[t.pc].data].subMatcher!1.test(s))
+                          {
+                              t.pc += IRL!(IR.Trie);
+                              nlist.insertBack(t);
+                          }
+                          else
+                              recycle(t);
                       }
                       t = worklist.fetch();
                       if(!t)
@@ -802,10 +840,17 @@ struct ThreadList(DataIndex)
                       break;
                   default:
                       assert(0, "Unrecognized instruction " ~ re.ir[t.pc].mnemonic);
+            L_kill_thread:
+                        recycle(t);
+                        t = worklist.fetch();
+                        if(!t)
+                            return;
                 }
                 else
                 {
+
                     default:
+            L_kill_thread:
                         recycle(t);
                         t = worklist.fetch();
                         if(!t)
@@ -815,70 +860,11 @@ struct ThreadList(DataIndex)
         }
 
     }
-    enum uint RestartPc = uint.max;
-    //match the input, evaluating IR without searching
-    MatchResult matchOneShot(Group!DataIndex[] matches, uint startPc = 0)
-    {
-        debug(std_regex_matcher)
-        {
-            writefln("---------------single shot match ----------------- ");
-        }
-        alias evalFn = eval;
-        assert(clist == (ThreadList!DataIndex).init || startPc == RestartPc); // incorrect after a partial match
-        assert(nlist == (ThreadList!DataIndex).init || startPc == RestartPc);
-        if(!atEnd)//if no char
-        {
-            debug(std_regex_matcher)
-            {
-                writefln("-- Threaded matching threads at  %s",  s[index..s.lastIndex]);
-            }
-            if(startPc!=RestartPc)
-            {
-                auto startT = createStart(index, startPc);
-                genCounter++;
-                evalFn!true(startT, matches);
-            }
-            for(;;)
-            {
-                debug(std_regex_matcher) writeln("\n-- Started iteration of main cycle");
-                genCounter++;
-                debug(std_regex_matcher)
-                {
-                    foreach(t; clist[])
-                    {
-                        assert(t);
-                    }
-                }
-                for(Thread!DataIndex* t = clist.fetch(); t; t = clist.fetch())
-                {
-                    evalFn!true(t, matches);
-                }
-                if(nlist.empty)
-                {
-                    debug(std_regex_matcher) writeln("Stopped  matching before consuming full input");
-                    break;//not a partial match for sure
-                }
-                clist = nlist;
-                nlist = (ThreadList!DataIndex).init;
-                if(!next())
-                {
-                    if (!atEnd) return MatchResult.PartialMatch;
-                    break;
-                }
-                debug(std_regex_matcher) writeln("-- Ended iteration of main cycle\n");
-            }
-        }
-        genCounter++; //increment also on each end
-        debug(std_regex_matcher) writefln("-- Matching threads at end");
-        //try out all zero-width posibilities
-        for(Thread!DataIndex* t = clist.fetch(); t; t = clist.fetch())
-        {
-            evalFn!false(t, matches);
-        }
-        if(!matched)
-            evalFn!false(createStart(index, startPc), matches);
 
-        return (matched?MatchResult.Match:MatchResult.NoMatch);
+    //match the input, evaluating IR without searching
+    bool matchOneShot(Group!DataIndex[] matches)
+    {
+        return matchImpl!(false, false)(matches);
     }
 
     //get a dirty recycled Thread

--- a/std/regex/internal/thompson.d
+++ b/std/regex/internal/thompson.d
@@ -419,18 +419,18 @@ int quickTestKnown(InputKind kind, RegEx, Stream)(uint pc, ref Stream s, ref Reg
                 //at start & end of input
                 if(atStart)
                 {
-                    if(!atEnd && !wordTrie[s.peek])
+                    if(!atEnd && !s.testWordClass())
                         goto L_kill_thread;
                 }
                 else if(atEnd)
                 {
-                    if(!wordTrie[s.loopBack(s._index).peek])
+                    if(!s.loopBack(s._index).testWordClass())
                         goto L_kill_thread;
                 }
                 else
                 {
-                    bool af = wordTrie[s.peek];
-                    bool ab = wordTrie[s.loopBack(s._index).peek];
+                    bool af = s.testWordClass();
+                    bool ab = s.loopBack(s._index).testWordClass();
                     if((af ^ ab) == false)
                         goto L_kill_thread;
                 }
@@ -440,18 +440,18 @@ int quickTestKnown(InputKind kind, RegEx, Stream)(uint pc, ref Stream s, ref Reg
                 //at start & end of input
                 if(atStart)
                 {
-                    if(atEnd || wordTrie[s.peek])
+                    if(atEnd || s.testWordClass())
                         goto L_kill_thread;
                 }
                 else if(atEnd)
                 {
-                    if(wordTrie[s.loopBack(s._index).peek])
+                    if(s.loopBack(s._index).testWordClass())
                         goto L_kill_thread;
                 }
                 else
                 {
-                    bool af = wordTrie[s.peek];
-                    bool ab = wordTrie[s.loopBack(s._index).peek];
+                    bool af = s.testWordClass();
+                    bool ab = s.loopBack(s._index).testWordClass();
                     if((af ^ ab) == true)
                         goto L_kill_thread;
                 }

--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -336,6 +336,7 @@ template ctRegexImpl(alias pattern, string flags=[])
     alias Matcher = BacktrackingMatcher!(true);
     @trusted bool func(ref Matcher!Char matcher)
     {
+        /*debug(std_regex_matcher) */import std.stdio;
         debug(std_regex_ctr) pragma(msg, source);
         mixin(source);
     }
@@ -1313,7 +1314,7 @@ public @trusted void replaceAllInto(alias fun, Sink, R, RegEx)
 public R replace(alias scheme = match, R, C, RegEx)(R input, RegEx re, const(C)[] format)
     if(isSomeString!R && isRegexFor!(RegEx, R))
 {
-    return replaceAllWith!((m, sink) => replaceFmt(format, m, sink), match)(input, re);
+    return replaceAllWith!((m, sink) => replaceFmt(format, m, sink), scheme)(input, re);
 }
 
 ///ditto

--- a/std/uni.d
+++ b/std/uni.d
@@ -4733,7 +4733,7 @@ template Utf8Matcher()
         import std.algorithm : map;
         auto ascii = set & unicode.ASCII;
         auto utf8_2 = set & CodepointSet(0x80, 0x800);
-        auto utf8_3 = set & CodepointSet(0x800, 0x1_0000);
+        auto utf8_3 = set & (CodepointSet(0x800, 0x1_0000) - CodepointSet(0xD800, 0xDFFF+1));
         auto utf8_4 = set & CodepointSet(0x1_0000, lastDchar+1);
         auto asciiT = ascii.byCodepoint.map!(x=>cast(char)x).buildTrie!(AsciiSpec);
         auto utf8_2T = utf8_2.byCodepoint.map!(x=>encode!2(x)).buildTrie!(Utf8Spec2);
@@ -4831,19 +4831,19 @@ template Utf8Matcher()
                 mixin(dispatch);
         }
 
-        bool match(C)(ref C[] str) const pure @trusted
+        public bool match(C)(ref C[] str) const pure @trusted
             if(isSomeChar!C)
         {
             return fwdStr!"match"(str);
         }
 
-        bool skip(C)(ref C[] str) const pure @trusted
+        public bool skip(C)(ref C[] str) const pure @trusted
             if(isSomeChar!C)
         {
             return fwdStr!"skip"(str);
         }
 
-        bool test(C)(ref C[] str) const pure @trusted
+        public bool test(C)(ref C[] str) const pure @trusted
             if(isSomeChar!C)
         {
             return fwdStr!"test"(str);
@@ -4984,9 +4984,9 @@ template Utf16Matcher()
     {
         import std.algorithm : map;
         auto ascii = set & unicode.ASCII;
-        auto bmp = (set & CodepointSet.fromIntervals(0x80, 0xFFFF+1))
-            - CodepointSet.fromIntervals(0xD800, 0xDFFF+1);
-        auto other = set - (bmp | ascii);
+        auto bmp = (set & CodepointSet(0x80, 0xFFFF+1))
+            - CodepointSet(0xD800, 0xDFFF+1);
+        auto other = set - CodepointSet(0x0, 0xFFFF+1);
         auto asciiT = ascii.byCodepoint.map!(x=>cast(char)x).buildTrie!(AsciiSpec);
         auto bmpT = bmp.byCodepoint.map!(x=>cast(wchar)x).buildTrie!(BmpSpec);
         auto otherT = other.byCodepoint.map!(x=>encode2(x)).buildTrie!(UniSpec);
@@ -5057,19 +5057,19 @@ template Utf16Matcher()
                 return lookupUni!mode(inp);
         }
 
-        bool match(C)(ref C[] str) const pure @trusted
+        public bool match(C)(ref C[] str) const pure @trusted
             if(isSomeChar!C)
         {
             return fwdStr!"match"(str);
         }
 
-        bool skip(C)(ref C[] str) const pure @trusted
+        public bool skip(C)(ref C[] str) const pure @trusted
             if(isSomeChar!C)
         {
             return fwdStr!"skip"(str);
         }
 
-        bool test(C)(ref C[] str) const pure @trusted
+        public bool test(C)(ref C[] str) const pure @trusted
             if(isSomeChar!C)
         {
             return fwdStr!"test"(str);
@@ -5203,7 +5203,7 @@ template Utf32Matcher()
             auto ch = decode(inp, idx);
             if(trie[ch])
             {
-                inp = inp[idx..$];
+                inp.popFrontN(idx);
                 return true;
             }
             else
@@ -5216,7 +5216,7 @@ template Utf32Matcher()
             assert(!inp.empty);
             size_t idx = 0;
             auto ch = decode(inp, idx);
-            inp = inp[idx..$];
+            inp.popFrontN(idx);
             return trie[ch];
         }
 
@@ -5270,6 +5270,9 @@ public auto utfMatcher(Char, Set)(Set set) @trusted
     else
         static assert(false, "Only character types 'char' and 'wchar' are allowed");
 }
+
+/// Type of matcher object returned by $(LREF utfMatcher) function.
+public alias UtfMatcher(Char) = typeof(utfMatcher!Char(CodepointSet.init));
 
 
 //a range of code units, packed with index to speed up forward iteration


### PR DESCRIPTION
I'm reviving some of my 2014 work on std.regex. Decoding UTF was deemed to be one of major performance problems in std.regex, and now it's gone.

As a side effect there are few cases left where now it does encode instead of decoding e.g. when doing some complex backwards matching, totally eliminating these (rare) cases would be further improvement.

I'm letting it hang here while I run benchmarks and otherwise make sure it does deliver. I vaguely remember getting numbers of around 15% speed up.

Also includes a few simplifications in both regex engines.

P.S. Pardon for this being a big chunk of changes, the layout of std.regex now has `std.regex.internal` package while the code was developed with plain `std.regex` in mind.