### PR TITLE
add auto-tester specific targets

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -445,3 +445,10 @@ html_consolidated :
 	$(DOCSRC)/std_consolidated_footer.html > $(DOC_OUTPUT_DIR)/std_consolidated.html
 
 #############################
+
+.PHONY : auto-tester-build
+auto-tester-build: all
+
+.PHONY : auto-tester-test
+auto-tester-test: unittest
+

--- a/win32.mak
+++ b/win32.mak
@@ -935,3 +935,8 @@ install: phobos.zip
 	$(CP) $(DOC)\index.html $(DIR)\html\d\phobos\index.html
 	+rd/s/q $(DIR)\src\phobos
 	unzip -o phobos.zip -d $(DIR)\src\phobos
+
+auto-tester-build: targets
+
+auto-tester-test: unittest
+

--- a/win64.mak
+++ b/win64.mak
@@ -889,3 +889,8 @@ install: phobos.zip
 	$(CP) $(DRUNTIME)\lib\gcstub.obj $(DRUNTIME)\lib\gcstub64.obj $(DIR)\windows\lib
 	+rd/s/q $(DIR)\src\phobos
 	unzip -o phobos.zip -d $(DIR)\src\phobos
+
+auto-tester-build: targets
+
+auto-tester-test: unittest
+


### PR DESCRIPTION
This gives control to the repository rather than the auto-tester.

The choice of target is based on current behavior.  For auto-tester-build, the tester isn't specifying a target, so the behavior is 'whatever is first in the makefile'.  That's 'all' for posix and 'targets' for the two windows make file.  For auto-tester-test, that's explicitly 'unittest' in the current tester build scripts.

This will need to be merged to the other branches before the tester can switch to using these new targets.