### PR TITLE
Adjust std.conv.parse to accept underscores in numeric strings

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -302,6 +302,21 @@ template to(T)
     {
         return toImpl!T(arg);
     }
+
+    T to(S)(ref S arg, AllowUnderscores uscores)
+        if (isRawStaticArray!S && isIntegral!T)
+    {
+        return toImpl!T(arg, uscores);
+    }
+}
+
+unittest
+{
+    string including = "5_000",
+           excluding = "5000";
+
+    assert( excluding.to!int == 5000 );
+    assert( including.to!int(AllowUnderscores.yes) == 5000 );
 }
 
 // Tests for issue 6175
@@ -1737,6 +1752,18 @@ T toImpl(T, S)(S value)
         }
     }
     return parse!T(value);
+}
+
+T toImpl(T, S)(S value, AllowUnderscores uscores)
+{
+    scope(success)
+    {
+        if (value.length)
+        {
+            throw convError!(S, T)(value);
+        }
+    }
+    return parse!T(value, uscores);
 }
 
 /// ditto

--- a/std/conv.d
+++ b/std/conv.d
@@ -1973,6 +1973,17 @@ unittest
 /// numeric strings.
 alias AllowUnderscores = Flag!"AllowUnderscores";
 
+/// Parses a numeric value from a string.
+/// 
+/// Params:
+///     s       =   The string to parse the value from.
+///     uscores =   Whether underscores should be accepted in numeric strings.
+///                 
+/// Throws:
+///     ConvOverflowException when a conversion from a string to a numeric
+///         value causes an overflow.
+///     ConvException when the first character in the provided string is not
+///         a valid digit for the specified base/radix.
 Target parse(Target, Source)(ref Source s, 
                              AllowUnderscores uscores = AllowUnderscores.no)
     if (isSomeChar!(ElementType!Source) &&

--- a/std/conv.d
+++ b/std/conv.d
@@ -1751,7 +1751,7 @@ T toImpl(T, S)(S value)
 /// ditto
 T toImpl(T, S)(S value, AllowUnderscores uscores)
     if ( isExactSomeString!S && isDynamicArray!S &&
-        !isExactSomeString!T && is(typeof(parse!T(value))))
+        !isExactSomeString!T && is(typeof(parse!T(value, uscores))))
 {
     scope(success)
     {
@@ -1766,7 +1766,7 @@ T toImpl(T, S)(S value, AllowUnderscores uscores)
 /// ditto
 T toImpl(T, S)(S value, uint radix, AllowUnderscores uscores = AllowUnderscores.no)
     if ( isExactSomeString!S && isDynamicArray!S &&
-        !isExactSomeString!T && is(typeof(parse!T(value, radix))))
+        !isExactSomeString!T && is(typeof(parse!T(value, radix, uscores))))
 {
     scope(success)
     {


### PR DESCRIPTION
Without this pull request:
```D
auto s = "FF_FF";
auto n = parse!int(s, 16);
writeln(n);  // 255
```

With this pull request:
```D
auto s = "FF_FF";
auto n = parse!int(s, 16);
writeln(n);  // 65535
```

Suggested in #3374.
See also: #3375.