### PR TITLE
add std.traits.isAutodecodableString() to fix Issue 14765

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -85,6 +85,7 @@
  *           $(LREF isFloatingPoint)
  *           $(LREF isIntegral)
  *           $(LREF isNarrowString)
+ *           $(LREF isAutodecodableString)
  *           $(LREF isNumeric)
  *           $(LREF isPointer)
  *           $(LREF isScalarType)
@@ -5234,6 +5235,38 @@ unittest
             static assert(!isNarrowString!( SubTypeOf!(Q!T) ));
         }
     }
+}
+
+
+/**
+ * Detect whether type $(D T) is a string that will be autodecoded.
+ *
+ * All arrays that use char, wchar, and their qualified versions are narrow
+ * strings. (Those include string and wstring).
+ * Aggregates that implicitly cast to narrow strings are included.
+ *
+ * Params:
+ *      T = type to be tested
+ *
+ * Returns:
+ *      true if T represents a string that is subject to autodecoding
+ *
+ * See Also:
+ *      $(LREF isNarrowString)
+ */
+enum bool isAutodecodableString(T) = (is(T : const char[]) || is(T : const wchar[])) && !isStaticArray!T;
+
+///
+unittest
+{
+    static struct Stringish
+    {
+        string s;
+        alias s this;
+    }
+    assert(isAutodecodableString!wstring);
+    assert(isAutodecodableString!Stringish);
+    assert(!isAutodecodableString!dstring);
 }
 
 /**


### PR DESCRIPTION
Reopened #3510 to target stable.
[Issue 14765 – [Reg2.068.0] Rangified functions no longer accept types that implicitly cast to string](https://issues.dlang.org/show_bug.cgi?id=14765)