### PR TITLE
Move TypeTuple alias to std.typetuple.

### DIFF
--- a/std/meta.d
+++ b/std/meta.d
@@ -41,7 +41,7 @@ template Arguments(TList...)
 ///
 unittest
 {
-    import std.typetuple;
+    import std.meta;
     alias TL = Arguments!(int, double);
 
     int foo(TL td)  // same as int foo(int, double);
@@ -58,11 +58,6 @@ unittest
     alias Types = Arguments!(TL, char);
     static assert(is(Types == Arguments!(int, double, char)));
 }
-
-/**
- * Alternate name for $(LREF Arguments) for legacy compatibility.
- */
-alias TypeTuple = Arguments;
 
 /**
  * Returns the index of the first occurrence of type T in the
@@ -88,7 +83,7 @@ unittest
     void foo()
     {
         writefln("The index of long is %s",
-                 staticIndexOf!(long, TypeTuple!(int, long, double)));
+                 staticIndexOf!(long, Arguments!(int, long, double)));
         // prints: The index of long is 1
     }
 }
@@ -164,9 +159,9 @@ template Erase(alias T, TList...)
 ///
 unittest
 {
-    alias Types = TypeTuple!(int, long, double, char);
+    alias Types = Arguments!(int, long, double, char);
     alias TL = Erase!(long, Types);
-    static assert(is(TL == TypeTuple!(int, double, char)));
+    static assert(is(TL == Arguments!(int, double, char)));
 }
 
 // [internal]
@@ -184,11 +179,11 @@ private template GenericErase(args...)
         static if (isSame!(e, head))
             alias result = tail;
         else
-            alias result = TypeTuple!(head, GenericErase!(e, tail).result);
+            alias result = Arguments!(head, GenericErase!(e, tail).result);
     }
     else
     {
-        alias result = TypeTuple!();
+        alias result = Arguments!();
     }
 }
 
@@ -222,10 +217,10 @@ template EraseAll(alias T, TList...)
 ///
 unittest
 {
-    alias Types = TypeTuple!(int, long, long, int);
+    alias Types = Arguments!(int, long, long, int);
 
     alias TL = EraseAll!(long, Types);
-    static assert(is(TL == TypeTuple!(int, int)));
+    static assert(is(TL == Arguments!(int, int)));
 }
 
 // [internal]
@@ -244,11 +239,11 @@ private template GenericEraseAll(args...)
         static if (isSame!(e, head))
             alias result = next;
         else
-            alias result = TypeTuple!(head, next);
+            alias result = Arguments!(head, next);
     }
     else
     {
-        alias result = TypeTuple!();
+        alias result = Arguments!();
     }
 }
 
@@ -274,16 +269,16 @@ template NoDuplicates(TList...)
         alias NoDuplicates = TList;
     else
         alias NoDuplicates =
-            TypeTuple!(TList[0], NoDuplicates!(EraseAll!(TList[0], TList[1 .. $])));
+            Arguments!(TList[0], NoDuplicates!(EraseAll!(TList[0], TList[1 .. $])));
 }
 
 ///
 unittest
 {
-    alias Types = TypeTuple!(int, long, long, int, float);
+    alias Types = Arguments!(int, long, long, int, float);
 
     alias TL = NoDuplicates!(Types);
-    static assert(is(TL == TypeTuple!(int, long, float)));
+    static assert(is(TL == Arguments!(int, long, float)));
 }
 
 unittest
@@ -325,10 +320,10 @@ template Replace(alias T, alias U, TList...)
 ///
 unittest
 {
-    alias Types = TypeTuple!(int, long, long, int, float);
+    alias Types = Arguments!(int, long, long, int, float);
 
     alias TL = Replace!(long, char, Types);
-    static assert(is(TL == TypeTuple!(int, char, long, int, float)));
+    static assert(is(TL == Arguments!(int, char, long, int, float)));
 }
 
 // [internal]
@@ -345,14 +340,14 @@ private template GenericReplace(args...)
         alias tail = tuple[1 .. $];
 
         static if (isSame!(from, head))
-            alias result = TypeTuple!(to, tail);
+            alias result = Arguments!(to, tail);
         else
-            alias result = TypeTuple!(head,
+            alias result = Arguments!(head,
                 GenericReplace!(from, to, tail).result);
     }
     else
     {
-        alias result = TypeTuple!();
+        alias result = Arguments!();
     }
  }
 
@@ -405,10 +400,10 @@ template ReplaceAll(alias T, alias U, TList...)
 ///
 unittest
 {
-    alias Types = TypeTuple!(int, long, long, int, float);
+    alias Types = Arguments!(int, long, long, int, float);
 
     alias TL = ReplaceAll!(long, char, Types);
-    static assert(is(TL == TypeTuple!(int, char, char, int, float)));
+    static assert(is(TL == Arguments!(int, char, char, int, float)));
 }
 
 // [internal]
@@ -426,13 +421,13 @@ private template GenericReplaceAll(args...)
         alias next = GenericReplaceAll!(from, to, tail).result;
 
         static if (isSame!(from, head))
-            alias result = TypeTuple!(to, next);
+            alias result = Arguments!(to, next);
         else
-            alias result = TypeTuple!(head, next);
+            alias result = Arguments!(head, next);
     }
     else
     {
-        alias result = TypeTuple!();
+        alias result = Arguments!();
     }
 }
 
@@ -467,7 +462,7 @@ template Reverse(TList...)
     else
     {
         alias Reverse =
-            TypeTuple!(
+            Arguments!(
                 Reverse!(TList[$/2 ..  $ ]),
                 Reverse!(TList[ 0  .. $/2]));
     }
@@ -476,10 +471,10 @@ template Reverse(TList...)
 ///
 unittest
 {
-    alias Types = TypeTuple!(int, long, long, int, float);
+    alias Types = Arguments!(int, long, long, int, float);
 
     alias TL = Reverse!(Types);
-    static assert(is(TL == TypeTuple!(float, int, long, long, int)));
+    static assert(is(TL == Arguments!(float, int, long, long, int)));
 }
 
 /**
@@ -502,7 +497,7 @@ unittest
     class A { }
     class B : A { }
     class C : B { }
-    alias Types = TypeTuple!(A, C, B);
+    alias Types = Arguments!(A, C, B);
 
     MostDerived!(Object, Types) x;  // x is declared as type C
     static assert(is(typeof(x) == C));
@@ -518,7 +513,7 @@ template DerivedToFront(TList...)
         alias DerivedToFront = TList;
     else
         alias DerivedToFront =
-            TypeTuple!(MostDerived!(TList[0], TList[1 .. $]),
+            Arguments!(MostDerived!(TList[0], TList[1 .. $]),
                        DerivedToFront!(ReplaceAll!(MostDerived!(TList[0], TList[1 .. $]),
                                 TList[0],
                                 TList[1 .. $])));
@@ -530,29 +525,29 @@ unittest
     class A { }
     class B : A { }
     class C : B { }
-    alias Types = TypeTuple!(A, C, B);
+    alias Types = Arguments!(A, C, B);
 
     alias TL = DerivedToFront!(Types);
-    static assert(is(TL == TypeTuple!(C, B, A)));
+    static assert(is(TL == Arguments!(C, B, A)));
 }
 
 /**
-Evaluates to $(D TypeTuple!(F!(T[0]), F!(T[1]), ..., F!(T[$ - 1]))).
+Evaluates to $(D Arguments!(F!(T[0]), F!(T[1]), ..., F!(T[$ - 1]))).
  */
 template staticMap(alias F, T...)
 {
     static if (T.length == 0)
     {
-        alias staticMap = TypeTuple!();
+        alias staticMap = Arguments!();
     }
     else static if (T.length == 1)
     {
-        alias staticMap = TypeTuple!(F!(T[0]));
+        alias staticMap = Arguments!(F!(T[0]));
     }
     else
     {
         alias staticMap =
-            TypeTuple!(
+            Arguments!(
                 staticMap!(F, T[ 0  .. $/2]),
                 staticMap!(F, T[$/2 ..  $ ]));
     }
@@ -563,7 +558,7 @@ unittest
 {
     import std.traits : Unqual;
     alias TL = staticMap!(Unqual, int, const int, immutable int);
-    static assert(is(TL == TypeTuple!(int, int, int)));
+    static assert(is(TL == Arguments!(int, int, int)));
 }
 
 unittest
@@ -576,10 +571,10 @@ unittest
 
     // single
     alias Single = staticMap!(Unqual, const int);
-    static assert(is(Single == TypeTuple!int));
+    static assert(is(Single == Arguments!int));
 
     alias T = staticMap!(Unqual, int, const int, immutable int);
-    static assert(is(T == TypeTuple!(int, int, int)));
+    static assert(is(T == Arguments!(int, int, int)));
 }
 
 /**
@@ -652,26 +647,26 @@ unittest
 
 
 /**
- * Filters a $(D TypeTuple) using a template predicate. Returns a
- * $(D TypeTuple) of the elements which satisfy the predicate.
+ * Filters a $(D Arguments) using a template predicate. Returns a
+ * $(D Arguments) of the elements which satisfy the predicate.
  */
 template Filter(alias pred, TList...)
 {
     static if (TList.length == 0)
     {
-        alias Filter = TypeTuple!();
+        alias Filter = Arguments!();
     }
     else static if (TList.length == 1)
     {
         static if (pred!(TList[0]))
-            alias Filter = TypeTuple!(TList[0]);
+            alias Filter = Arguments!(TList[0]);
         else
-            alias Filter = TypeTuple!();
+            alias Filter = Arguments!();
     }
     else
     {
         alias Filter =
-            TypeTuple!(
+            Arguments!(
                 Filter!(pred, TList[ 0  .. $/2]),
                 Filter!(pred, TList[$/2 ..  $ ]));
     }
@@ -682,21 +677,21 @@ unittest
 {
     import std.traits : isNarrowString, isUnsigned;
 
-    alias Types1 = TypeTuple!(string, wstring, dchar[], char[], dstring, int);
+    alias Types1 = Arguments!(string, wstring, dchar[], char[], dstring, int);
     alias TL1 = Filter!(isNarrowString, Types1);
-    static assert(is(TL1 == TypeTuple!(string, wstring, char[])));
+    static assert(is(TL1 == Arguments!(string, wstring, char[])));
 
-    alias Types2 = TypeTuple!(int, byte, ubyte, dstring, dchar, uint, ulong);
+    alias Types2 = Arguments!(int, byte, ubyte, dstring, dchar, uint, ulong);
     alias TL2 = Filter!(isUnsigned, Types2);
-    static assert(is(TL2 == TypeTuple!(ubyte, uint, ulong)));
+    static assert(is(TL2 == Arguments!(ubyte, uint, ulong)));
 }
 
 unittest
 {
     import std.traits : isPointer;
 
-    static assert(is(Filter!(isPointer, int, void*, char[], int*) == TypeTuple!(void*, int*)));
-    static assert(is(Filter!isPointer == TypeTuple!()));
+    static assert(is(Filter!(isPointer, int, void*, char[], int*) == Arguments!(void*, int*)));
+    static assert(is(Filter!isPointer == Arguments!()));
 }
 
 
@@ -740,7 +735,7 @@ unittest
 
 unittest
 {
-    foreach (T; TypeTuple!(int, staticMap, 42))
+    foreach (T; Arguments!(int, staticMap, 42))
     {
         static assert(!Instantiate!(templateNot!testAlways, T));
         static assert(Instantiate!(templateNot!testNever, T));
@@ -791,7 +786,7 @@ unittest
 
 unittest
 {
-    foreach (T; TypeTuple!(int, staticMap, 42))
+    foreach (T; Arguments!(int, staticMap, 42))
     {
         static assert( Instantiate!(templateAnd!(), T));
         static assert( Instantiate!(templateAnd!(testAlways), T));
@@ -849,7 +844,7 @@ unittest
 
 unittest
 {
-    foreach (T; TypeTuple!(int, staticMap, 42))
+    foreach (T; Arguments!(int, staticMap, 42))
     {
         static assert( Instantiate!(templateOr!(testAlways), T));
         static assert( Instantiate!(templateOr!(testAlways, testAlways), T));

--- a/std/typetuple.d
+++ b/std/typetuple.d
@@ -9,3 +9,29 @@
 module std.typetuple;
 
 public import std.meta;
+
+/**
+ * Alternate name for $(LREF Arguments) for legacy compatibility.
+ */
+alias TypeTuple = Arguments;
+
+///
+unittest
+{
+    import std.typetuple;
+    alias TL = TypeTuple!(int, double);
+
+    int foo(TL td)  // same as int foo(int, double);
+    {
+        return td[0] + cast(int)td[1];
+    }
+}
+
+///
+unittest
+{
+    alias TL = TypeTuple!(int, double);
+
+    alias Types = TypeTuple!(TL, char);
+    static assert(is(Types == TypeTuple!(int, double, char)));
+}


### PR DESCRIPTION
There is no reason to expose this more than it needs to. This ensure the role of backward compatibility already.