### PR TITLE
Build phobos package at a time

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -276,7 +276,11 @@ $(ROOT)/%$(DOTOBJ): %.c
 	@[ -d $(dir $@) ] || mkdir -p $(dir $@) || [ -d $(dir $@) ]
 	$(CC) -c $(CFLAGS) $< -o$@
 
-$(LIB): $(OBJS) $(DRUNTIME) $(call P2LIB,$(STD_PACKAGES))
+$(LIB): $(OBJS) $(DRUNTIME) $(call P2LIB,$(STD_PACKAGES))\
+		$(ROOT)/libphobos2_xtra$(DOTLIB)
+	$(DMD) $(DFLAGS) -lib -of$@ $^
+
+$(ROOT)/libphobos2_xtra$(DOTLIB): $(addsuffix .d,$(EXTRA_MODULES))
 	$(DMD) $(DFLAGS) -lib -of$@ $^
 
 # Each package depends on everything. We may improve that in the future.

--- a/posix.mak
+++ b/posix.mak
@@ -113,10 +113,12 @@ endif
 # Set DOTOBJ and DOTEXE
 ifeq (,$(findstring win,$(OS)))
 	DOTOBJ:=.o
+	DOTLIB:=.a
 	DOTEXE:=
 	PATHSEP:=/
 else
 	DOTOBJ:=.obj
+	DOTLIB:=.lib
 	DOTEXE:=.exe
 	PATHSEP:=$(shell echo "\\")
 endif
@@ -148,29 +150,38 @@ LINKCURL:=$(if $(LIBCURL_STUB),-L$(LIBCURL_STUB),-L-lcurl)
 ################################################################################
 MAIN = $(ROOT)/emptymain.d
 
-# Packages in std. Just mention the package name here and the actual files in
-# the package in STD_MODULES.
-STD_PACKAGES = $(addprefix std/, algorithm container experimental/logger \
-	range regex)
+# Given one or more packages, returns their respective libraries
+P2LIB=$(addprefix $(ROOT)/libphobos2_,$(addsuffix $(DOTLIB),$(subst /,_,$1)))
+# Given one or more packages, returns the modules they contain
+P2MODULES=$(foreach P,$1,$(addprefix $P/,$(PACKAGE_$(subst /,_,$P))))
 
-# Modules in std (including those in packages), in alphabetical order.
-STD_MODULES = $(addprefix std/, \
-  array ascii base64 bigint bitmanip compiler complex concurrency \
-  $(addprefix container/, array binaryheap dlist rbtree slist util) \
-  conv cstream csv datetime demangle \
-  $(addprefix digest/, digest crc md ripemd sha) \
-  encoding exception \
-  $(addprefix experimental/logger/, core filelogger nulllogger multilogger) \
-  file format functional getopt json math mathspecial \
-  meta metastrings mmfile net/isemail net/curl numeric outbuffer parallelism path \
-  process random \
-  $(addprefix range/, primitives interfaces) \
-  $(addprefix regex/, $(addprefix internal/,generator ir parser backtracking \
-  	kickstart tests thompson)) \
-  signals socket socketstream stdint stdio stdiobase stream \
-  string syserror system traits typecons typetuple uni uri utf uuid variant \
-  xml zip zlib $(addprefix algorithm/,comparison iteration \
-    mutation searching setops sorting))
+# Packages in std. Just mention the package name here. The contents of package
+# xy/zz is in variable PACKAGE_xy_zz. This allows automation in iterating
+# packages and their modules.
+STD_PACKAGES = std $(addprefix std/,\
+  algorithm container digest experimental net range regex)
+
+# Modules broken down per package
+
+PACKAGE_std = array ascii base64 bigint bitmanip compiler complex concurrency \
+  conv cstream csv datetime demangle encoding exception file format \
+  functional getopt json math mathspecial meta metastrings mmfile numeric \
+  outbuffer parallelism path process random signals socket socketstream stdint \
+  stdio stdiobase stream string syserror system traits typecons typetuple uni \
+  uri utf uuid variant xml zip zlib
+PACKAGE_std_algorithm = comparison iteration mutation package searching setops \
+  sorting
+PACKAGE_std_container = array binaryheap dlist package rbtree slist util
+PACKAGE_std_digest = crc digest md ripemd sha
+PACKAGE_std_experimental = $(addprefix logger/, core filelogger \
+  nulllogger multilogger package)
+PACKAGE_std_net = curl isemail
+PACKAGE_std_range = interfaces package primitives
+PACKAGE_std_regex = package $(addprefix internal/,generator ir parser \
+  backtracking kickstart tests thompson)
+
+# Modules in std (including those in packages)
+STD_MODULES=$(call P2MODULES,$(STD_PACKAGES))
 
 # OS-specific D modules
 EXTRA_MODULES_LINUX := $(addprefix std/c/linux/, linux socket)
@@ -198,9 +209,7 @@ EXTRA_MODULES += $(EXTRA_DOCUMENTABLES) $(addprefix			\
 	$(addprefix std/algorithm/, internal)
 
 # Aggregate all D modules relevant to this build
-D_MODULES = $(STD_MODULES) $(EXTRA_MODULES) \
-  $(addsuffix /package,$(STD_PACKAGES))
-
+D_MODULES = $(STD_MODULES) $(EXTRA_MODULES)
 # Add the .d suffix to the module names
 D_FILES = $(addsuffix .d,$(D_MODULES))
 # Aggregate all D modules over all OSs (this is for the zip file)
@@ -267,8 +276,13 @@ $(ROOT)/%$(DOTOBJ): %.c
 	@[ -d $(dir $@) ] || mkdir -p $(dir $@) || [ -d $(dir $@) ]
 	$(CC) -c $(CFLAGS) $< -o$@
 
-$(LIB): $(OBJS) $(ALL_D_FILES) $(DRUNTIME)
-	$(DMD) $(DFLAGS) -lib -of$@ $(DRUNTIME) $(D_FILES) $(OBJS)
+$(LIB): $(OBJS) $(DRUNTIME) $(call P2LIB,$(STD_PACKAGES))
+	$(DMD) $(DFLAGS) -lib -of$@ $^
+
+# Each package depends on everything. We may improve that in the future.
+$(foreach P,$(STD_PACKAGES),$(eval \
+$(call P2LIB,$P): $(addsuffix .d,$(STD_MODULES)) ;\
+  $(DMD) $(DFLAGS) -lib -of$$@ $(call P2MODULES,$P)))
 
 $(ROOT)/libphobos2.so: $(ROOT)/$(SONAME)
 	ln -sf $(notdir $(LIBSO)) $@
@@ -335,7 +349,7 @@ $(ROOT)/unittest/test_runner: $(DRUNTIME_PATH)/src/test_runner.d $(UT_LIBSO)
 endif
 
 # macro that returns the module name given the src path
-moduleName=$(subst /,.,$(1))
+moduleName=$(subst /,.,$1)
 
 # target for batch unittests (using shared phobos library and test_runner)
 unittest/%.run : $(ROOT)/unittest/test_runner
@@ -425,13 +439,13 @@ $(DOC_OUTPUT_DIR)/$(call D2HTML,$p) : $p $(STDDOC) ;\
 # For each package, define a rule e.g.:
 # ../web/phobos/std_algorithm.html : std/algorithm/package.d $(STDDOC) ; ...
 $(foreach p,$(STD_PACKAGES),$(eval \
-$(DOC_OUTPUT_DIR)/$(call P2HTML,$p) : $p/package.d $(STDDOC) ;\
+$(DOC_OUTPUT_DIR)/$(call P2HTML,$p) : $(STDDOC) ;\
   $(DDOC) project.ddoc $(STDDOC) -Df$$@ $$<))
 
 html : $(DOC_OUTPUT_DIR)/. $(HTMLS) $(STYLECSS_TGT)
 
 allmod :
-	@echo $(SRC_DOCUMENTABLES) $(addsuffix /package.d,$(STD_PACKAGES))
+	@echo $(SRC_DOCUMENTABLES)
 
 rsync-prerelease : html
 	rsync -avz $(DOC_OUTPUT_DIR)/ d-programming@digitalmars.com:data/phobos-prerelease/


### PR DESCRIPTION
On my Powerbook, ran the command:

    make clean && /usr/bin/time -lp make -j6 BUILD=debug MODEL=64

Took the best of three runs for baseline and proposed.

Before:  4.93s, 960270336 maximum resident set size
After: 3.85s, 618004480 maximum resident set size

On a big iron at work running Centos 6, ran the command:

    make clean && /usr/bin/time -f "%P %M" make -j64 BUILD=debug MODEL=64 lib

Took the best of three.

Before: 5.12s, 1191664
After: 3.86s, 767252


