### PR TITLE
std.file: Fix building documentation on Windows

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -863,7 +863,7 @@ version(StdDdoc) void getTimesWin(R)(R name,
                                   out SysTime fileCreationTime,
                                   out SysTime fileAccessTime,
                                   out SysTime fileModificationTime)
-    if (isInputRange!R && isSomeChar!(ElementEncodingType!R));
+    if (isInputRange!R && isSomeChar!(ElementEncodingType!R)) {}
 
 else version(Windows) void getTimesWin(R)(R name,
                                        out SysTime fileCreationTime,


### PR DESCRIPTION
This fixes the error:

```
safe function 'std.file.timeLastModified' cannot call system function 'std.file.getTimesWin!(const(char)[]).getTimesWin'
```