### PR TITLE
Make Ranges Chainable through Concatenation Operator ~

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -3755,6 +3755,8 @@ if (isSomeChar!C)
         {
             return this;
         }
+
+        mixin Chainable;
     }
     return Result(s);
 }
@@ -3765,6 +3767,7 @@ if (isSomeChar!C)
     import std.algorithm.comparison : equal;
     auto a = " a     bcd   ef gh ";
     assert(equal(splitter(a), ["a", "bcd", "ef", "gh"][]));
+    assert(equal(splitter(a) ~ splitter(a), ["a", "bcd", "ef", "gh", "a", "bcd", "ef", "gh"][]));
 }
 
 @safe pure unittest

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -2070,6 +2070,8 @@ if (isInputRange!RoR && isInputRange!(ElementType!RoR)
                 return copy;
             }
         }
+
+        mixin Chainable;
     }
     return Result(r, sep);
 }
@@ -2093,6 +2095,11 @@ if (isInputRange!RoR && isInputRange!(ElementType!RoR)
     assert(equal(joiner(["Mary", "has", "a", "little", "lamb"], "..."),
                     "Mary...has...a...little...lamb"));
     assert(equal(joiner(["abc", "def"]), "abcdef"));
+    /* TODO This fails, as
+       iteration.d(2098,18): Error: incompatible types for ((joiner(["abc", "def"])) ~ (joiner(["abc", "def"]))): 'Result' and 'Result'
+       why?:
+       assert(equal(joiner(["abc", "def"]) ~ joiner(["abc", "def"]), "abcdefabcdef"));
+    */
 }
 
 unittest

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -1020,6 +1020,8 @@ private struct FilterResult(alias pred, Range)
             return typeof(this)(_input.save);
         }
     }
+
+    mixin Chainable;
 }
 
 @safe unittest
@@ -1034,6 +1036,7 @@ private struct FilterResult(alias pred, Range)
     auto r = filter!("a > 3")(a);
     static assert(isForwardRange!(typeof(r)));
     assert(equal(r, [ 4 ][]));
+    assert(equal(r ~ r, [ 4, 4][]));
 
     a = [ 1, 22, 3, 42, 5 ];
     auto under10 = filter!("a < 10")(a);

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -608,6 +608,8 @@ private struct MapResult(alias fun, Range)
             return typeof(this)(_input.save);
         }
     }
+
+    mixin Chainable;
 }
 
 @safe unittest
@@ -620,7 +622,9 @@ private struct MapResult(alias fun, Range)
         writeln("unittest @", __FILE__, ":", __LINE__, " done.");
 
     alias stringize = map!(to!string);
-    assert(equal(stringize([ 1, 2, 3, 4 ]), [ "1", "2", "3", "4" ]));
+    auto s = stringize([ 1, 2, 3, 4 ]);
+    assert(equal(s, [ "1", "2", "3", "4" ]));
+    assert(equal(s ~ s, [ "1", "2", "3", "4", "1", "2", "3", "4" ]));
 
     uint counter;
     alias count = map!((a) { return counter++; });

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -1160,6 +1160,7 @@ template filterBidirectional(alias pred)
     static assert(isBidirectionalRange!(typeof(small)));
     assert(small.back == 2);
     assert(equal(small, [ 1, 2 ]));
+    assert(equal(small ~ small, [ 1, 2, 1, 2]));
     assert(equal(retro(small), [ 2, 1 ]));
     // In combination with chain() to span multiple ranges
     int[] a = [ 3, -2, 400 ];
@@ -1212,6 +1213,8 @@ private struct FilterBidiResult(alias pred, Range)
     {
         return typeof(this)(_input.save);
     }
+
+    mixin Chainable;
 }
 
 // group

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -4168,6 +4168,8 @@ private struct UniqResult(alias pred, Range)
             return typeof(this)(_input.save);
         }
     }
+
+    mixin Chainable;
 }
 
 @safe unittest
@@ -4183,6 +4185,7 @@ private struct UniqResult(alias pred, Range)
     static assert(isForwardRange!(typeof(r)));
 
     assert(equal(r, [ 1, 2, 3, 4, 5 ][]));
+    assert(equal(r ~ r, [ 1, 2, 3, 4, 5, 1, 2, 3, 4, 5 ][]));
     assert(equal(retro(r), retro([ 1, 2, 3, 4, 5 ][])));
 
     foreach (DummyType; AllDummyRanges) {

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -181,6 +181,7 @@ if (isBidirectionalRange!Range)
 
     // the values of x that have a negative y are:
     assert(equal(result2, [-3, -2, 2]));
+    assert(equal(result2 ~ result2, [-3, -2, 2, -3, -2, 2]));
 
     // Check how many times fun was evaluated.
     // Only as many times as the number of items in source.
@@ -412,6 +413,8 @@ private struct _Cache(R, bool bidir)
             }
         }
     }
+
+    mixin Chainable;
 }
 
 /**

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -1037,6 +1037,7 @@ private struct FilterResult(alias pred, Range)
     static assert(isForwardRange!(typeof(r)));
     assert(equal(r, [ 4 ][]));
     assert(equal(r ~ r, [ 4, 4][]));
+    assert(equal(r ~ r ~ r, [ 4, 4, 4][]));
 
     a = [ 1, 22, 3, 42, 5 ];
     auto under10 = filter!("a < 10")(a);

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -181,7 +181,6 @@ if (isBidirectionalRange!Range)
 
     // the values of x that have a negative y are:
     assert(equal(result2, [-3, -2, 2]));
-    assert(equal(result2 ~ result2, [-3, -2, 2, -3, -2, 2]));
 
     // Check how many times fun was evaluated.
     // Only as many times as the number of items in source.
@@ -213,6 +212,7 @@ same cost or side effects.
     auto r2 = r.cache().take(3);
 
     assert(equal(r1, [0, 1, 2]));
+    assert(equal(r1 ~ r1, [0, 1, 2, 0, 1, 2]));
     assert(i == 2); //The last "seen" element was 2. The data in cache has been cleared.
 
     assert(equal(r2, [0, 1, 2]));

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -2133,6 +2133,8 @@ if (isInputRange!R)
                     return _input.front = v;
                 }
             }
+
+            mixin Chainable;
         }
 
         return Result(range, n);
@@ -2148,6 +2150,8 @@ if (isInputRange!R)
 
     auto b = takeExactly(a, 3);
     assert(equal(b, [1, 2, 3]));
+    assert(equal(b ~ b, [1, 2, 3,
+                         1, 2, 3]));
     static assert(is(typeof(b.length) == size_t));
     assert(b.length == 3);
     assert(b.front == 1);

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -1622,6 +1622,8 @@ if (Rs.length > 1 && allSatisfy!(isInputRange, staticMap!(Unqual, Rs)))
 
             alias opDollar = length;
         }
+
+        mixin Chainable;
     }
 
     return Result(rs, 0);
@@ -1636,6 +1638,8 @@ if (Rs.length > 1 && allSatisfy!(isInputRange, staticMap!(Unqual, Rs)))
     int[] b = [ 10, 20, 30, 40 ];
     auto r = roundRobin(a, b);
     assert(equal(r, [ 1, 10, 2, 20, 3, 30, 40 ]));
+    assert(equal(r ~ r, [ 1, 10, 2, 20, 3, 30, 40,
+                          1, 10, 2, 20, 3, 30, 40 ]));
 }
 
 /**

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -1894,6 +1894,8 @@ if (isInputRange!(Unqual!Range) &&
     {
         return _maxAvailable;
     }
+
+    mixin Chainable;
 }
 
 // This template simply aliases itself to R and is useful for consistency in
@@ -1927,6 +1929,8 @@ if (isInputRange!(Unqual!R) && !isInfinite!(Unqual!R) && hasSlicing!(Unqual!R) &
     assert(s.length == 5);
     assert(s[4] == 5);
     assert(equal(s, [ 1, 2, 3, 4, 5 ][]));
+    assert(equal(s ~ s, [ 1, 2, 3, 4, 5,
+                          1, 2, 3, 4, 5 ][]));
 }
 
 // take(take(r, n1), n2)

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -1495,14 +1495,14 @@ unittest
         uint[] foo = [1,2,3,4,5];
         uint[] bar = [6,7,8,9,10];
         auto c = chooseAmong(1,foo, bar);
+        assert(equal(c ~ c, [6,7,8,9,10,
+                             6,7,8,9,10]));
         assert(c[3] == 9);
         c[3] = 42;
         assert(c[3] == 42);
         assert(c.moveFront() == 6);
         assert(c.moveBack() == 10);
         assert(c.moveAt(4) == 10);
-        assert(equal(c ~ c, [6,7,8,9,10,
-                             6,7,8,9,10]));
     }
     {
         import std.range : cycle;

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -2732,6 +2732,7 @@ public:
     private static struct DollarToken {}
     enum opDollar = DollarToken.init;
     auto opSlice(size_t, DollarToken) inout { return this; }
+    mixin Chainable;
 }
 
 /// Ditto
@@ -2742,7 +2743,9 @@ Repeat!T repeat(T)(T value) { return Repeat!T(value); }
 {
     import std.algorithm : equal;
 
-    assert(equal(5.repeat().take(4), [ 5, 5, 5, 5 ]));
+    assert(equal(5.repeat.take(4), [ 5, 5, 5, 5 ]));
+    assert(equal((1.repeat.take(2) ~ 5.repeat).take(4), [ 1, 1,
+                                                          5, 5 ]));
 }
 
 @safe unittest

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -1106,6 +1106,16 @@ if (Ranges.length > 0 &&
                     }
                     return result;
                 }
+
+            auto opCat(Range)(Range r)
+            if (isInputRange!(Unqual!Range)//  &&
+                // is(CommonType!(RvalueElementType,
+                //                ElementType!Range))
+                )
+            {
+                import std.range : chain;
+                return chain(source, r); // flatten tree
+            }
         }
         return Result(rs);
     }

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -2294,6 +2294,7 @@ auto takeOne(R)(R source) if (isInputRange!R)
             }
             // Non-standard property
             @property R source() { return _source; }
+            mixin Chainable;
         }
 
         return Result(source, source.empty);
@@ -2303,7 +2304,10 @@ auto takeOne(R)(R source) if (isInputRange!R)
 ///
 @safe unittest
 {
+    import std.algorithm : equal;
+
     auto s = takeOne([42, 43, 44]);
+    assert(equal(s ~ s, [42, 42]));
     static assert(isRandomAccessRange!(typeof(s)));
     assert(s.length == 1);
     assert(!s.empty);

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -858,6 +858,11 @@ if (Ranges.length > 0 &&
 
             import std.typetuple : anySatisfy;
 
+            static if (anySatisfy!(isInfinite, R[0 .. $ - 1]))
+            {
+                static assert(false, "No sense in appending ranges after an infinite range in a chain.");
+            }
+
             static if (anySatisfy!(isInfinite, R))
             {
                 // Propagate infiniteness.
@@ -1178,12 +1183,15 @@ unittest
     auto c = chain( iota(0, 10), iota(0, 10) );
 
     // Test the case where infinite ranges are present.
-    auto inf = chain([0,1,2][], cycle([4,5,6][]), [7,8,9][]); // infinite range
+    auto inf = chain([0,1,2][], cycle([4,5,6][])); // infinite range
     assert(inf[0] == 0);
     assert(inf[3] == 4);
     assert(inf[6] == 4);
     assert(inf[7] == 5);
     static assert(isInfinite!(typeof(inf)));
+
+    // Infinite ranges may only be placed at the end of a chain
+    static assert(!__traits(compiles, { auto inf = chain([0,1,2][], cycle([4,5,6][]), [7,8,9][]); }));
 
     immutable int[] immi = [ 1, 2, 3 ];
     immutable float[] immf = [ 1, 2, 3 ];

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -1670,6 +1670,8 @@ if (isRandomAccessRange!(Unqual!R) && hasLength!(Unqual!R))
     assert(equal(radial(a), [ 3, 4, 2, 5, 1 ]));
     a = [ 1, 2, 3, 4 ];
     assert(equal(radial(a), [ 2, 3, 1, 4 ]));
+    assert(equal(radial(a) ~ radial(a), [ 2, 3, 1, 4,
+                                          2, 3, 1, 4 ]));
 }
 
 @safe unittest

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -1107,7 +1107,7 @@ if (Ranges.length > 0 &&
                     return result;
                 }
 
-            auto opCat(Range)(Range r)
+            auto opBinary(string op : "~", Range)(Range r)
             if (isInputRange!(Unqual!Range)//  &&
                 // is(CommonType!(RvalueElementType,
                 //                ElementType!Range))

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -1414,6 +1414,7 @@ if (isInputRange!(Unqual!R1) && isInputRange!(Unqual!R2) &&
                 else result.r2 = result.r2[begin .. end];
                 return result;
             }
+        mixin Chainable;
     }
     return Result(condition, r1, r2);
 }
@@ -1500,6 +1501,8 @@ unittest
         assert(c.moveFront() == 6);
         assert(c.moveBack() == 10);
         assert(c.moveAt(4) == 10);
+        assert(equal(c ~ c, [6,7,8,9,10,
+                             6,7,8,9,10]));
     }
     {
         import std.range : cycle;

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -2239,3 +2239,17 @@ if (!isNarrowString!(T[]))
     size_t i = a.length - std.utf.strideBack(a, a.length);
     return decode(a, i);
 }
+
+template Chainable()
+{
+    import std.traits: Unqual, CommonType;
+    import std.range: ElementType;
+    auto opCat(Range)(Range r)
+    if (isInputRange!(Unqual!Range) &&
+        is(CommonType!(ElementType!(typeof(this)),
+                       ElementType!Range)))
+    {
+        import std.range : chain;
+        return chain(this, r);
+    }
+}

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -2244,7 +2244,7 @@ template Chainable()
 {
     import std.traits: Unqual, CommonType;
     import std.range: ElementType;
-    auto opCat(Range)(Range r)
+    auto opBinary(string op : "~", Range)(Range r)
     if (isInputRange!(Unqual!Range) &&
         is(CommonType!(ElementType!(typeof(this)),
                        ElementType!Range)))

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -2240,6 +2240,11 @@ if (!isNarrowString!(T[]))
     return decode(a, i);
 }
 
+/**
+   This template shall be mixed in at the top-scope inside of the $(D Result)
+   struct of each $(D InputRange) in order to support lazy chaining via
+   concatenation operation as `x ~ y` instead of via $(D chain(x, y))).
+*/
 template Chainable()
 {
     import std.traits: Unqual, CommonType;


### PR DESCRIPTION
This allows to write more natural and readable code like:

```D
iota(5) ~ filter!q{a}([1,0,3])
map!abs([1,2,-5]) ~ [10, 20]
```

instead of more noisy:

```D
chain(iota(5), filter!q{a}([1,0,3]))
chain(map!abs([1,2,-5]), [10, 20])
```
Publishing this at an early stage to get quick feedback.

For details see

http://forum.dlang.org/thread/cxgrlifaovdlwzbwsmsp@forum.dlang.org#post-bcazbwztlspwzpvlrblm:40forum.dlang.org

One question: 

Should

```D
a ~ b ~ c
```

evaluate to a single instance of `chain` as

```D
chain(a, b, c)
```

or to

```D
chain(chain(a, b), c)
```

?