### PR TITLE
std.regex: simplify case

### DIFF
--- a/std/regex/internal/parser.d
+++ b/std/regex/internal/parser.d
@@ -924,6 +924,7 @@ struct Parser(R)
                     addWithFlags(set, last, re_flags);
                     break L_CharTermLoop;
                 default:
+                    state = State.Char;
                     addWithFlags(set, last, re_flags);
                     last = current;
                 }
@@ -937,39 +938,7 @@ struct Parser(R)
                     next();//skip second twin char
                     break L_CharTermLoop;
                 }
-                //~~~WORKAROUND~~~
-                //It's a copy of State.Char, should be goto case but see @@@BUG12603
-                switch(current)
-                {
-                case '|':
-                case '~':
-                case '&':
-                    // then last is treated as normal char and added as implicit union
-                    state = State.PotentialTwinSymbolOperator;
-                    addWithFlags(set, last, re_flags);
-                    last = current;
-                    break;
-                case '-': // still need more info
-                    state = State.CharDash;
-                    break;
-                case '\\':
-                    set |= last;
-                    state = State.Escape;
-                    break;
-                case '[':
-                    op = Operator.Union;
-                    goto case;
-                case ']':
-                    addWithFlags(set, last, re_flags);
-                    break L_CharTermLoop;
-                default:
-                    addWithFlags(set, last, re_flags);
-                    state = State.Char;
-                    last = current;
-                }
-                break;
-                //~~~END OF WORKAROUND~~~
-                //goto case State.Char;// it's not a twin lets re-run normal logic
+                goto case State.Char;
             case State.Escape:
                 // xxx \ current xxx
                 switch(current)

--- a/std/regex/internal/tests.d
+++ b/std/regex/internal/tests.d
@@ -249,6 +249,10 @@ unittest
         TestVectors(  "[0-9a-f~~0-5a-z]{2}",         "g0a58x",    "y",   "$&",     "8x"),
         TestVectors(  "[abc[pq]xyz[rs]]{4}",         "cqxr",      "y",   "$&",     "cqxr"),
         TestVectors(  "[abcdf--[ab&&[bcd]][acd]]",   "abcdefgh",  "y",   "$&",     "f"),
+        TestVectors(  "[a-c||d-f]+",    "abcdef", "y", "$&", "abcdef"),
+        TestVectors(  "[a-f--a-c]+",    "abcdef", "y", "$&", "def"),
+        TestVectors(  "[a-c&&b-f]+",    "abcdef", "y", "$&", "bc"),
+        TestVectors(  "[a-c~~b-f]+",    "abcdef", "y", "$&", "a"),
 //unicode blocks & properties:
         TestVectors(  `\P{Inlatin1suppl ement}`, "\u00c2!", "y", "$&", "!"),
         TestVectors(  `\p{InLatin-1 Supplement}\p{in-mathematical-operators}\P{Inlatin1suppl ement}`, "\u00c2\u2200\u00c3\u2203.", "y", "$&", "\u00c3\u2203."),


### PR DESCRIPTION
Simplify the case in std.regex.internal.parser as proposed in the code. Please take this as a RFC to help me understand the code base a bit better. I added some more unittests which should be useful.

@DmitryOlshansky