### PR TITLE
Issue 14760 - Add clearContentLength for avoiding segmentation fault

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -768,6 +768,7 @@ private auto _basicHTTP(T)(const(char)[] url, const(void)[] sendData, HTTP clien
         {
             client.onSend = null;
             client.handle.onSeek = null;
+            client.clearContentLength();
         }
     }
     client.url = url;
@@ -2804,6 +2805,35 @@ struct HTTP
         else
         {
             p.curl.set(lenOpt, len);
+        }
+    }
+
+    // Clear ContentLength depending on method.
+    void clearContentLength()
+    {
+        CurlOption lenOpt;
+        if (p.method == Method.put)
+            lenOpt = CurlOption.infilesize_large;
+        else
+            lenOpt = CurlOption.postfieldsize_large;
+        p.curl.clear(lenOpt);
+    }
+
+    // segmentation fault test
+    unittest
+    {
+        if (!netAllowed()) return;
+        auto http = HTTP();
+        {
+            string data = "Hello world";
+            auto res = post(testUrl2, data, http);
+            assert(res == data,
+                   "post!HTTP() returns unexpected content " ~ res);
+        }
+        {
+            auto res = trace(testUrl1, http);
+            assert(res == "Hello world\n",
+                   "trace!HTTP() returns unexpected content " ~ res);
         }
     }
 


### PR DESCRIPTION
clearContentLength method make content length option clear as same as contentLength property for cleaing the extra option.

It is done to test the changes by persistent connection.