### PR TITLE
Add thisPid() and Pid.getThis()

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -1147,7 +1147,7 @@ final class Pid
 
     /** Returns the $(D Pid) of the current process.
      */
-    static Pid getThis() { return new Pid(thisProcessID); }
+    static Pid getThis() @safe nothrow { return new Pid(thisProcessID); }
 
 private:
     /*

--- a/std/process.d
+++ b/std/process.d
@@ -2248,8 +2248,9 @@ version (Windows) private immutable string shellSwitch = "/C";
 
 /** Returns the $(D Pid) of the current process.
 
-    Usage of this function is preferred over $(D thisProcessID) as $(D Pid) is more
-    typesafe that int. For instance $(LREF kill) requires a $(D Pid) as argument.
+    Usage of this function is preferred over $(D thisProcessID) as its return
+    type $(D Pid) is more typesafe than $(D int). For instance, $(LREF kill)
+    requires a $(D Pid) as argument.
     */
 @property Pid thisPid() @trusted nothrow //TODO: @safe
 {

--- a/std/process.d
+++ b/std/process.d
@@ -2264,7 +2264,7 @@ version (Windows) private immutable string shellSwitch = "/C";
     */
 @property Pid thisPid() @trusted nothrow //TODO: @safe
 {
-    return new typeof(return)(thisProcessID);
+    return Pid.getThis();
 }
 
 // Unittest support code:  TestScript takes a string that contains a

--- a/std/process.d
+++ b/std/process.d
@@ -2247,7 +2247,7 @@ version (Windows) private immutable string shellSwitch = "/C";
     Usage of this function is preferred over $(D thisProcessID) as $(D Pid) is more
     typesafe that int. For instance $(LREF kill) requires a $(D Pid) as argument.
     */
-@property Pid thisProcessPid() @trusted nothrow //TODO: @safe
+@property Pid thisPid() @trusted nothrow //TODO: @safe
 {
     return new typeof(return)(thisProcessID);
 }
@@ -3522,7 +3522,7 @@ else
  * Returns the process ID of the calling process, which is guaranteed to be
  * unique on the system. This call is always successful.
  *
- * $(RED Deprecated.  Please use $(LREF thisProcessID) or $(LREF thisProcessPid)
+ * $(RED Deprecated.  Please use $(LREF thisProcessID) or $(LREF thisPid)
  *       instead.  This function will be removed in August 2015.)
  *
  * Example:

--- a/std/process.d
+++ b/std/process.d
@@ -1145,6 +1145,10 @@ final class Pid
         return _processID;
     }
 
+    /** Returns the $(D Pid) of the current process.
+     */
+    static Pid getThis() { return new Pid(thisProcessID); }
+
 private:
     /*
     Pid.performWait() does the dirty work for wait() and nonBlockingWait().

--- a/std/process.d
+++ b/std/process.d
@@ -1147,7 +1147,17 @@ final class Pid
 
     /** Returns the $(D Pid) of the current process.
      */
-    static Pid getThis() @safe nothrow { return new Pid(thisProcessID); }
+    static Pid getThis() @safe nothrow
+    {
+        version (Windows)
+        {
+            return new Pid(thisProcessID, INVALID_HANDLE_VALUE);
+        }
+        else
+        {
+            return new Pid(thisProcessID);
+        }
+    }
 
 private:
     /*

--- a/std/process.d
+++ b/std/process.d
@@ -2244,14 +2244,13 @@ version (Windows) private immutable string shellSwitch = "/C";
 
 /** Returns the $(D Pid) of the current process.
 
-    Using this function is preferred over $(D thisProcessID) as $(D Pid) is more
-    typesafe that int.
+    Usage of this function is preferred over $(D thisProcessID) as $(D Pid) is more
+    typesafe that int. For instance $(LREF kill) requires a $(D Pid) as argument.
     */
 @property Pid thisProcessPid() @trusted nothrow //TODO: @safe
 {
     return new typeof(return)(thisProcessID);
 }
-
 
 // Unittest support code:  TestScript takes a string that contains a
 // shell script for the current platform, and writes it to a temporary

--- a/std/process.d
+++ b/std/process.d
@@ -2242,6 +2242,16 @@ version (Windows) private immutable string shellSwitch = "/C";
     else version (Posix) return core.sys.posix.unistd.getpid();
 }
 
+/** Returns the $(D Pid) of the current process.
+
+    Using this function is preferred over $(D thisProcessID) as $(D Pid) is more
+    typesafe that int.
+    */
+@property Pid thisProcessPid() @trusted nothrow //TODO: @safe
+{
+    return new typeof(return)(thisProcessID);
+}
+
 
 // Unittest support code:  TestScript takes a string that contains a
 // shell script for the current platform, and writes it to a temporary
@@ -3513,8 +3523,8 @@ else
  * Returns the process ID of the calling process, which is guaranteed to be
  * unique on the system. This call is always successful.
  *
- * $(RED Deprecated.  Please use $(LREF thisProcessID) instead.
- *       This function will be removed in August 2015.)
+ * $(RED Deprecated.  Please use $(LREF thisProcessID) or $(LREF thisProcessPid)
+ *       instead.  This function will be removed in August 2015.)
  *
  * Example:
  * ---


### PR DESCRIPTION
This adds a typesafer version of `thisProcessID` named `thisProcessPid`.
 
See discussion at http://forum.dlang.org/post/pziiwlhoyyolgvvljgcg@forum.dlang.org.