### PR TITLE
stream deprecation breaks doc building

### DIFF
--- a/std/cstream.d
+++ b/std/cstream.d
@@ -21,7 +21,7 @@
  *    (See accompanying file LICENSE_1_0.txt or copy at
  *          http://www.boost.org/LICENSE_1_0.txt)
  */
-deprecated module std.cstream;
+module std.cstream;
 
 public import core.stdc.stdio;
 public import std.stream;

--- a/std/socketstream.d
+++ b/std/socketstream.d
@@ -37,7 +37,7 @@
  * Macros: WIKI=Phobos/StdSocketstream
  */
 
-deprecated module std.socketstream;
+module std.socketstream;
 
 private import std.stream;
 private import std.socket;

--- a/std/stream.d
+++ b/std/stream.d
@@ -27,7 +27,7 @@
  * "as is" without express or implied warranty.
  */
 
-deprecated module std.stream;
+module std.stream;
 
 
 import std.internal.cstring;


### PR DESCRIPTION
this removes the `deprecated module std.s`