### PR TITLE
std.process.spawnProcessImpl memory corruption bug

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -562,8 +562,9 @@ private Pid spawnProcessImpl(in char[] commandLine,
     DWORD dwCreationFlags =
         CREATE_UNICODE_ENVIRONMENT |
         ((config & Config.suppressConsole) ? CREATE_NO_WINDOW : 0);
+    auto pworkDir = workDir.tempCStringW();
     if (!CreateProcessW(null, commandLine.tempCStringW().buffPtr, null, null, true, dwCreationFlags,
-                        envz, workDir.length ? workDir.tempCStringW() : null, &startinfo, &pi))
+                        envz, workDir.length ? pworkDir : null, &startinfo, &pi))
         throw ProcessException.newFromLastError("Failed to spawn new process");
 
     // figure out if we should close any of the streams


### PR DESCRIPTION
Destructors are called for temps created in the leaves of ?: statements. See also https://github.com/D-Programming-Language/phobos/pull/3404