### PR TITLE
deprecate std.stream and friends

### DIFF
--- a/std/cstream.d
+++ b/std/cstream.d
@@ -21,7 +21,7 @@
  *    (See accompanying file LICENSE_1_0.txt or copy at
  *          http://www.boost.org/LICENSE_1_0.txt)
  */
-module std.cstream;
+deprecated module std.cstream;
 
 public import core.stdc.stdio;
 public import std.stream;

--- a/std/socketstream.d
+++ b/std/socketstream.d
@@ -37,7 +37,7 @@
  * Macros: WIKI=Phobos/StdSocketstream
  */
 
-module std.socketstream;
+deprecated module std.socketstream;
 
 private import std.stream;
 private import std.socket;

--- a/std/stream.d
+++ b/std/stream.d
@@ -27,7 +27,7 @@
  * "as is" without express or implied warranty.
  */
 
-module std.stream;
+deprecated module std.stream;
 
 
 import std.internal.cstring;

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -3011,11 +3011,6 @@ unittest
         inout(Object) foo() inout;
     }
     BlackHole!Foo o;
-
-    // Bugzilla 12464
-    import std.stream;
-    import std.typecons;
-    BlackHole!OutputStream dout;
 }
 
 


### PR DESCRIPTION
deprecate

* std.stream
* std.socketstream
* std.cstream

this needs to be pulled before https://github.com/D-Programming-Language/phobos/pull/3318