### PR TITLE
eliminate dangerous and/or useless casts from zlib

### DIFF
--- a/etc/c/zlib.d
+++ b/etc/c/zlib.d
@@ -80,7 +80,7 @@ alias void  function (void* opaque, void* address) free_func;
 
 struct z_stream
 {
-    ubyte*   next_in;  /* next input byte */
+    const(ubyte)*   next_in;  /* next input byte */
     uint     avail_in;  /* number of bytes available at next_in */
     c_ulong  total_in;  /* total nb of input bytes read so far */
 
@@ -88,7 +88,7 @@ struct z_stream
     uint     avail_out; /* remaining free space at next_out */
     c_ulong  total_out; /* total nb of bytes output so far */
 
-    char*    msg;      /* last error message, NULL if no error */
+    const(char)*    msg;      /* last error message, NULL if no error */
     void*    state;     /* not visible by applications */
 
     alloc_func zalloc;  /* used to allocate the internal state */


### PR DESCRIPTION
It looks like the etc.c.zlib.d was mostly written in D1; it isn't const correct, even compared to the original C! http://www.zlib.net/manual.html

Fixing that constness, I went up and started fixing other const related issues in the public API. `compress` returned a const void[]... and uncompress took a mutable array. Why? With the fixed C binding, there was no need for these. (And the presence of two casts on most unittest lines that used this showed the signature was just wrong to begin with anyway. Any typical usage that requires two casts ought to be a bit smelly. Especially since those unittests are the closest thing std.zlib has to usage examples!)

So this fixes the broken api in a way that won't break any code - the fixed signature will still implicitly cast to/from the old one, while enabling the elimination of like a bazillion casts.

Finally, casting slices to something directly just kinda worries me, so I tossed in the `.ptr` property explicitly when I saw that. Half those casts aren't necessary either, but half of them are (the ones from void*) so I kept them while just cleaning it up a wee bit.