### PR TITLE
std.variant housekeeping

### DIFF
--- a/std/variant.d
+++ b/std/variant.d
@@ -1431,14 +1431,6 @@ function in the $(D std.boxer) module can achieve it like this:
 */
 unittest
 {
-    /* old
-    Box[] fun(...)
-    {
-        // ...
-        return boxArray(_arguments, _argptr);
-    }
-    */
-    // new
     Variant[] fun(T...)(T args)
     {
         // ...
@@ -1612,8 +1604,7 @@ unittest
     assert( v.get!(long) == 42L );
     assert( v.get!(ulong) == 42uL );
 
-    // should be string... @@@BUG IN COMPILER
-    v = "Hello, World!"c;
+    v = "Hello, World!";
     assert( v.peek!(string) );
 
     assert( v.get!(string) == "Hello, World!" );
@@ -1627,10 +1618,9 @@ unittest
     assert( v.get!(int[4]) == [1,2,3,4] );
 
     {
-        // @@@BUG@@@: array literals should have type T[], not T[5] (I guess)
-        // v = [1,2,3,4,5];
-        // assert( v.peek!(int[]) );
-        // assert( v.get!(int[]) == [1,2,3,4,5] );
+         v = [1,2,3,4,5];
+         assert( v.peek!(int[]) );
+         assert( v.get!(int[]) == [1,2,3,4,5] );
     }
 
     v = 3.1413;
@@ -1709,9 +1699,7 @@ unittest
         assert( hash[v2] == 1 );
         assert( hash[v3] == 2 );
     }
-    /+
-    // @@@BUG@@@
-    // dmd: mtype.c:3886: StructDeclaration* TypeAArray::getImpl(): Assertion `impl' failed.
+
     {
         int[char[]] hash;
         hash["a"] = 1;
@@ -1723,7 +1711,6 @@ unittest
         assert( vhash.get!(int[char[]])["b"] == 2 );
         assert( vhash.get!(int[char[]])["c"] == 3 );
     }
-    +/
 }
 
 unittest


### PR DESCRIPTION
variant hat some code disabled due to compiler bugs.
Some of these bugs have been fixed.
This re-enables this dead code.

removed some old code