### PR TITLE
format() returns the correct type

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -2409,8 +2409,10 @@ unittest
         result ~= c;
     }
 
+    import std.conv : to;
     assert(equal(result, "abc12def34"d),
-        "Unexpected result: '%s'"d.algoFormat(result));
+        //Convert to string for assert's message
+        to!string("Unexpected result: '%s'"d.algoFormat(result)));
 }
 
 // Issue 8061

--- a/std/conv.d
+++ b/std/conv.d
@@ -27,7 +27,7 @@ import std.range.primitives;
 import std.traits;
 import std.typetuple;
 
-private string convFormat(Char, Args...)(in Char[] fmt, Args args)
+private S convFormat(S, Args...)(in S fmt, Args args)
 {
     import std.format : format;
     return std.format.format(fmt, args);

--- a/std/conv.d
+++ b/std/conv.d
@@ -27,7 +27,7 @@ import std.range.primitives;
 import std.traits;
 import std.typetuple;
 
-private S convFormat(S, Args...)(in S fmt, Args args)
+private S convFormat(S, Args...)(in S fmt, Args args) if (isSomeString!S)
 {
     import std.format : format;
     return std.format.format(fmt, args);

--- a/std/conv.d
+++ b/std/conv.d
@@ -27,10 +27,13 @@ import std.range.primitives;
 import std.traits;
 import std.typetuple;
 
-private S convFormat(S, Args...)(in S fmt, Args args) if (isSomeString!S)
+// Same as std.string.format, but "self-importing".
+// Helps reduce code and imports, particularly in static asserts.
+// Also helps with missing imports errors.
+package template convFormat()
 {
     import std.format : format;
-    return std.format.format(fmt, args);
+    alias convFormat = format;
 }
 
 /* ************* Exceptions *************** */

--- a/std/format.d
+++ b/std/format.d
@@ -6545,11 +6545,11 @@ unittest
  * Params: fmt  = Format string. For detailed specification, see $(XREF _format,formattedWrite).
  *         args = Variadic list of arguments to format into returned string.
  */
-S format(S, Args...)(in S fmt, Args args) if (isSomeString!S)
+pure Char[] format(Char, Args...)(in Char[] fmt, Args args) if (isSomeChar!Char)
 {
     import std.format : formattedWrite, FormatException;
     import std.array : appender;
-    auto w = appender!S;
+    auto w = appender!(Char[]);
     auto n = formattedWrite(w, fmt, args);
     version (all)
     {

--- a/std/format.d
+++ b/std/format.d
@@ -6540,11 +6540,11 @@ unittest
  * Params: fmt  = Format string. For detailed specification, see $(XREF _format,formattedWrite).
  *         args = Variadic list of arguments to format into returned string.
  */
-string format(Char, Args...)(in Char[] fmt, Args args)
+S format(S, Args...)(in S fmt, Args args) if (isSomeString!S)
 {
     import std.format : formattedWrite, FormatException;
     import std.array : appender;
-    auto w = appender!string();
+    auto w = appender!S;
     auto n = formattedWrite(w, fmt, args);
     version (all)
     {
@@ -6580,6 +6580,10 @@ unittest
     assert(format("hel%slo%s%s%s", "world", -138, 'c', true) ==
                   "helworldlo-138ctrue");
     });
+
+    assert(is(typeof(format("happy")) == string));
+    assert(is(typeof(format("happy"w)) == wstring));
+    assert(is(typeof(format("happy"d)) == dstring));
 }
 
 /*****************************************************

--- a/std/format.d
+++ b/std/format.d
@@ -6545,11 +6545,11 @@ unittest
  * Params: fmt  = Format string. For detailed specification, see $(XREF _format,formattedWrite).
  *         args = Variadic list of arguments to format into returned string.
  */
-Char[] format(Char, Args...)(in Char[] fmt, Args args) if (isSomeChar!Char)
+immutable(Char)[] format(Char, Args...)(in Char[] fmt, Args args) if (isSomeChar!Char)
 {
     import std.format : formattedWrite, FormatException;
     import std.array : appender;
-    auto w = appender!(Char[]);
+    auto w = appender!(immutable(Char)[]);
     auto n = formattedWrite(w, fmt, args);
     version (all)
     {

--- a/std/format.d
+++ b/std/format.d
@@ -6545,11 +6545,11 @@ unittest
  * Params: fmt  = Format string. For detailed specification, see $(XREF _format,formattedWrite).
  *         args = Variadic list of arguments to format into returned string.
  */
-Char[] format(Char, Args...)(in Char[] fmt, Args args) if (isSomeChar!Char)
+S format(S, Args...)(in S fmt, Args args) if (isSomeString!S)
 {
     import std.format : formattedWrite, FormatException;
     import std.array : appender;
-    auto w = appender!(Char[]);
+    auto w = appender!S;
     auto n = formattedWrite(w, fmt, args);
     version (all)
     {

--- a/std/format.d
+++ b/std/format.d
@@ -6403,10 +6403,15 @@ unittest
 
     r = format("abc"c);
     assert(r == "abc");
-    r = format("def"w);
-    assert(r == "def");
-    r = format("ghi"d);
-    assert(r == "ghi");
+
+    //format() returns the same type as inputted.
+    wstring wr;
+    wr = format("def"w);
+    assert(wr == "def"w);
+
+    dstring dr;
+    dr = format("ghi"d);
+    assert(dr == "ghi"d);
 
     void* p = cast(void*)0xDEADBEEF;
     r = format("%s", p);

--- a/std/format.d
+++ b/std/format.d
@@ -6545,11 +6545,11 @@ unittest
  * Params: fmt  = Format string. For detailed specification, see $(XREF _format,formattedWrite).
  *         args = Variadic list of arguments to format into returned string.
  */
-S format(S, Args...)(in S fmt, Args args) if (isSomeString!S)
+Char[] format(Char, Args...)(in Char[] fmt, Args args) if (isSomeChar!Char)
 {
     import std.format : formattedWrite, FormatException;
     import std.array : appender;
-    auto w = appender!S;
+    auto w = appender!(Char[]);
     auto n = formattedWrite(w, fmt, args);
     version (all)
     {


### PR DESCRIPTION
Changed `format()` to return the same type of string that was inputted.

For instance, formatting a *dstring* returns a *dstring* and not *string*.