### PR TITLE
Fix Issue 12966 - Optimization for BinaryHeap

### DIFF
--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1196,7 +1196,7 @@ package(std) template HeapOps(alias less, Range)
             --i;
         }
     }
-    
+
     //template because of @@@12410@@@
     void heapify()(Range r)
     {

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1185,7 +1185,7 @@ package(std) template HeapOps(alias less, Range)
         if(r.length < 2) return;
 
         // Build Heap
-        heapify(r);
+        buildHeap(r);
 
         // Sort
         size_t i = r.length - 1;
@@ -1198,7 +1198,7 @@ package(std) template HeapOps(alias less, Range)
     }
 
     //template because of @@@12410@@@
-    void heapify()(Range r)
+    void buildHeap()(Range r)
     {
         size_t i = r.length / 2;
         while(i > 0) percolate(r, --i, r.length);

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1123,7 +1123,7 @@ private void quickSortImpl(alias less, Range)(Range r, size_t depth)
     {
         if (depth == 0)
         {
-            HeapSortImpl!(less, Range).heapSort(r);
+            HeapOps!(less, Range).heapSort(r);
             return;
         }
         depth = depth >= depth.max / 2 ? (depth / 3) * 2 : (depth * 2) / 3;
@@ -1167,8 +1167,8 @@ private void quickSortImpl(alias less, Range)(Range r, size_t depth)
     }
 }
 
-// Bottom-Up Heap-Sort Implementation
-private template HeapSortImpl(alias less, Range)
+// Heap operations for random-access ranges
+package(std) template HeapOps(alias less, Range)
 {
     import std.algorithm.mutation : swapAt;
 
@@ -1185,21 +1185,27 @@ private template HeapSortImpl(alias less, Range)
         if(r.length < 2) return;
 
         // Build Heap
-        size_t i = r.length / 2;
-        while(i > 0) sift(r, --i, r.length);
+        heapify(r);
 
         // Sort
-        i = r.length - 1;
+        size_t i = r.length - 1;
         while(i > 0)
         {
             swapAt(r, 0, i);
-            sift(r, 0, i);
+            percolate(r, 0, i);
             --i;
         }
     }
+    
+    //template because of @@@12410@@@
+    void heapify()(Range r)
+    {
+        size_t i = r.length / 2;
+        while(i > 0) percolate(r, --i, r.length);
+    }
 
     //template because of @@@12410@@@
-    void sift()(Range r, size_t parent, immutable size_t end)
+    void percolate()(Range r, size_t parent, immutable size_t end)
     {
         immutable root = parent;
         size_t child = void;

--- a/std/container/binaryheap.d
+++ b/std/container/binaryheap.d
@@ -61,7 +61,7 @@ if (isRandomAccessRange!(Store) || isRandomAccessRange!(typeof(Store.init[])))
     import std.exception : enforce;
     import std.algorithm : move, min, HeapOps, swapAt;
     import std.typecons : RefCounted, RefCountedAutoInitialize;
-    
+
     alias percolate = HeapOps!(less, Store).percolate;
     alias heapify = HeapOps!(less, Store).heapify;
 


### PR DESCRIPTION
This pull request replaces the function `percolateDown` in `BinaryHeap` with a more efficient version simply dubbed `percolate`. This function is used initially to build the heap and to restore the heap property when an element is inserted or removed. The original function used a sift-down approach which is typical. This new function uses a [bottom-up](https://en.wikipedia.org/wiki/Heapsort#Bottom-up_heapsort) approach. The code is about 15% faster and performs nearly half the number of comparisons in most cases.

The code was copied over from `std.algorithm:sort`.