### PR TITLE
std.path: Rename setExt to withExtension

### DIFF
--- a/std/path.d
+++ b/std/path.d
@@ -988,7 +988,7 @@ unittest
     ---
 
     See_Also:
-        $(LREF setExt) which does not allocate and returns a lazy range.
+        $(LREF withExtension) which does not allocate and returns a lazy range.
 */
 immutable(Unqual!C1)[] setExtension(C1, C2)(in C1[] path, in C2[] ext)
     if (isSomeChar!C1 && !is(C1 == immutable) && is(Unqual!C1 == Unqual!C2))
@@ -996,7 +996,7 @@ immutable(Unqual!C1)[] setExtension(C1, C2)(in C1[] path, in C2[] ext)
     try
     {
         import std.conv : to;
-        return setExt(path, ext).to!(typeof(return));
+        return withExtension(path, ext).to!(typeof(return));
     }
     catch (Exception e)
     {
@@ -1014,7 +1014,7 @@ immutable(C1)[] setExtension(C1, C2)(immutable(C1)[] path, const(C2)[] ext)
     try
     {
         import std.conv : to;
-        return setExt(path, ext).to!(typeof(return));
+        return withExtension(path, ext).to!(typeof(return));
     }
     catch (Exception e)
     {
@@ -1061,7 +1061,7 @@ unittest
  * See_Also:
  *      $(LREF setExtension)
  */
-auto setExt(R, C)(R path, C[] ext)
+auto withExtension(R, C)(R path, C[] ext)
     if ((isRandomAccessRange!R && hasSlicing!R && hasLength!R && isSomeChar!(ElementType!R) ||
          is(StringTypeOf!R)) &&
         isSomeChar!C)
@@ -1080,14 +1080,14 @@ auto setExt(R, C)(R path, C[] ext)
 unittest
 {
     import std.array;
-    assert (setExt("file", "ext").array == "file.ext");
-    assert (setExt("file"w, ".ext"w).array == "file.ext");
-    assert (setExt("file.ext"w, ".").array == "file.");
+    assert (withExtension("file", "ext").array == "file.ext");
+    assert (withExtension("file"w, ".ext"w).array == "file.ext");
+    assert (withExtension("file.ext"w, ".").array == "file.");
 
     import std.utf : byChar, byWchar;
-    assert (setExt("file".byChar, "ext").array == "file.ext");
-    assert (setExt("file"w.byWchar, ".ext"w).array == "file.ext"w);
-    assert (setExt("file.ext"w.byWchar, ".").array == "file."w);
+    assert (withExtension("file".byChar, "ext").array == "file.ext");
+    assert (withExtension("file"w.byWchar, ".ext"w).array == "file.ext"w);
+    assert (withExtension("file.ext"w.byWchar, ".").array == "file."w);
 }
 
 


### PR DESCRIPTION
We really don't need two functions called `setExt` and `setExtension` within the same module.

See https://github.com/D-Programming-Language/phobos/pull/3370#issuecomment-111115953 and linked discussion.