### PR TITLE
fix Issue 14842 - [REG 2.068-b2] approxEqual does not work with integers

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -6691,6 +6691,11 @@ bool approxEqual(T, U, V)(T lhs, U rhs, V maxRelDiff, V maxAbsDiff = 1e-5)
                     return false;
             }
         }
+        else static if (isIntegral!U)
+        {
+            // convert rhs to real
+            return approxEqual(lhs, real(rhs), maxRelDiff, maxAbsDiff);
+        }
         else
         {
             // lhs is range, rhs is number
@@ -6708,6 +6713,11 @@ bool approxEqual(T, U, V)(T lhs, U rhs, V maxRelDiff, V maxAbsDiff = 1e-5)
         {
             // lhs is number, rhs is array
             return approxEqual(rhs, lhs, maxRelDiff, maxAbsDiff);
+        }
+        else static if (isIntegral!T || isIntegral!U)
+        {
+            // convert both lhs and rhs to real
+            return approxEqual(real(lhs), real(rhs), maxRelDiff, maxAbsDiff);
         }
         else
         {
@@ -6751,6 +6761,14 @@ bool approxEqual(T, U)(T lhs, U rhs)
     num = -real.infinity;
     assert(num == -real.infinity);  // Passes.
     assert(approxEqual(num, -real.infinity));  // Fails.
+
+    assert(!approxEqual(3, 0));
+    assert(approxEqual(3, 3));
+    assert(approxEqual(3.0, 3));
+    assert(approxEqual([3, 3, 3], 3.0));
+    assert(approxEqual([3.0, 3.0, 3.0], 3));
+    int a = 10;
+    assert(approxEqual(10, a));
 }
 
 // Included for backwards compatibility with Phobos1


### PR DESCRIPTION
- promote any comparision with integers to real

[Issue 14842 – [REG 2.068-b2] approxEqual does not work with integers](https://issues.dlang.org/show_bug.cgi?id=14842)