### PR TITLE
std.concurrency: receiveTimeout: document behavior with negative timeout

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -814,6 +814,7 @@ unittest
 
 /**
  * Tries to receive but will give up if no matches arrive within duration.
+ * Won't wait at all if provided $(CXREF time, Duration) is negative.
  *
  * Same as $(D receive) except that rather than wait forever for a message,
  * it waits until either it receives a message or the given


### PR DESCRIPTION
http://stackoverflow.com/questions/31616339/non-blocking-concurrent-message-receive