### PR TITLE
mmfile.d: MmFile destructor changed not to cal enforce

### DIFF
--- a/std/mmfile.d
+++ b/std/mmfile.d
@@ -369,9 +369,8 @@ class MmFile
         }
         else version (Posix)
         {
-            errnoEnforce(fd == -1 || fd <= 2
-                    || .close(fd) != -1,
-                    "Could not close handle");
+            // enforce shouldn't be here and close() is safe anyway
+            .close(fd);
             fd = -1;
         }
         else


### PR DESCRIPTION
Issue 14868:
MmFile(File,Mode,..) constructor caused the underlying file descriptor to be closed twice, in ~File() and ~MmFile(). Since MmFile destructor called enforce to check return status of close() system call, exception was thrown from inside GC.
The .close() call is safe and the only meaningful error is EBADF, when the descriptor is closed already, so I commented out the enforce part.
