### PR TITLE
Issue 14763 - Use optionsData argument for options function.

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -764,7 +764,9 @@ private auto _basicHTTP(T)(const(char)[] url, const(void)[] sendData, HTTP clien
         client.onReceive = null;
 
         if (sendData !is null &&
-            (client.method == HTTP.Method.post || client.method == HTTP.Method.put))
+            (client.method == HTTP.Method.post ||
+             client.method == HTTP.Method.put ||
+             client.method == HTTP.Method.options))
         {
             client.onSend = null;
             client.handle.onSeek = null;
@@ -781,7 +783,9 @@ private auto _basicHTTP(T)(const(char)[] url, const(void)[] sendData, HTTP clien
     };
 
     if (sendData !is null &&
-        (client.method == HTTP.Method.post || client.method == HTTP.Method.put))
+        (client.method == HTTP.Method.post ||
+         client.method == HTTP.Method.put ||
+         client.method == HTTP.Method.options))
     {
         client.contentLength = sendData.length;
         auto remainingData = sendData;
@@ -2786,7 +2790,9 @@ struct HTTP
         CurlOption lenOpt;
 
         // Force post if necessary
-        if (p.method != Method.put && p.method != Method.post)
+        if (p.method != Method.put &&
+            p.method != Method.post &&
+            p.method != Method.options)
             p.method = Method.post;
 
         if (p.method == Method.put)


### PR DESCRIPTION
Test code is in https://github.com/karronoli/std_net_curl_test
It is not tested in curl.d unittest block, because test http server is poor.
- client
 - options.d
- server
 - options.go