### PR TITLE
Supplemental fix for issue 14846

### DIFF
--- a/std/csv.d
+++ b/std/csv.d
@@ -850,8 +850,7 @@ public:
      */
     this(Range input, Separator delimiter, Separator quote)
     {
-        _input = new Input!(Range, ErrorLevel);
-        _input.range = input;
+        _input = new Input!(Range, ErrorLevel)(input);
         _separator = delimiter;
         _quote = quote;
 
@@ -880,8 +879,7 @@ public:
      */
     this(Range input, Header colHeaders, Separator delimiter, Separator quote)
     {
-        _input = new Input!(Range, ErrorLevel);
-        _input.range = input;
+        _input = new Input!(Range, ErrorLevel)(input);
         _separator = delimiter;
         _quote = quote;
 


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14846

`new Input!(Range, ErrorLevel)` should take the `input` parameter to initialize its field by that, because: if `Range` is a nested struct, its context pointer is not accessible from inside CsvReader.

Required by: https://github.com/D-Programming-Language/dmd/pull/4848