### PR TITLE
workaround Issue 14718 - float parsing depends on platform strtold

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -2754,6 +2754,7 @@ float ldexp(float n, int exp) @safe pure nothrow @nogc { return ldexp(cast(real)
     else static assert(false, "Floating point type real not supported");
 }
 
+/* workaround Issue 14718, float parsing depends on platform strtold
 @safe pure nothrow @nogc unittest
 {
     assert(ldexp(1.0, -1024) == 0x1p-1024);
@@ -2775,6 +2776,7 @@ float ldexp(float n, int exp) @safe pure nothrow @nogc { return ldexp(cast(real)
     assert(x==-127);
     assert(ldexp(n, x)==0x1p-128f);
 }
+*/
 
 unittest
 {


### PR DESCRIPTION
- comment out the affected unittests for now

[Issue 14718 – float parsing depends on libc strtold precision](https://issues.dlang.org/show_bug.cgi?id=14718)