### PR TITLE
Supplemental fix for issue 14860

### DIFF
--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -2624,7 +2624,8 @@ public:
                 }
             }
 
-            tasks[] = RTask.init;
+            foreach (ref t; tasks[])
+                emplaceRef(t, RTask());
 
             // Hack to take the address of a nested function w/o
             // making a closure.


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14860

Required by: https://github.com/D-Programming-Language/dmd/pull/4856

`task[] = RTask.init;` has two bugs:

1. `RTask` is a nested struct, so `RTask.init` contains null context pointer.
2. That is a block assignment, so there is a possibility to call
   `RTask.~this()` on garbage objects (stack allocated `buf` is initialized by `void`).

Fixed to use `emplaceRef` on each elements.