### PR TITLE
Accept EISDIR as an error code for mkdir(2)

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -1539,7 +1539,7 @@ private bool ensureDirExists(in char[] pathname)
     {
         if (core.sys.posix.sys.stat.mkdir(pathname.tempCString(), octal!777) == 0)
             return true;
-        cenforce(errno == EEXIST, pathname);
+        cenforce(errno == EEXIST || errno == EISDIR, pathname);
     }
     enforce(pathname.isDir, new FileException(pathname.idup));
     return false;


### PR DESCRIPTION
Older versions of Linux, older versions of FreeBSD, and current versions
of Darwin can return EISDIR to signal an existing directory[1].  Accept
that as a possible return code.

[1] http://cr.yp.to/docs/unixport.html