### PR TITLE
std.internal.cstring - @nogc must be inferred

### DIFF
--- a/std/internal/cstring.d
+++ b/std/internal/cstring.d
@@ -83,7 +83,7 @@ lead to memory corruption.
 See $(RED WARNING) in $(B Examples) section.
 */
 
-auto tempCString(To = char, From)(From str) @nogc
+auto tempCString(To = char, From)(From str)
     if (isSomeChar!To && (isInputRange!From || isSomeString!From) &&
         isSomeChar!(ElementEncodingType!From))
 {


### PR DESCRIPTION
Templates should infer their attributes - after all, what if the range argument allocates gc memory (which it does in parts of Phobos)?