### PR TITLE
package-shared unittest functions should not be under version(unittest)

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -361,8 +361,11 @@ unittest/%.run : $(ROOT)/unittest/test_runner
 
 # Target for quickly running a single unittest (using static phobos library).
 # For example: "make std/algorithm/mutation.test"
+# The mktemp business is needed so .o files don't clash in concurrent unittesting.
 %.test : %.d $(LIB)
-	$(DMD) $(DFLAGS) -main -unittest $(LIB) -defaultlib= -debuglib= -L-lcurl -cov -run $<
+	T=`mktemp -d /tmp/.dmd-run-test.XXXXXX` && \
+	  $(DMD) -od$$T $(DFLAGS) -main -unittest $(LIB) -defaultlib= -debuglib= -L-lcurl -cov -run $< && \
+	  rm -rf $$T
 
 # Target for quickly unittesting all modules and packages within a package,
 # transitively. For example: "make std/algorithm.test"

--- a/std/experimental/logger/core.d
+++ b/std/experimental/logger/core.d
@@ -1804,19 +1804,14 @@ unittest
     stdThreadLocalLog = l;
 }
 
-version (unittest)
+@trusted package string randomString(size_t upto)
 {
-    import std.array;
-    import std.ascii;
-    import std.random;
-
-    @trusted package string randomString(size_t upto)
-    {
-        auto app = Appender!string();
-        foreach (_ ; 0 .. upto)
-            app.put(letters[uniform(0, letters.length)]);
-        return app.data;
-    }
+    import std.ascii : letters;
+    import std.random : uniform;
+    auto app = Appender!string();
+    foreach (_ ; 0 .. upto)
+        app.put(letters[uniform(0, letters.length)]);
+    return app.data;
 }
 
 @safe unittest
@@ -1827,38 +1822,35 @@ version (unittest)
     globalLogLevel = ll;
 }
 
-version (unittest)
+package class TestLogger : Logger
 {
-    package class TestLogger : Logger
+    int line = -1;
+    string file = null;
+    string func = null;
+    string prettyFunc = null;
+    string msg = null;
+    LogLevel lvl;
+
+    this(const LogLevel lv = LogLevel.all) @safe
     {
-        int line = -1;
-        string file = null;
-        string func = null;
-        string prettyFunc = null;
-        string msg = null;
-        LogLevel lvl;
-
-        this(const LogLevel lv = LogLevel.all) @safe
-        {
-            super(lv);
-        }
-
-        override protected void writeLogMsg(ref LogEntry payload) @safe
-        {
-            this.line = payload.line;
-            this.file = payload.file;
-            this.func = payload.funcName;
-            this.prettyFunc = payload.prettyFuncName;
-            this.lvl = payload.logLevel;
-            this.msg = payload.msg;
-        }
+        super(lv);
     }
 
-    private void testFuncNames(Logger logger) @safe
+    override protected void writeLogMsg(ref LogEntry payload) @safe
     {
-        string s = "I'm here";
-        logger.log(s);
+        this.line = payload.line;
+        this.file = payload.file;
+        this.func = payload.funcName;
+        this.prettyFunc = payload.prettyFuncName;
+        this.lvl = payload.logLevel;
+        this.msg = payload.msg;
     }
+}
+
+version(unittest) private void testFuncNames(Logger logger) @safe
+{
+    string s = "I'm here";
+    logger.log(s);
 }
 
 @safe unittest

--- a/std/file.d
+++ b/std/file.d
@@ -42,33 +42,30 @@ else version (Posix)
 else
     static assert(false, "Module " ~ .stringof ~ " not implemented for this OS.");
 
-version (unittest)
+package @property string deleteme() @safe
 {
-    @property string deleteme() @safe
+    import std.process : thisProcessID;
+    static _deleteme = "deleteme.dmd.unittest.pid";
+    static _first = true;
+
+    if(_first)
     {
-        import std.process : thisProcessID;
-        static _deleteme = "deleteme.dmd.unittest.pid";
-        static _first = true;
-
-        if(_first)
-        {
-            _deleteme = buildPath(tempDir(), _deleteme) ~ to!string(thisProcessID);
-            _first = false;
-        }
-
-        return _deleteme;
+        _deleteme = buildPath(tempDir(), _deleteme) ~ to!string(thisProcessID);
+        _first = false;
     }
 
-    version(Android)
-    {
-        enum system_directory = "/system/etc";
-        enum system_file      = "/system/etc/hosts";
-    }
-    else version(Posix)
-    {
-        enum system_directory = "/usr/include";
-        enum system_file      = "/usr/include/assert.h";
-    }
+    return _deleteme;
+}
+
+version(Android)
+{
+    package enum system_directory = "/system/etc";
+    package enum system_file      = "/system/etc/hosts";
+}
+else version(Posix)
+{
+    package enum system_directory = "/usr/include";
+    package enum system_file      = "/usr/include/assert.h";
 }
 
 


### PR DESCRIPTION
Package-shared artifacts used only for unittesting should not be versioned with `version(unittest)` because that precludes unittesting one or more modules against the build library. Example:

    make std/experimental/logger.test

has link-time errors. This PR fixes them.