### PR TITLE
std.process.browse() - fix memory corruption bug

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -3685,17 +3685,18 @@ else version (OSX)
     {
         const(char)*[5] args;
 
+        auto curl = url.tempCString();
         const(char)* browser = core.stdc.stdlib.getenv("BROWSER");
         if (browser)
         {   browser = strdup(browser);
             args[0] = browser;
-            args[1] = url.tempCString();
+            args[1] = curl;
             args[2] = null;
         }
         else
         {
             args[0] = "open".ptr;
-            args[1] = url.tempCString();
+            args[1] = curl;
             args[2] = null;
         }
 


### PR DESCRIPTION
Can't use result of `tempCString` after it goes out of scope.