### PR TITLE
Rename AliasTuple to Pack

### DIFF
--- a/std/typetuple.d
+++ b/std/typetuple.d
@@ -11,9 +11,9 @@ module std.typetuple;
 public import std.meta;
 
 /**
- * Alternate name for $(LREF AliasTuple) for legacy compatibility.
+ * Alternate name for $(LREF Pack) for legacy compatibility.
  */
-alias TypeTuple = AliasTuple;
+alias TypeTuple = Pack;
 
 ///
 unittest


### PR DESCRIPTION
See forum discussion http://forum.dlang.org/post/mnhfhs$2b9o$1@digitalmars.com

I propose `Pack`, which is inspired by C++'s [`Parameter Pack`](http://en.cppreference.com/w/cpp/language/parameter_pack). 

From the description:
> A template parameter pack is a template parameter that accepts zero or more template arguments (non-types, types, or templates). A function parameter pack is a function parameter that accepts zero or more function arguments.
>A template with at least one parameter pack is called a variadic template. 

Given that that D has its roots in C++ and this construct is similar to the one in question, it seems like a good fit.

I prefer `Pack` over `AliasPack` or other variations because it's more general and allows us to be more specific in the future with `TypePack`, `ExpressionPack`, `AliasPack`, etc... later.

FYI: There was already a private template in std/meta.d named `Pack` explained as "Confines an alias tuple within a template", so I renamed it to `Confine`.  Sorry if that makes things more difficult to review.