### PR TITLE
Supplemental fix for issue 14735 - Prevent self-recursive match

### DIFF
--- a/std/string.d
+++ b/std/string.d
@@ -472,7 +472,8 @@ ptrdiff_t indexOf(T, size_t n)(ref T[n] s, in dchar c,
         in CaseSensitive cs = CaseSensitive.yes) @safe pure
     if (isSomeChar!T)
 {
-    return indexOf(s[], c, cs);
+    auto r = s[];
+    return indexOf(r, c, cs);
 }
 
 @safe pure unittest


### PR DESCRIPTION
The slice expression `s[]` will match to T[n] by using compile-time length deduction.

Required by: https://github.com/D-Programming-Language/dmd/pull/4779