### PR TITLE
Revert "Modify std.conv.octal to be usable at runtime"

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -3737,28 +3737,10 @@ unittest
 @property T octal(T, string num)()
     if (isOctalLiteral!num)
 {
-    return octal!T(num);
-}
-
-/// Takes an octal literal string and returns its value as the specified type.
-/// 
-/// Params:
-///     num     =   The octal literal string.
-///     
-/// Preconditions:
-///     Asserts that $(D num) is an octal literal string using
-///     $(D isOctalLiteralString).
-@property T octal(T)(const(char)[] num) pure nothrow
-    if (isNumeric!T)
-{
-    assert( isOctalLiteralString(num),
-            "The provided string contains non-octal digits."
-            );
-
     ulong pow = 1;
     T value = 0;
 
-    for (ptrdiff_t pos = num.length - 1; pos >= 0; pos--)
+    for (int pos = num.length - 1; pos >= 0; pos--)
     {
         char s = num[pos];
         if (s < '0' || s > '7') // we only care about digits; skip the rest
@@ -3777,10 +3759,8 @@ unittest
 unittest
 {
     int a = octal!(int, "10");
-    int b = octal!int("10");
 
     assert(a == 8);
-    assert(a == b);
 }
 
 /*
@@ -3832,7 +3812,7 @@ Returns if the given string is a correctly formatted octal literal.
 The format is specified in lex.html. The leading zero is allowed, but
 not required.
  */
-bool isOctalLiteralString(const(char)[] num) pure nothrow
+bool isOctalLiteralString(string num)
 {
     if (num.length == 0)
         return false;


### PR DESCRIPTION
Reverts D-Programming-Language/phobos#3343

I forgot that `to` and `parse` already do this:

```D
auto x = parse!int(octalString, 8)
```

having 2 ways to do this, within the same module no less, is unnecessary. I'm wondering actually whether `octal` (the one that uses the literal at compile time) could actually simply forward to `parse` instead of having its own special mechanism.