### PR TITLE
Issue 14762 - Reduce confusion for libcurl after HTTP request.

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -2266,35 +2266,45 @@ struct HTTP
     {
         p.status.reset();
 
+        CurlOption opt;
         final switch (p.method)
         {
         case Method.head:
             p.curl.set(CurlOption.nobody, 1L);
+            opt = CurlOption.nobody;
             break;
         case Method.undefined:
         case Method.get:
             p.curl.set(CurlOption.httpget, 1L);
+            opt = CurlOption.httpget;
             break;
         case Method.post:
             p.curl.set(CurlOption.post, 1L);
+            opt = CurlOption.post;
             break;
         case Method.put:
             p.curl.set(CurlOption.upload, 1L);
+            opt = CurlOption.upload;
             break;
         case Method.del:
             p.curl.set(CurlOption.customrequest, "DELETE");
+            opt = CurlOption.customrequest;
             break;
         case Method.options:
             p.curl.set(CurlOption.customrequest, "OPTIONS");
+            opt = CurlOption.customrequest;
             break;
         case Method.trace:
             p.curl.set(CurlOption.customrequest, "TRACE");
+            opt = CurlOption.customrequest;
             break;
         case Method.connect:
             p.curl.set(CurlOption.customrequest, "CONNECT");
+            opt = CurlOption.customrequest;
             break;
         }
 
+        scope (exit) p.curl.clear(opt);
         return p.curl.perform(throwOnError);
     }
 


### PR DESCRIPTION
After http request is done, Clear curl option for below problems.

- Prefer CUSTOM request by libcurl
https://github.com/bagder/curl/blob/master/lib/http.c#L1834
- Change any method to PUT after PUT by libcurl
https://github.com/bagder/curl/blob/master/lib/http.c#L1830
