### PR TITLE
Range-ify std.internal.cstring 2nd try

### DIFF
--- a/std/internal/cstring.d
+++ b/std/internal/cstring.d
@@ -1,4 +1,4 @@
-﻿/**
+/**
 Helper functions for working with $(I C strings).
 
 This module is intended to provide fast, safe and garbage free
@@ -38,6 +38,7 @@ module std.internal.cstring;
 
 
 import std.traits;
+import std.range;
 
 version(unittest)
 @property inout(C)[] asArray(C)(inout C* cstr) pure nothrow @nogc
@@ -52,9 +53,15 @@ body
 }
 
 /**
-Creates temporary $(I C string) with copy of passed text.
+Creates temporary 0-terminated $(I C string) with copy of passed text.
 
-Returned object is implicitly convertible to $(D const To*) and
+Params:
+    To = character type of returned C string
+    str = string or input range to be converted
+
+Returns:
+
+The value returned is implicitly convertible to $(D const To*) and
 has two properties: $(D ptr) to access $(I C string) as $(D const To*)
 and $(D buffPtr) to access it as $(D To*).
 
@@ -75,13 +82,16 @@ $(D strlen(str.tempCString()))). Incorrect usage of this function may
 lead to memory corruption.
 See $(RED WARNING) in $(B Examples) section.
 */
-auto tempCString(To = char, From)(in From[] str) nothrow @nogc
-if(isSomeChar!To && isSomeChar!From)
-{
-    import core.checkedint : addu;
-    import core.exception : onOutOfMemoryError;
 
-    enum useStack = cast(To*) -1;
+auto tempCString(To = char, From)(From str)
+    if (isSomeChar!To && (isInputRange!From || isSomeString!From))
+{
+    import core.exception : onOutOfMemoryError;
+    import core.stdc.string : memcpy;
+
+    enum useStack = cast(To*) size_t.max;
+
+    alias CF = Unqual!(ElementEncodingType!From);
 
     static struct Res
     {
@@ -91,41 +101,86 @@ if(isSomeChar!To && isSomeChar!From)
         @disable this(this);
         alias ptr this;
 
-        @property inout(To)* buffPtr() inout @safe pure
-        { return _ptr == useStack ? _buff.ptr : _ptr; }
+        @property inout(To)* buffPtr() inout pure
+        {
+            return _ptr == useStack ? _buff.ptr : _ptr;
+        }
 
-        @property const(To)* ptr() const @safe pure
-        { return buffPtr; }
+        @property const(To)* ptr() const pure
+        {
+            return buffPtr;
+        }
 
         ~this()
-        { if(_ptr != useStack) rawFree(_ptr); }
+        {
+            if (_ptr != useStack)
+            {
+                import core.stdc.stdlib : free;
+                free(_ptr);
+            }
+        }
 
     private:
         To* _ptr;
-        To[256] _buff;
+        version (unittest)
+        {
+            enum buffLength = 16 / To.sizeof;   // smaller size to trigger reallocations
+        }
+        else
+        {
+            enum buffLength = 256 / To.sizeof;   // production size
+        }
+
+        To[256 / To.sizeof] _buff;  // the 'small string optimization'
     }
 
-    // TODO: Don't stack allocate uninitialized array to
-    // not confuse unprecise GC.
-
-    Res res = void;
-    if(!str.ptr)
-    {
-        res._ptr = null;
-        return res;
-    }
+    Res res = void;     // expensive to fill _buff[]
 
     // Note: res._ptr can't point to res._buff as structs are movable.
 
-    bool overflow = false;
-    const totalCount = addu(maxLength!To(str), 1, overflow);
-    if(overflow)
-        onOutOfMemoryError();
-    const needAllocate = totalCount > res._buff.length;
-    To[] arr = copyEncoded(str, needAllocate ?
-        allocate!To(totalCount)[0 .. $ - 1] : res._buff[0 .. totalCount - 1]);
-    *(arr.ptr + arr.length) = '\0';
-    res._ptr = needAllocate ? arr.ptr : useStack;
+    import std.utf : byUTF;
+
+    To* p      = res._buff.ptr;
+    size_t len = res.buffLength;
+    size_t i;
+
+    static if (isSomeString!From)
+        auto r = cast(const(CF)[])str;
+    else
+        alias r = str;
+    foreach (const c; byUTF!(Unqual!To)(r))
+    {
+        if (i + 1 == len)
+        {
+            import core.stdc.stdlib : malloc, realloc;
+
+            if (len >= size_t.max / (2 * To.sizeof))
+                onOutOfMemoryError();
+            size_t newlen = len * 3 / 2;
+            if (p == res._buff.ptr)
+            {
+                static if (hasLength!From)
+                {
+                    if (newlen <= str.length)
+                        newlen = str.length + 1; // +1 for terminating 0
+                }
+                p = cast(To*)malloc(newlen * To.sizeof);
+                if (!p)
+                    onOutOfMemoryError();
+                memcpy(p, res._buff.ptr, i * To.sizeof);
+            }
+            else
+            {
+                p = cast(To*)realloc(p, newlen * To.sizeof);
+                if (!p)
+                    onOutOfMemoryError();
+            }
+            len = newlen;
+        }
+        p[i++] = c;
+    }
+    p[i] = 0;
+    res._ptr = (p == res._buff.ptr) ? useStack : p;
     return res;
 }
 
@@ -156,178 +211,15 @@ nothrow @nogc unittest
     assert("abc".tempCString().asArray == "abc");
     assert("abc"d.tempCString().ptr.asArray == "abc");
     assert("abc".tempCString!wchar().buffPtr.asArray == "abc"w);
+
+    import std.utf : byChar, byWchar;
+    char[300] abc = 'a';
+    assert(tempCString(abc[].byChar).buffPtr.asArray == abc);
+    assert(tempCString(abc[].byWchar).buffPtr.asArray == abc);
 }
 
-// Test for Issue 13367: ensure there is no memory corruption
-nothrow @nogc unittest
-{
-    @property str(C)() { C[300] arr = 'a'; return arr; }
-    assert(str!char.tempCString!wchar().asArray == str!wchar);
-    assert(str!char.tempCString!dchar().asArray == str!dchar);
-}
 
 version(Windows)
-    alias tempCStringW = tempCString!(wchar, char);
+    alias tempCStringW = tempCString!(wchar, const(char)[]);
 
 
-private:
-
-
-// Helper UTF functions.
-// ----------------------------------------------------------------------------------------------------
-
-/**
-Returns maximum possible length of string conversion
-to another Unicode Transformation Format result.
-*/
-size_t maxLength(To, From)(in size_t length) pure nothrow @nogc
-if(isSomeChar!To && isSomeChar!From)
-{
-    static if (To.sizeof >= From.sizeof)
-        enum k = 1; // worst case: every code unit represents a character
-    else static if (To.sizeof == 1 && From.sizeof == 2)
-        enum k = 3; // worst case: every wchar in top of BMP
-    else static if (To.sizeof == 1 && From.sizeof == 4)
-        enum k = 4; // worst case: every dchar not in BMP
-    else static if (To.sizeof == 2 && From.sizeof == 4)
-        enum k = 2; // worst case: every dchar not in BMP
-    else
-        static assert(0);
-    return length * k;
-}
-
-/// ditto
-size_t maxLength(To, From)(in From[] str) pure nothrow @nogc
-{ return maxLength!(To, From)(str.length); }
-
-pure nothrow @nogc unittest
-{
-    assert(maxLength!char("abc") == 3);
-    assert(maxLength!dchar("abc") == 3);
-    assert(maxLength!char("abc"w) == 9);
-    assert(maxLength!char("abc"d) == 12);
-    assert(maxLength!wchar("abc"d) == 6);
-}
-
-
-/**
-Copies text from $(D source) to $(D buff) performing conversion
-to different Unicode Transformation Format if needed.
-
-$(D buff) must be large enough to hold the result.
-
-Returns:
-Slice of the provided buffer $(D buff) with the copy of $(D source).
-*/
-To[] copyEncoded(To, From)(in From[] source, To[] buff) @trusted nothrow @nogc
-if(isSomeChar!To && isSomeChar!From)
-{
-    static if(is(Unqual!To == Unqual!From))
-    {
-        return buff[0 .. source.length] = source[];
-    }
-    else
-    {
-        import std.utf : byChar, byWchar, byDchar;
-        alias GenericTuple(Args...) = Args;
-        alias byFunc = GenericTuple!(byChar, byWchar, null, byDchar)[To.sizeof - 1];
-
-        To* ptr = buff.ptr;
-        const To* last = ptr + buff.length;
-        foreach(const c; byFunc(source))
-        {
-            assert(ptr != last);
-            *ptr++ = c;
-        }
-        return buff[0 .. ptr - buff.ptr];
-    }
-}
-
-///
-pure nothrow @nogc unittest
-{
-    const str = "abc-ЭЮЯ";
-    wchar[100] wsbuff;
-    assert(copyEncoded(str, wsbuff) == "abc-ЭЮЯ"w);
-}
-
-pure nothrow @nogc unittest
-{
-    wchar[100] wsbuff;
-    assert(copyEncoded("abc-ЭЮЯ"w, wsbuff) == "abc-ЭЮЯ"w);
-}
-
-pure unittest
-{
-    import std.range;
-    import std.utf : toUTF16, toUTF32;
-
-    const str = "abc-ЭЮЯ";
-    char[100] sbuff;
-
-    {
-        wchar[100] wsbuff;
-        const strW = toUTF16(str);
-        assert(copyEncoded(str, wsbuff[0 .. strW.length]) == strW);
-        assert(copyEncoded(strW, sbuff[0 .. str.length]) == str);
-    }
-    {
-        dchar[100] dsbuff;
-        const strD = toUTF32(str);
-        assert(copyEncoded(str, dsbuff[0 .. walkLength(str)]) == strD);
-        assert(copyEncoded(strD, sbuff[0 .. str.length]) == str);
-    }
-}
-
-
-// Helper functions for memory allocation & freeing.
-// ----------------------------------------------------------------------------------------------------
-
-// WARNING: Alignment is implementation defined in C so the value '4'
-// relies on undocumented but common behaviour.
-// FIXME: This value should be checked and adjusted on every C runtime.
-enum mallocAlignment = 4;
-
-// NOTE: `allocate`/`rawFree` simply wraps C allocation functions for now
-// but it may be changed in future so one shouldn't rely on that.
-
-T[] allocate(T)(in size_t count) nothrow @nogc
-if(T.alignof <= mallocAlignment)
-in { assert(count); }
-body
-{
-    import core.exception : onOutOfMemoryError;
-    import core.checkedint: mulu;
-
-    bool overflow = false;
-    const buffBytes = mulu(T.sizeof, count, overflow);
-    if(overflow)
-        onOutOfMemoryError();
-
-    auto ptr = cast(T*) tryRawAllocate(buffBytes);
-    if(!ptr)
-        onOutOfMemoryError();
-
-    return ptr[0 .. count];
-}
-
-void* tryRawAllocate(in size_t count) nothrow @nogc
-in { assert(count); }
-body
-{
-    import core.stdc.stdlib: malloc;
-    // Workaround snn @@@BUG11646@@@
-    version(DigitalMars) version(Win32)
-        if(count > 0xD5550000) return null;
-
-    // FIXME: `malloc` must be checked on every C runtime for
-    // possible bugs and workarounded if necessary.
-
-    return malloc(count);
-}
-
-void rawFree(void* ptr) nothrow @nogc
-{
-    import core.stdc.stdlib: free;
-    free(ptr);
-}


### PR DESCRIPTION
The same code as for https://github.com/D-Programming-Language/phobos/pull/3404. The https://issues.dlang.org/show_bug.cgi?id=14696 issue is not caused by this PR, and the existing cstring.d it replaces has the same latent issue. Also, 14696 should not hold up this PR, and the Phobos problem has been worked around with https://github.com/D-Programming-Language/phobos/pull/3413