### PR TITLE
std.traits.hasMember: just forward to __traits(hasMember, ...)

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -3573,6 +3573,12 @@ unittest
     assert(app3.data == [1, 2, 3]);
 }
 
+unittest // issue 14605
+{
+    static assert(isOutputRange!(Appender!(int[]), int));
+    static assert(isOutputRange!(RefAppender!(int[]), int));
+}
+
 unittest
 {
     Appender!(int[]) app;

--- a/std/traits.d
+++ b/std/traits.d
@@ -3279,19 +3279,7 @@ alias Identity(alias A) = A;
    Yields $(D true) if and only if $(D T) is an aggregate that defines
    a symbol called $(D name).
  */
-template hasMember(T, string name)
-{
-    static if (is(T == struct) || is(T == class) || is(T == union) || is(T == interface))
-    {
-        enum bool hasMember =
-            staticIndexOf!(name, __traits(allMembers, T)) != -1 ||
-            __traits(compiles, { mixin("alias Sym = Identity!(T."~name~");"); });
-    }
-    else
-    {
-        enum bool hasMember = false;
-    }
-}
+enum hasMember(T, string name) = __traits(hasMember, T, name);
 
 ///
 unittest
@@ -3337,6 +3325,15 @@ unittest
     static assert(hasMember!(R2!S, "f"));
     static assert(hasMember!(R2!S, "t"));
     static assert(hasMember!(R2!S, "T"));
+}
+
+unittest
+{
+    static struct S
+    {
+        void opDispatch(string n, A)(A dummy) {}
+    }
+    static assert(hasMember!(S, "foo"));
 }
 
 /**

--- a/std/traits.d
+++ b/std/traits.d
@@ -133,6 +133,7 @@
  *           $(LREF getSymbolsByUDA)
  * ))
  * )
+ * )
  *
  * Macros:
  *  WIKI = Phobos/StdTraits


### PR DESCRIPTION
This way opDispatch'ed members are recognized.

Fixes [issue 14605 - RefAppender fails isOutputRange](https://issues.dlang.org/show_bug.cgi?id=14605).

Drive-by change: add a missing Ddoc parenthesis.

This is an alternative to PR #3294.