### PR TITLE
fix Issue 14877 - std.net.curl needs PATCH http method

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -446,8 +446,7 @@ unittest
  * postData = data to send as the body of the request. An array
  *            of an arbitrary type is accepted and will be cast to ubyte[]
  *            before sending it.
- * conn = connection to use e.g. FTP or HTTP. The default AutoProtocol will
- *        guess connection type and create a new instance for this call only.
+ * conn = HTTP connection to use
  *
  * The template parameter $(D T) specifies the type to return. Possible values
  * are $(D char) and $(D ubyte) to return $(D char[]) or $(D ubyte[]). If asking
@@ -716,8 +715,7 @@ unittest
  *
  * Params:
  * url = resource make a connect to
- * conn = connection to use e.g. FTP or HTTP. The default AutoProtocol will
- *        guess connection type and create a new instance for this call only.
+ * conn = HTTP connection to use
  *
  * The template parameter $(D T) specifies the type to return. Possible values
  * are $(D char) and $(D ubyte) to return $(D char[]) or $(D ubyte[]).

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -758,14 +758,17 @@ unittest
  */
 private auto _basicHTTP(T)(const(char)[] url, const(void)[] sendData, HTTP client)
 {
+    immutable doSend = sendData !is null &&
+        (client.method == HTTP.Method.post ||
+         client.method == HTTP.Method.put);
+
     scope (exit)
     {
         client.onReceiveHeader = null;
         client.onReceiveStatusLine = null;
         client.onReceive = null;
 
-        if (sendData !is null &&
-            (client.method == HTTP.Method.post || client.method == HTTP.Method.put))
+        if (doSend)
         {
             client.onSend = null;
             client.handle.onSeek = null;
@@ -782,8 +785,7 @@ private auto _basicHTTP(T)(const(char)[] url, const(void)[] sendData, HTTP clien
         return data.length;
     };
 
-    if (sendData !is null &&
-        (client.method == HTTP.Method.post || client.method == HTTP.Method.put))
+    if (doSend)
     {
         client.contentLength = sendData.length;
         auto remainingData = sendData;


### PR DESCRIPTION
- use infilesize for anything but post requests
  though apparently curl can use both for non-POST
  methods

[Issue 14877 – std.net.curl needs PATCH http method](https://issues.dlang.org/show_bug.cgi?id=14877)