### PR TITLE
Revert "Merge pull request #3466 from karronoli/fix-curl-options-arg"

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -764,9 +764,7 @@ private auto _basicHTTP(T)(const(char)[] url, const(void)[] sendData, HTTP clien
         client.onReceive = null;
 
         if (sendData !is null &&
-            (client.method == HTTP.Method.post ||
-             client.method == HTTP.Method.put ||
-             client.method == HTTP.Method.options))
+            (client.method == HTTP.Method.post || client.method == HTTP.Method.put))
         {
             client.onSend = null;
             client.handle.onSeek = null;
@@ -784,9 +782,7 @@ private auto _basicHTTP(T)(const(char)[] url, const(void)[] sendData, HTTP clien
     };
 
     if (sendData !is null &&
-        (client.method == HTTP.Method.post ||
-         client.method == HTTP.Method.put ||
-         client.method == HTTP.Method.options))
+        (client.method == HTTP.Method.post || client.method == HTTP.Method.put))
     {
         client.contentLength = sendData.length;
         auto remainingData = sendData;
@@ -2801,9 +2797,7 @@ struct HTTP
         CurlOption lenOpt;
 
         // Force post if necessary
-        if (p.method != Method.put &&
-            p.method != Method.post &&
-            p.method != Method.options)
+        if (p.method != Method.put && p.method != Method.post)
             p.method = Method.post;
 
         if (p.method == Method.put)


### PR DESCRIPTION
This reverts questionable idea of allowing std.net.curl OPTIONS requests with non-empty body.

See #3466 