### PR TITLE
Add attributes to several methods for std.typecons.RefCounted

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -4686,7 +4686,7 @@ if (!is(T == class) && !(is(T == interface)))
            Returns $(D true) if and only if the underlying store has been
            allocated and initialized.
         */
-        @property nothrow @safe
+        @property nothrow @safe pure @nogc
         bool isInitialized() const
         {
             return _store !is null;
@@ -4696,7 +4696,7 @@ if (!is(T == class) && !(is(T == interface)))
            Returns underlying reference count if it is allocated and initialized
            (a positive integer), and $(D 0) otherwise.
         */
-        @property nothrow @safe
+        @property nothrow @safe pure @nogc
         size_t refCount() const
         {
             return isInitialized ? _store._count : 0;
@@ -4741,7 +4741,7 @@ Postcondition: $(D refCountedStore.isInitialized)
 Constructor that tracks the reference count appropriately. If $(D
 !refCountedStore.isInitialized), does nothing.
  */
-    this(this)
+    this(this) @safe pure nothrow @nogc
     {
         if (!_refCounted.isInitialized) return;
         ++_refCounted._store._count;
@@ -4818,7 +4818,7 @@ Assignment operators
         ref T refCountedPayload() return;
 
         /// ditto
-        @property nothrow @safe
+        @property nothrow @safe pure @nogc
         ref inout(T) refCountedPayload() inout return;
     }
     else
@@ -4834,7 +4834,7 @@ Assignment operators
             }
         }
 
-        @property nothrow @safe
+        @property nothrow @safe pure @nogc
         ref inout(T) refCountedPayload() inout return
         {
             assert(_refCounted.isInitialized, "Attempted to access an uninitialized payload.");


### PR DESCRIPTION
This request adds `@safe`, `pure`, `nothrow` and `@nogc` to several methods for `RefCounted` and `RefCountedStore`.

Here are the details:
- `RefCountedStore.isInitialized` and `refCount`: There are no impure nor GC-related operations.
- `RefCounted.this(this)`: There are no unsafe, impure, throwable nor GC-related operations.
- `RefCounted.refCountedPayload`: There are no impure nor GC-related operations.

