### PR TITLE
Suppress gcc warnings in zlib

### DIFF
--- a/etc/c/zlib/gzlib.c
+++ b/etc/c/zlib/gzlib.c
@@ -4,6 +4,7 @@
  */
 
 #include "gzguts.h"
+#include <unistd.h>
 
 #if defined(_WIN32) && !defined(__BORLANDC__)
 #  define LSEEK _lseeki64

--- a/etc/c/zlib/gzread.c
+++ b/etc/c/zlib/gzread.c
@@ -4,6 +4,7 @@
  */
 
 #include "gzguts.h"
+#include <unistd.h>
 
 /* Local functions */
 local int gz_load OF((gz_statep, unsigned char *, unsigned, unsigned *));

--- a/etc/c/zlib/gzwrite.c
+++ b/etc/c/zlib/gzwrite.c
@@ -4,6 +4,7 @@
  */
 
 #include "gzguts.h"
+#include <unistd.h>
 
 /* Local functions */
 local int gz_init OF((gz_statep));


### PR DESCRIPTION
Got sick and tired of seeing those warnings...