### PR TITLE
Remove superfluous ctor in ddoc version of UnixAddress

### DIFF
--- a/std/socket.d
+++ b/std/socket.d
@@ -1947,8 +1947,6 @@ version(StdDdoc)
         /// Construct a new $(D UnixAddress) from the specified path.
         this(in char[] path) { }
 
-        this() pure nothrow @nogc { }
-
         /**
          * Construct a new $(D UnixAddress).
          * Params:


### PR DESCRIPTION
See https://github.com/D-Programming-Language/phobos/pull/3349#issuecomment-107649732