### PR TITLE
std.regex: correctly add last character of a set to regex (bugzilla 14529)

### DIFF
--- a/std/regex/internal/parser.d
+++ b/std/regex/internal/parser.d
@@ -921,7 +921,7 @@ struct Parser(R)
                     op = Operator.Union;
                     goto case;
                 case ']':
-                    set |= last;
+                    addWithFlags(set, last, re_flags);
                     break L_CharTermLoop;
                 default:
                     addWithFlags(set, last, re_flags);
@@ -960,7 +960,7 @@ struct Parser(R)
                     op = Operator.Union;
                     goto case;
                 case ']':
-                    set |= last;
+                    addWithFlags(set, last, re_flags);
                     break L_CharTermLoop;
                 default:
                     addWithFlags(set, last, re_flags);

--- a/std/regex/internal/tests.d
+++ b/std/regex/internal/tests.d
@@ -955,3 +955,12 @@ unittest
     assertThrown(regex(`^(x(\1))`));
     assertThrown(regex(`^((x)(?=\1))`));
 }
+
+// bugzilla 14529
+unittest
+{
+    auto ctPat2 = regex(r"^[CDF]$", "i");
+    foreach(v; ["C", "c", "D", "d", "F", "f"])
+        assert(matchAll(v, ctPat2).front.hit == v);
+}
+


### PR DESCRIPTION
When encounting the end of a character set ']' we have to correctly add the last
encountered valid character to the regex and resepect flags. This bug caused the
last character to not be correctly case folded if case folding was requested.

This fixes https://issues.dlang.org/show_bug.cgi?id=14529.