### PR TITLE
add std.concurrencybase

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -164,7 +164,7 @@ STD_PACKAGES = std $(addprefix std/,\
 # Modules broken down per package
 
 PACKAGE_std = array ascii base64 bigint bitmanip compiler complex concurrency \
-  conv cstream csv datetime demangle encoding exception file format \
+  concurrencybase conv cstream csv datetime demangle encoding exception file format \
   functional getopt json math mathspecial meta metastrings mmfile numeric \
   outbuffer parallelism path process random signals socket socketstream stdint \
   stdio stdiobase stream string syserror system traits typecons typetuple uni \

--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -81,6 +81,7 @@ private
     import std.traits;
     import std.typecons;
     import std.typetuple;
+    import std.concurrencybase;
 
     template hasLocalAliasing(T...)
     {
@@ -955,7 +956,7 @@ private
 }
 
 
-shared static this()
+extern (C) void std_concurrency_static_this()
 {
     registryLock = new Mutex;
 }

--- a/std/concurrencybase.d
+++ b/std/concurrencybase.d
@@ -1,0 +1,20 @@
+// Written in the D programming language.
+
+/**
+ * The only purpose of this module is to do the static construction for
+ * std.concurrency, to eliminate cyclic construction errors.
+ *
+ * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Source:    $(PHOBOSSRC std/_concurrencybase.d)
+ */
+module std.concurrencybase;
+
+import core.sync.mutex;
+
+extern(C) void std_concurrency_static_this();
+
+shared static this()
+{
+    std_concurrency_static_this();
+}
+

--- a/win32.mak
+++ b/win32.mak
@@ -120,7 +120,7 @@ SRC_STD_3a= std\signals.d std\meta.d std\typetuple.d std\traits.d \
 	std\random.d \
 	std\exception.d \
 	std\compiler.d \
-	std\system.d std\concurrency.d
+	std\system.d std\concurrency.d std\concurrencybase.d
 
 SRC_STD_3b= std\datetime.d
 
@@ -178,7 +178,7 @@ SRC_STD= std\zlib.d std\zip.d std\stdint.d std\conv.d std\utf.d std\uri.d \
 	std\variant.d std\numeric.d std\bitmanip.d std\complex.d std\mathspecial.d \
 	std\functional.d std\array.d std\typecons.d \
 	std\json.d std\xml.d std\encoding.d std\bigint.d std\concurrency.d \
-	std\stdiobase.d std\parallelism.d \
+	std\concurrencybase.d std\stdiobase.d std\parallelism.d \
 	std\exception.d std\ascii.d
 
 SRC_STD_REGEX= std\regex\internal\ir.d std\regex\package.d std\regex\internal\parser.d \
@@ -481,6 +481,7 @@ cov : $(SRC_TO_COMPILE) $(LIB)
 	$(DMD) -conf= -cov=79 -unittest -main -run std\random.d
 	$(DMD) -conf= -cov=92 -unittest -main -run std\exception.d
 	$(DMD) -conf= -cov=73 -unittest -main -run std\concurrency.d
+	$(DMD) -conf= -cov=100 -unittest -main -run std\concurrencybase.d
 	$(DMD) -conf= -cov=95 -unittest -main -run std\datetime.d
 	$(DMD) -conf= -cov=96 -unittest -main -run std\uuid.d
 	$(DMD) -conf= -cov=100 -unittest -main -run std\digest\crc.d

--- a/win64.mak
+++ b/win64.mak
@@ -126,7 +126,7 @@ SRC_STD_3b= std\signals.d std\meta.d std\typetuple.d std\traits.d \
 	std\random.d \
 	std\exception.d \
 	std\compiler.d \
-	std\system.d std\concurrency.d
+	std\system.d std\concurrency.d std\concurrencybase.d
 
 #can't place SRC_STD_DIGEST in SRC_STD_REST because of out-of-memory issues
 SRC_STD_DIGEST= std\digest\crc.d std\digest\sha.d std\digest\md.d \
@@ -199,7 +199,7 @@ SRC_STD= std\zlib.d std\zip.d std\stdint.d std\conv.d std\utf.d std\uri.d \
 	std\variant.d std\numeric.d std\bitmanip.d std\complex.d std\mathspecial.d \
 	std\functional.d std\array.d std\typecons.d \
 	std\json.d std\xml.d std\encoding.d std\bigint.d std\concurrency.d \
-	std\stdiobase.d std\parallelism.d \
+	std\concurrencybase.d std\stdiobase.d std\parallelism.d \
 	std\exception.d std\ascii.d
 
 SRC_STD_REGEX= std\regex\internal\ir.d std\regex\package.d std\regex\internal\parser.d \


### PR DESCRIPTION
Following the stdio.d / stdiobase.d model, this adds concurrencybase.d, in order to eliminate the following circular import madness:
```
object.Exception@src\rt\minfo.d(167): Aborting: Cycle detected between modules with shared ctors/dtors:
std.concurrency* ->
std.exception ->
std.range ->
std.range.primitives ->
std.traits ->
std.array ->
std.functional ->
std.ascii ->
std.uni ->
std.format ->
std.conv ->
std.string ->
std.typecons ->
std.json ->
std.math ->
std.stdio ->
std.file ->
std.datetime ->
std.path ->
std.process ->
std.uuid ->
std.digest.md ->
std.digest.digest ->
std.digest.hmac ->
std.algorithm.mutation ->
std.algorithm.comparison ->
std.algorithm.iteration ->
std.parallelism* ->
std.concurrency
```
which happens when building for unit tests on Windows.
