### PR TITLE
Add missing references to std.digest.hmac to fix doc generation

### DIFF
--- a/index.d
+++ b/index.d
@@ -89,6 +89,7 @@ $(BOOKTABLE ,
         $(TD
             Cyclic Redundancy Check (32-bit) implementation$(BR)
             Compute digests such as md5, sha1 and crc32$(BR)
+            Compute HMAC of arbitrary data using a user-specified hash algorithm$(BR)
             Compute MD5 hash of arbitrary data$(BR)
             Compute RIPEMD-160 hash of arbitrary data$(BR)
             Compute SHA1 and SHA2 hashes of arbitrary data

--- a/unittest.d
+++ b/unittest.d
@@ -59,6 +59,7 @@ public import std.digest.digest;
 public import std.digest.crc;
 public import std.digest.sha;
 public import std.digest.md;
+public import std.digest.hmac;
 
 int main(string[] args)
 {

--- a/win32.mak
+++ b/win32.mak
@@ -328,6 +328,7 @@ DOCS=	$(DOC)\object.html \
 	$(DOC)\std_digest_sha.html \
 	$(DOC)\std_digest_md.html \
 	$(DOC)\std_digest_ripemd.html \
+	$(DOC)\std_digest_hmac.html \
 	$(DOC)\std_digest_digest.html \
 	$(DOC)\std_cstream.html \
 	$(DOC)\std_csv.html \

--- a/win64.mak
+++ b/win64.mak
@@ -349,6 +349,7 @@ DOCS=	$(DOC)\object.html \
 	$(DOC)\std_digest_sha.html \
 	$(DOC)\std_digest_md.html \
 	$(DOC)\std_digest_ripemd.html \
+	$(DOC)\std_digest_hmac.html \
 	$(DOC)\std_digest_digest.html \
 	$(DOC)\std_cstream.html \
 	$(DOC)\std_csv.html \


### PR DESCRIPTION
It seems I missed a few places where the new std.digest.hmac should have been mentioned, because the documentation is missing:
http://dlang.org/phobos/std_digest_hmac.html

Please don't merge yet, I want to make sure there are no other missing places. Can one of the build-system gurus please have a look?