### PR TITLE
Add new lazy range: merge()

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -8842,7 +8842,7 @@ auto merge(alias pred = "a < b", Rs...)(Rs rs) if (Rs.length > 1 &&
     alias I = int;
     alias D = double;
 
-    S[] a = [1, 2, 3 ];
+    S[] a = [1, 2, 3];
     I[] b = [50, 60];
     D[] c = [10, 20, 30, 40];
 

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -8656,8 +8656,9 @@ template CommonElementType(Rs...)
 alias isSortedRange(R) = isInstanceOf!(SortedRange, R); // TODO Or use: __traits(isSame, TemplateOf!R, SortedRange)
 
 /**
-   Merge several sorted ranges with less-than function $(D pred) into one single
-   sorted range containing the sorted union of the elements of inputs.
+   Merge several sorted ranges $(D rs) with less-than predicate function $(D
+   pred) into one single sorted range containing the sorted union of the
+   elements of inputs.
 
    Example:
    -------

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -8668,8 +8668,6 @@ auto merge(alias less = "a < b", Rs...)(Rs rs) if (Rs.length > 1 &&
 
     struct Result
     {
-        import std.conv : to;
-
         this(Rs source)
         {
             this.source = source;

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -80,7 +80,7 @@ $(BOOKTABLE ,
     ))
     $(TR $(TD $(D $(LREF merge)))
         $(TD Creates a _range that iterates over the merged sorted union of its
-        sorted arguments. Is bidrectional if all it inputs are.
+        sorted arguments. Is bidrectional if all its inputs are.
     ))
     $(TR $(TD $(D $(LREF NullSink)))
         $(TD An output _range that discards the data it receives.

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -8852,7 +8852,7 @@ auto merge(alias pred = "a < b", Rs...)(Rs rs) if (Rs.length > 1 &&
                    b.assumeSorted,
                    c.assumeSorted);
 
-    static assert(is(typeof(m.front) == CommonType!(I, D)));
+    static assert(is(typeof(m.front) == CommonType!(S, I, D)));
     assert(equal(m, [1, 2, 3, 10, 20, 30, 40, 50, 60]));
     assert(equal(m.retro, [60, 50, 40, 30, 20, 10, 3, 2, 1]));
 

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -8701,14 +8701,23 @@ if (Rs.length > 1 &&
                 this._lastBackIndex = backIndex;
         }
 
-        @property bool empty()
+        import std.typetuple : anySatisfy;
+        static if (anySatisfy!(isInfinite, Rs))
         {
-            if (_lastFrontIndex == size_t.max)
-                return true;
-            static if (isBidirectional)
-                return _lastBackIndex == size_t.max;
-            else
-                return false;
+            // Propagate infiniteness.
+            enum bool empty = false;
+        }
+        else
+        {
+            @property bool empty()
+            {
+                if (_lastFrontIndex == size_t.max)
+                    return true;
+                static if (isBidirectional)
+                    return _lastBackIndex == size_t.max;
+                else
+                    return false;
+            }
         }
 
         @property auto ref front()

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -8656,7 +8656,7 @@ template CommonElementType(Rs...)
 alias isSortedRange(R) = isInstanceOf!(SortedRange, R); // TODO Or use: __traits(isSame, TemplateOf!R, SortedRange)
 
 /**
-   Merge several sorted ranges with less-than function $(D less) into one single
+   Merge several sorted ranges with less-than function $(D pred) into one single
    sorted range containing the sorted union of the elements of inputs assuming.
 
    Example:
@@ -8668,7 +8668,7 @@ alias isSortedRange(R) = isInstanceOf!(SortedRange, R); // TODO Or use: __traits
    assert(equal(c.retro, [5, 4, 3, 2, 1, 0]));
    -------
 */
-auto merge(alias less = "a < b", Rs...)(Rs rs) if (Rs.length > 1 &&
+auto merge(alias pred = "a < b", Rs...)(Rs rs) if (Rs.length > 1 &&
                                                    allSatisfy!(isSortedRange,
                                                                staticMap!(Unqual, Rs)) &&
                                                    is(CommonElementType!(Rs)))
@@ -8720,7 +8720,7 @@ auto merge(alias less = "a < b", Rs...)(Rs rs) if (Rs.length > 1 &&
                 if (!source[i].empty)
                 {
                     if (bestIndex == size_t.max || // either this is the first or
-                        binaryFun!less(source[i].front, bestElement))
+                        binaryFun!pred(source[i].front, bestElement))
                     {
                         bestIndex = i;
                         bestElement = source[i].front;
@@ -8770,7 +8770,7 @@ auto merge(alias less = "a < b", Rs...)(Rs rs) if (Rs.length > 1 &&
                     if (!source[i].empty)
                     {
                         if (bestIndex == size_t.max || // either this is the first or
-                            binaryFun!less(bestElement, source[i].back))
+                            binaryFun!pred(bestElement, source[i].back))
                         {
                             bestIndex = i;
                             bestElement = source[i].back;

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -8740,7 +8740,7 @@ if (Rs.length > 1 &&
             E bestElement;
             foreach (i, _; Rs)
             {
-                import std.functional: binaryFun;
+                import std.functional : binaryFun;
                 if (!source[i].empty)
                 {
                     if (bestIndex == size_t.max || // either this is the first or
@@ -8786,7 +8786,7 @@ if (Rs.length > 1 &&
 
             private size_t backIndex()
             {
-                import std.functional: binaryFun;
+                import std.functional : binaryFun;
                 size_t bestIndex = size_t.max; // indicate undefined
                 E bestElement;
                 foreach (i, _; Rs)
@@ -8860,7 +8860,7 @@ if (Rs.length > 1 &&
 
 @safe pure nothrow unittest
 {
-    import std.algorithm: equal;
+    import std.algorithm : equal;
 
     alias S = short;
     alias I = int;

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -8846,13 +8846,18 @@ auto merge(alias pred = "a < b", Rs...)(Rs rs) if (Rs.length > 1 &&
     I[] b = [50, 60];
     D[] c = [10, 20, 30, 40];
 
-    static assert(!__traits(compiles, { auto c = merge(a.assumeSorted); }));
+    auto d = ["a", "b", "c"];
+
+    static assert(!__traits(compiles, { auto m = merge(a.assumeSorted); }));
+    static assert(!__traits(compiles, { auto m = merge(a.assumeSorted,
+                                                       d.assumeSorted); }));
 
     auto m = merge(a.assumeSorted,
                    b.assumeSorted,
                    c.assumeSorted);
 
     static assert(is(typeof(m.front) == CommonType!(S, I, D)));
+
     assert(equal(m, [1, 2, 3, 10, 20, 30, 40, 50, 60]));
     assert(equal(m.retro, [60, 50, 40, 30, 20, 10, 3, 2, 1]));
 

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -8657,7 +8657,7 @@ alias isSortedRange(R) = isInstanceOf!(SortedRange, R); // TODO Or use: __traits
 
 /**
    Merge several sorted ranges with less-than function $(D pred) into one single
-   sorted range containing the sorted union of the elements of inputs assuming.
+   sorted range containing the sorted union of the elements of inputs.
 
    Example:
    -------

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -8648,17 +8648,30 @@ if (is(typeof(fun) == void) || isSomeFunction!fun)
     auto r = [1, 2, 3, 4].tee!func1.tee!func2;
 }
 
-template CommonElementType(Rs...)
+package template CommonElementType(Rs...)
 {
     alias CommonElementType = CommonType!(staticMap!(ElementType, Rs));
 }
 
-alias isSortedRange(R) = isInstanceOf!(SortedRange, R); // TODO Or use: __traits(isSame, TemplateOf!R, SortedRange)
+package alias isSortedRange(R) = isInstanceOf!(SortedRange, R); // TODO Or use: __traits(isSame, TemplateOf!R, SortedRange)
 
 /**
    Merge several sorted ranges $(D rs) with less-than predicate function $(D
    pred) into one single sorted range containing the sorted union of the
    elements of inputs.
+
+   All of its inputs must be instantiations of $(XREF range, SortedRange). Use
+   the result of $(XREF algorithm, sort), or $(XREF range, assumeSorted) to
+   merge ranges known to be sorted (show in the example below).
+
+   This algorithm is lazy, doing work progressively as elements are pulled off
+   the result.
+
+   Average complexity is $(BIGOH n * k) for $(D k) ranges of maximum length $(D n).
+
+   If all ranges have the same element type and offer it by $(D ref), merge
+   offers a range with mutable $(D front) (and $(D back) where appropriate) that
+   reflects in the original ranges.
 
    Example:
    -------

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -8838,35 +8838,40 @@ auto merge(alias pred = "a < b", Rs...)(Rs rs) if (Rs.length > 1 &&
 {
     import std.algorithm: equal;
 
+    alias S = short;
     alias I = int;
     alias D = double;
 
-    I[] a = [ 1, 2, 3, 50, 60];
-    D[] b = [ 10, 20, 30, 40 ];
+    S[] a = [1, 2, 3 ];
+    I[] b = [50, 60];
+    D[] c = [10, 20, 30, 40];
 
-    auto r = merge(a.assumeSorted,
-                   b.assumeSorted);
+    static assert(!__traits(compiles, { auto c = merge(a.assumeSorted); }));
 
-    static assert(is(typeof(r.front) == CommonType!(I, D)));
-    assert(equal(r, [1, 2, 3, 10, 20, 30, 40, 50, 60]));
-    assert(equal(r.retro, [60, 50, 40, 30, 20, 10, 3, 2, 1]));
+    auto m = merge(a.assumeSorted,
+                   b.assumeSorted,
+                   c.assumeSorted);
 
-    r.popFront;
-    assert(equal(r, [2, 3, 10, 20, 30, 40, 50, 60]));
-    r.popBack;
-    assert(equal(r, [2, 3, 10, 20, 30, 40, 50]));
-    r.popFront;
-    assert(equal(r, [3, 10, 20, 30, 40, 50]));
-    r.popBack;
-    assert(equal(r, [3, 10, 20, 30, 40]));
-    r.popFront;
-    assert(equal(r, [10, 20, 30, 40]));
-    r.popBack;
-    assert(equal(r, [10, 20, 30]));
-    r.popFront;
-    assert(equal(r, [20, 30]));
-    r.popBack;
-    assert(equal(r, [20]));
-    r.popFront;
-    assert(r.empty);
+    static assert(is(typeof(m.front) == CommonType!(I, D)));
+    assert(equal(m, [1, 2, 3, 10, 20, 30, 40, 50, 60]));
+    assert(equal(m.retro, [60, 50, 40, 30, 20, 10, 3, 2, 1]));
+
+    m.popFront;
+    assert(equal(m, [2, 3, 10, 20, 30, 40, 50, 60]));
+    m.popBack;
+    assert(equal(m, [2, 3, 10, 20, 30, 40, 50]));
+    m.popFront;
+    assert(equal(m, [3, 10, 20, 30, 40, 50]));
+    m.popBack;
+    assert(equal(m, [3, 10, 20, 30, 40]));
+    m.popFront;
+    assert(equal(m, [10, 20, 30, 40]));
+    m.popBack;
+    assert(equal(m, [10, 20, 30]));
+    m.popFront;
+    assert(equal(m, [20, 30]));
+    m.popBack;
+    assert(equal(m, [20]));
+    m.popFront;
+    assert(m.empty);
 }

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -8656,7 +8656,17 @@ template CommonElementType(Rs...)
 alias isSortedRange(R) = isInstanceOf!(SortedRange, R); // TODO Or use: __traits(isSame, TemplateOf!R, SortedRange)
 
 /**
-   Merge several sorted ranges with less-than function $(D less).
+   Merge several sorted ranges with less-than function $(D less) into one single
+   sorted range containing the sorted union of the elements of inputs assuming.
+
+   Example:
+   -------
+   auto a = [0, 2, 4];
+   auto b = [1, 3, 5];
+   auto c = merge(a.assumeSorted, b.assumeSorted)
+   assert(equal(c, [0, 1, 2, 3, 4, 5]));
+   assert(equal(c.retro, [5, 4, 3, 2, 1, 0]));
+   -------
 */
 auto merge(alias less = "a < b", Rs...)(Rs rs) if (Rs.length > 1 &&
                                                    allSatisfy!(isSortedRange,

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -8666,7 +8666,13 @@ package alias isSortedRange(R) = isInstanceOf!(SortedRange, R); // TODO Or use: 
 
    All of its inputs must be instantiations of $(XREF range, SortedRange). Use
    the result of $(XREF algorithm, sort), or $(XREF range, assumeSorted) to
-   merge ranges known to be sorted (show in the example below).
+   merge ranges known to be sorted (show in the example below). However, note
+   that there is currently no way of ensuring that two or more instances of
+   $(XREF range, SortedRange) are sorted using a specific comparison function
+   $(D pred). Therefore no checking is done here to assure that the $(D pred)
+   template parmeter matches the $(D pred) template parameter that were given to
+   each instance of $(XREF range, SortedRange) when the $(D rs) were
+   instantiated.
 
    This algorithm is lazy, doing work progressively as elements are pulled off
    the result.

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -8682,10 +8682,11 @@ package alias isSortedRange(R) = isInstanceOf!(SortedRange, R); // TODO Or use: 
    assert(equal(c.retro, [5, 4, 3, 2, 1, 0]));
    -------
 */
-auto merge(alias pred = "a < b", Rs...)(Rs rs) if (Rs.length > 1 &&
-                                                   allSatisfy!(isSortedRange,
-                                                               staticMap!(Unqual, Rs)) &&
-                                                   is(CommonElementType!(Rs)))
+auto merge(alias pred = "a < b", Rs...)(Rs rs)
+if (Rs.length > 1 &&
+    allSatisfy!(isSortedRange,
+                staticMap!(Unqual, Rs)) &&
+    is(CommonElementType!(Rs)))
 {
     alias E = CommonElementType!Rs;
     enum isBidirectional = allSatisfy!(isBidirectionalRange, staticMap!(Unqual, Rs));

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -78,6 +78,10 @@ $(BOOKTABLE ,
         loop. Similar to $(D zip), except that $(D lockstep) is designed
         especially for $(D foreach) loops.
     ))
+    $(TR $(TD $(D $(LREF merge)))
+        $(TD Creates a _range that iterates over the merged sorted union of its
+        sorted arguments. Is bidrectional if all it inputs are.
+    ))
     $(TR $(TD $(D $(LREF NullSink)))
         $(TD An output _range that discards the data it receives.
     ))

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -8673,6 +8673,9 @@ package alias isSortedRange(R) = isInstanceOf!(SortedRange, R); // TODO Or use: 
    offers a range with mutable $(D front) (and $(D back) where appropriate) that
    reflects in the original ranges.
 
+   If any of the inputs $(D rs) is infinite so is the merge result (`empty` is
+   statically always false).
+
    Example:
    -------
    auto a = [0, 2, 4];


### PR DESCRIPTION
In compliance with C++ STL `std::merge`: http://en.cppreference.com/w/cpp/algorithm/merge
but variadic, of course! :)

Implementation is a tweak of `roundRobin` extended to support bidirectional access iff all its input ranges does.

Respects `CommonType` of the `ElementTypes` of the input ranges.

Propagates infiniteness if any of the inputs is infinite.

- Need advice on what to write about in documentation.
- How about putting `CommonElementType` in std.traits?
- How do we assert that the inputs are sorted according to the template parameter `pred`?
- How about putting `isSortedRange` in `std/range/primitives.d`?
- There might be some clever optimization of the min calculations in successive calls to popFront for a large number of parameters. But that's perhaps outside the scope of this implementation.