### PR TITLE
Alpha renaming, yay

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -6774,10 +6774,7 @@ private string replaceTypeInFunctionType(X, Y, fun)()
 {
     alias storageClasses = ParameterStorageClassTuple!fun;
     string result;
-    static if (functionLinkage!fun == "C")
-    {
-        result ~= "extern(C) ";
-    }
+    result ~= "extern(" ~ functionLinkage!fun ~ ") ";
     static if (functionAttributes!fun & FunctionAttribute.ref_)
     {
         result ~= "ref ";

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -6685,3 +6685,222 @@ public:
     auto value = cast(int)flags_A;
     assert(value == Enum.A);
 }
+
+// ReplaceType
+/**
+Replaces all occurrences of `From` into `To`, in one or more types `T`. For
+example, $(D ReplaceType!(int, uint, Tuple!(int, float)[string])) yields
+$(D Tuple!(uint, float)[string]). The types in which replacement is performed
+may be arbitrarily complex, including qualifiers, built-in type constructors
+(pointers, arrays, associative arrays, functions, and delegates), and template
+instantiations; replacement proceeds transitively through the type definition.
+However, member types in `struct`s or `class`es are not replaced because there
+are no ways to express the types resulting after replacement.
+
+This is an advanced type manipulation necessary e.g. for replacing the
+placeholder type `This` in $(XREF variant, Algebraic).
+
+Returns: `ReplaceType` aliases itself to the type(s) that result after
+replacement.
+*/
+template ReplaceType(From, To, T...)
+{
+    static if (T.length == 1)
+    {
+        static if (is(T[0] == From)) alias ReplaceType = To;
+        else static if (is(T[0] == const(U), U))
+            alias ReplaceType = const(ReplaceType!(From, To, U));
+        else static if (is(T[0] == immutable(U), U))
+            alias ReplaceType = immutable(ReplaceType!(From, To, U));
+        else static if (is(T[0] == shared(U), U))
+            alias ReplaceType = shared(ReplaceType!(From, To, U));
+        else static if (is(T[0] == U*, U))
+        {
+            static if (is(U == function) || is(U == delegate))
+            {
+                mixin("alias ReplaceType = "
+                    ~replaceTypeInFunctionType!(From, To, T[0])~";");
+            }
+            else
+            {
+                alias ReplaceType = ReplaceType!(From, To, U)*;
+            }
+        }
+        else static if (is(T[0] == delegate))
+        {
+            mixin("alias ReplaceType = "
+                ~replaceTypeInFunctionType!(From, To, T[0])~";");
+        }
+        else static if (is(T[0] == function))
+        {
+            static assert(0, "Function types not supported,"
+                " use a function pointer type instead of "~T[0].stringof);
+        }
+        else static if (is(T[0] == U[], U))
+            alias ReplaceType = ReplaceType!(From, To, U)[];
+        else static if (is(T[0] == U[n], U, size_t n))
+            alias ReplaceType = ReplaceType!(From, To, U)[n];
+        else static if (is(T[0] == U[V], U, V))
+            alias ReplaceType =
+                ReplaceType!(From, To, U)[ReplaceType!(From, To, V)];
+        else static if (is(T[0] : U!V, alias U, V...))
+            alias ReplaceType = U!(ReplaceType!(From, To, V));
+        else alias ReplaceType = T[0];
+    }
+    else static if (T.length > 1)
+    {
+        alias ReplaceType = TypeTuple!(ReplaceType!(From, To, T[0]),
+            ReplaceType!(From, To, T[1 .. $]));
+    }
+    else
+    {
+        alias ReplaceType = TypeTuple!();
+    }
+}
+
+///
+unittest
+{
+    static assert(
+        is(ReplaceType!(int, string, int[]) == string[]) &&
+        is(ReplaceType!(int, string, int[int]) == string[string]) &&
+        is(ReplaceType!(int, string, const(int)[]) == const(string)[]) &&
+        is(ReplaceType!(int, string, Tuple!(int[], float))
+            == Tuple!(string[], float))
+    );
+}
+
+private string replaceTypeInFunctionType(X, Y, fun)()
+{
+    alias storageClasses = ParameterStorageClassTuple!fun;
+    string result;
+    static if (functionLinkage!fun == "C")
+    {
+        result ~= "extern(C) ";
+    }
+    static if (functionAttributes!fun & FunctionAttribute.ref_)
+    {
+        result ~= "ref ";
+    }
+    result ~= (ReplaceType!(X, Y, ReturnType!fun)).stringof;
+    static if (is(fun == delegate))
+        result ~= " delegate";
+    else
+        result ~= " function";
+    result ~= "(";
+    foreach (i, T; Parameters!fun)
+    {
+        if (i) result ~= ", ";
+        if (storageClasses[i] & ParameterStorageClass.scope_)
+            result ~= "scope ";
+        if (storageClasses[i] & ParameterStorageClass.out_)
+            result ~= "out ";
+        if (storageClasses[i] & ParameterStorageClass.ref_)
+            result ~= "ref ";
+        if (storageClasses[i] & ParameterStorageClass.lazy_)
+            result ~= "lazy ";
+        if (storageClasses[i] & ParameterStorageClass.return_)
+            result ~= "return ";
+        result ~= ReplaceType!(X, Y, T).stringof;
+    }
+    static if (variadicFunctionStyle!fun != Variadic.no)
+    {
+        result ~= ", ...";
+    }
+    result ~= ")";
+    alias attributes = functionAttributes!fun;
+    static if (attributes & FunctionAttribute.pure_)
+        result ~= " pure";
+    static if (attributes & FunctionAttribute.nothrow_)
+        result ~= " nothrow";
+    static if (attributes & FunctionAttribute.property)
+        result ~= " @property";
+    static if (attributes & FunctionAttribute.trusted)
+        result ~= " @trusted";
+    static if (attributes & FunctionAttribute.safe)
+        result ~= " @safe";
+    static if (attributes & FunctionAttribute.nogc)
+        result ~= " @nogc";
+    static if (attributes & FunctionAttribute.system)
+        result ~= " @system";
+    static if (attributes & FunctionAttribute.const_)
+        result ~= " @const";
+    static if (attributes & FunctionAttribute.immutable_)
+        result ~= " immutable";
+    static if (attributes & FunctionAttribute.inout_)
+        result ~= " inout";
+    static if (attributes & FunctionAttribute.shared_)
+        result ~= " shared";
+    static if (attributes & FunctionAttribute.return_)
+        result ~= " return";
+    return result;
+}
+
+unittest
+{
+    template Test(Ts...)
+    {
+        static if (Ts.length)
+        {
+            //pragma(msg, "Testing: ReplaceType!("~Ts[0].stringof~", "
+            //    ~Ts[1].stringof~", "~Ts[2].stringof~")");
+            static assert(is(ReplaceType!(Ts[0], Ts[1], Ts[2]) == Ts[3]),
+                "ReplaceType!("~Ts[0].stringof~", "~Ts[1].stringof~", "
+                    ~Ts[2].stringof~") == "
+                    ~ReplaceType!(Ts[0], Ts[1], Ts[2]).stringof);
+            alias Test = Test!(Ts[4 .. $]);
+        }
+        else alias Test = void;
+    }
+
+    //import core.stdc.stdio;
+    alias RefFun1 = ref int function(float, long);
+    alias RefFun2 = ref float function(float, long);
+    extern(C) int printf(const char*, ...) nothrow @nogc @system;
+    extern(C) float floatPrintf(const char*, ...) nothrow @nogc @system;
+    int func(float);
+
+    alias Pass = Test!(
+        int, float, typeof(&func), float delegate(float),
+        int, float, typeof(&printf), typeof(&floatPrintf),
+        int, float, int function(out long, ...),
+            float function(out long, ...),
+        int, float, int function(ref float, long),
+            float function(ref float, long),
+        int, float, int function(ref int, long),
+            float function(ref float, long),
+        int, float, int function(out int, long),
+            float function(out float, long),
+        int, float, int function(lazy int, long),
+            float function(lazy float, long),
+        int, float, int function(out long, ref const int),
+            float function(out long, ref const float),
+        int, int, int, int,
+        int, float, int, float,
+        int, float, const int, const float,
+        int, float, immutable int, immutable float,
+        int, float, shared int, shared float,
+        int, float, int*, float*,
+        int, float, const(int)*, const(float)*,
+        int, float, const(int*), const(float*),
+        const(int)*, float, const(int*), const(float),
+        int*, float, const(int)*, const(int)*,
+        int, float, int[], float[],
+        int, float, int[42], float[42],
+        int, float, const(int)[42], const(float)[42],
+        int, float, const(int[42]), const(float[42]),
+        int, float, int[int], float[float],
+        int, float, int[double], float[double],
+        int, float, double[int], double[float],
+        int, float, int function(float, long), float function(float, long),
+        int, float, int function(float), float function(float),
+        int, float, int function(float, int), float function(float, float),
+        int, float, int delegate(float, long), float delegate(float, long),
+        int, float, int delegate(float), float delegate(float),
+        int, float, int delegate(float, int), float delegate(float, float),
+        int, float, Unique!int, Unique!float,
+        int, float, Tuple!(float, int), Tuple!(float, float),
+        int, float, RefFun1, RefFun2,
+    );
+}
+

--- a/std/variant.d
+++ b/std/variant.d
@@ -55,7 +55,7 @@ the current value.
 
 In addition to $(LREF Variant), this module also defines the $(LREF Algebraic)
 type constructor. Unlike `Variant`, `Algebraic` only allows a finite set of
-types, which are specified in the instantiation (e.g. $(D_PARAM Algebraic!(int,
+types, which are specified in the instantiation (e.g. $(D Algebraic!(int,
 string)) may only hold an `int` or a `string`).
 
 Credits: Reviewed by Brad Roberts. Daniel Keep provided a detailed code review
@@ -100,30 +100,30 @@ private template This2Variant(V, T...)
 }
 
 /**
- * $(D_PARAM VariantN) is a back-end type seldom used directly by user
- * code. Two commonly-used types using $(D_PARAM VariantN) as
+ * $(D VariantN) is a back-end type seldom used directly by user
+ * code. Two commonly-used types using $(D VariantN) as
  * back-end are:
  *
  * $(OL $(LI $(B Algebraic): A closed discriminated union with a
- * limited type universe (e.g., $(D_PARAM Algebraic!(int, double,
+ * limited type universe (e.g., $(D Algebraic!(int, double,
  * string)) only accepts these three types and rejects anything
  * else).) $(LI $(B Variant): An open discriminated union allowing an
- * unbounded set of types. If any of the types in the $(D_PARAM Variant)
+ * unbounded set of types. If any of the types in the $(D Variant)
  * are larger than the largest built-in type, they will automatically
  * be boxed. This means that even large types will only be the size
- * of a pointer within the $(D_PARAM Variant), but this also implies some
- * overhead. $(D_PARAM Variant) can accommodate all primitive types and
+ * of a pointer within the $(D Variant), but this also implies some
+ * overhead. $(D Variant) can accommodate all primitive types and
  * all user-defined types.))
  *
- * Both $(D_PARAM Algebraic) and $(D_PARAM Variant) share $(D_PARAM
+ * Both $(D Algebraic) and $(D Variant) share $(D
  * VariantN)'s interface. (See their respective documentations below.)
  *
- * $(D_PARAM VariantN) is a discriminated union type parameterized
- * with the largest size of the types stored ($(D_PARAM maxDataSize))
- * and with the list of allowed types ($(D_PARAM AllowedTypes)). If
- * the list is empty, then any type up of size up to $(D_PARAM
+ * $(D VariantN) is a discriminated union type parameterized
+ * with the largest size of the types stored ($(D maxDataSize))
+ * and with the list of allowed types ($(D AllowedTypes)). If
+ * the list is empty, then any type up of size up to $(D
  * maxDataSize) (rounded up for alignment) can be stored in a
- * $(D_PARAM VariantN) object without being boxed (types larger
+ * $(D VariantN) object without being boxed (types larger
  * than this will be boxed).
  *
  */
@@ -143,9 +143,9 @@ private:
     }
     enum size = SizeChecker.sizeof - (int function()).sizeof;
 
-    /** Tells whether a type $(D_PARAM T) is statically allowed for
-     * storage inside a $(D_PARAM VariantN) object by looking
-     * $(D_PARAM T) up in $(D_PARAM AllowedTypes).
+    /** Tells whether a type $(D T) is statically allowed for
+     * storage inside a $(D VariantN) object by looking
+     * $(D T) up in $(D AllowedTypes).
      */
     public template allowed(T)
     {
@@ -543,7 +543,7 @@ private:
     }
 
 public:
-    /** Constructs a $(D_PARAM VariantN) value given an argument of a
+    /** Constructs a $(D VariantN) value given an argument of a
      * generic type. Statically rejects disallowed types.
      */
 
@@ -577,7 +577,7 @@ public:
         }
     }
 
-    /** Assigns a $(D_PARAM VariantN) from a generic
+    /** Assigns a $(D VariantN) from a generic
      * argument. Statically rejects disallowed types. */
 
     VariantN opAssign(T)(T rhs)
@@ -664,7 +664,7 @@ public:
         return pack[0];
     }
 
-    /** Returns true if and only if the $(D_PARAM VariantN) object
+    /** Returns true if and only if the $(D VariantN) object
      * holds a valid value (has been initialized with, or assigned
      * from, a valid value).
      */
@@ -687,10 +687,10 @@ public:
     }
 
     /**
-     * If the $(D_PARAM VariantN) object holds a value of the
-     * $(I exact) type $(D_PARAM T), returns a pointer to that
-     * value. Otherwise, returns $(D_PARAM null). In cases
-     * where $(D_PARAM T) is statically disallowed, $(D_PARAM
+     * If the $(D VariantN) object holds a value of the
+     * $(I exact) type $(D T), returns a pointer to that
+     * value. Otherwise, returns $(D null). In cases
+     * where $(D T) is statically disallowed, $(D
      * peek) will not compile.
      */
     @property inout(T)* peek(T)() inout
@@ -717,7 +717,7 @@ public:
     }
 
     /**
-     * Returns the $(D_PARAM typeid) of the currently held value.
+     * Returns the $(D typeid) of the currently held value.
      */
 
     @property TypeInfo type() const nothrow @trusted
@@ -730,8 +730,8 @@ public:
     }
 
     /**
-     * Returns $(D_PARAM true) if and only if the $(D_PARAM VariantN)
-     * object holds an object implicitly convertible to type $(D_PARAM
+     * Returns $(D true) if and only if the $(D VariantN)
+     * object holds an object implicitly convertible to type $(D
      * U). Implicit convertibility is defined as per
      * $(LINK2 std_traits.html#ImplicitConversionTargets,ImplicitConversionTargets).
      */
@@ -780,12 +780,12 @@ public:
     }
 
     /**
-     * Returns the value stored in the $(D_PARAM VariantN) object,
-     * explicitly converted (coerced) to the requested type $(D_PARAM
-     * T). If $(D_PARAM T) is a string type, the value is formatted as
-     * a string. If the $(D_PARAM VariantN) object is a string, a
-     * parse of the string to type $(D_PARAM T) is attempted. If a
-     * conversion is not possible, throws a $(D_PARAM
+     * Returns the value stored in the $(D VariantN) object,
+     * explicitly converted (coerced) to the requested type $(D
+     * T). If $(D T) is a string type, the value is formatted as
+     * a string. If the $(D VariantN) object is a string, a
+     * parse of the string to type $(D T) is attempted. If a
+     * conversion is not possible, throws a $(D
      * VariantException).
      */
 
@@ -868,7 +868,7 @@ public:
     /**
      * Ordering comparison used by the "<", "<=", ">", and ">="
      * operators. In case comparison is not sensible between the held
-     * value and $(D_PARAM rhs), an exception is thrown.
+     * value and $(D rhs), an exception is thrown.
      */
 
     int opCmp(T)(T rhs)
@@ -971,8 +971,8 @@ public:
     }
 
     /**
-     * Arithmetic between $(D_PARAM VariantN) objects and numeric
-     * values. All arithmetic operations return a $(D_PARAM VariantN)
+     * Arithmetic between $(D VariantN) objects and numeric
+     * values. All arithmetic operations return a $(D VariantN)
      * object typed depending on the types of both values
      * involved. The conversion rules mimic D's built-in rules for
      * arithmetic conversions.
@@ -1081,7 +1081,7 @@ public:
     }
 
     /**
-     * Array and associative array operations. If a $(D_PARAM
+     * Array and associative array operations. If a $(D
      * VariantN) contains an (associative) array, it can be indexed
      * into. Otherwise, an exception is thrown.
      */
@@ -1105,7 +1105,7 @@ public:
 
     /** Caveat:
     Due to limitations in current language, read-modify-write
-    operations $(D_PARAM op=) will not work properly:
+    operations $(D op=) will not work properly:
     */
     unittest
     {
@@ -1132,7 +1132,7 @@ public:
         return args[0];
     }
 
-    /** If the $(D_PARAM VariantN) contains an (associative) array,
+    /** If the $(D VariantN) contains an (associative) array,
      * returns the length of that array. Otherwise, throws an
      * exception.
      */
@@ -1395,15 +1395,15 @@ unittest
 `char[]`, and `void delegate()`. This ensures that `Variant` is large enough
 to hold all of D's predefined types unboxed, including all numeric types,
 pointers, delegates, and class references.  You may want to use
-$(D_PARAM VariantN) directly with a different maximum size either for
+$(D VariantN) directly with a different maximum size either for
 storing larger types unboxed, or for saving memory.
  */
 alias Variant = VariantN!(maxSize!(creal, char[], void delegate()));
 
 /**
- * Returns an array of variants constructed from $(D_PARAM args).
+ * Returns an array of variants constructed from $(D args).
  *
- * This is by design. During construction the $(D_PARAM Variant) needs
+ * This is by design. During construction the $(D Variant) needs
  * static type information about the type being held, so as to store a
  * pointer to function for fast retrieval.
  */
@@ -1426,8 +1426,8 @@ unittest
     assert(b[1] == 3.14);
 }
 
-/** Code that needs functionality similar to the $(D_PARAM boxArray)
-function in the $(D_PARAM std.boxer) module can achieve it like this:
+/** Code that needs functionality similar to the $(D boxArray)
+function in the $(D std.boxer) module can achieve it like this:
 */
 unittest
 {
@@ -1452,9 +1452,9 @@ unittest
  * Thrown in three cases:
  *
  * $(OL $(LI An uninitialized Variant is used in any way except
- * assignment and $(D_PARAM hasValue);) $(LI A $(D_PARAM get) or
- * $(D_PARAM coerce) is attempted with an incompatible target type;)
- * $(LI A comparison between $(D_PARAM Variant) objects of
+ * assignment and $(D hasValue);) $(LI A $(D get) or
+ * $(D coerce) is attempted with an incompatible target type;)
+ * $(LI A comparison between $(D Variant) objects of
  * incompatible types is attempted.))
  *
  */
@@ -1983,11 +1983,11 @@ unittest
  * ensuring that all types are handled by the visiting functions.
  *
  * The delegate or function having the currently held value as parameter is called
- * with $(D_PARAM variant)'s current value. Visiting handlers are passed
+ * with $(D variant)'s current value. Visiting handlers are passed
  * in the template parameter list.
  * It is statically ensured that all types of
- * $(D_PARAM variant) are handled across all handlers.
- * $(D_PARAM visit) allows delegates and static functions to be passed
+ * $(D variant) are handled across all handlers.
+ * $(D visit) allows delegates and static functions to be passed
  * as parameters.
  *
  * If a function without parameters is specified, this function is called
@@ -1999,7 +1999,7 @@ unittest
  * Returns: The return type of visit is deduced from the visiting functions and must be
  * the same across all overloads.
  * Throws: If no parameter-less, error function is specified:
- * $(D_PARAM VariantException) if $(D_PARAM variant) doesn't hold a value.
+ * $(D VariantException) if $(D variant) doesn't hold a value.
  */
 template visit(Handler ...)
     if (Handler.length > 0)
@@ -2093,18 +2093,18 @@ unittest
 }
 
 /**
- * Behaves as $(D_PARAM visit) but doesn't enforce that all types are handled
+ * Behaves as $(D visit) but doesn't enforce that all types are handled
  * by the visiting functions.
  *
  * If a parameter-less function is specified it is called when
- * either $(D_PARAM variant) doesn't hold a value or holds a type
+ * either $(D variant) doesn't hold a value or holds a type
  * which isn't handled by the visiting functions.
  *
  * Returns: The return type of tryVisit is deduced from the visiting functions and must be
  * the same across all overloads.
- * Throws: If no parameter-less, error function is specified: $(D_PARAM VariantException) if
- *         $(D_PARAM variant) doesn't hold a value or
- *         if $(D_PARAM variant) holds a value which isn't handled by the visiting
+ * Throws: If no parameter-less, error function is specified: $(D VariantException) if
+ *         $(D variant) doesn't hold a value or
+ *         if $(D variant) holds a value which isn't handled by the visiting
  *         functions.
  */
 template tryVisit(Handler ...)
@@ -2180,11 +2180,11 @@ private auto visitImpl(bool Strict, VariantType, Handler...)(VariantType variant
 
 
     /**
-     * Returns: Struct where $(D_PARAM indices)  is an array which
+     * Returns: Struct where $(D indices)  is an array which
      * contains at the n-th position the index in Handler which takes the
      * n-th type of AllowedTypes. If an Handler doesn't match an
      * AllowedType, -1 is set. If a function in the delegates doesn't
-     * have parameters, the field $(D_PARAM exceptionFuncIdx) is set;
+     * have parameters, the field $(D exceptionFuncIdx) is set;
      * otherwise it's -1.
      */
     auto visitGetOverloadMap()


### PR DESCRIPTION
Now Algebraic can be used for creating self-referenced types. Refer to https://issues.dlang.org/show_bug.cgi?id=9608 for more motivation (probably this ought to close it).