### PR TITLE
Fix issue 14832 - make array work with ranges that use ulong for length on 32-bit systems

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -106,9 +106,16 @@ if (isIterable!Range && !isNarrowString!Range && !isInfinite!Range)
         if (length == 0)
             return null;
 
+        // We cannot make more than size_t.max elements, so if length
+        // is larger integer than size_t, we must cast. Check at runtime
+        // whether the cast will truncate.
+        static if(length.sizeof > size_t.sizeof)
+        {
+            if(length > size_t.max) throw new Exception("Range length exceeds maximum array size");
+        }
         import std.conv : emplaceRef;
 
-        auto result = (() @trusted => uninitializedArray!(Unqual!E[])(length))();
+        auto result = (() @trusted => uninitializedArray!(Unqual!E[])(cast(size_t)length))();
 
         // Every element of the uninitialized array must be initialized
         size_t i;
@@ -180,6 +187,14 @@ unittest
     import std.range;
     static struct S{int* p;}
     auto a = array(immutable(S).init.repeat(5));
+}
+
+unittest
+{
+    // Issue 14832
+    import std.range : iota;
+    auto a = array(iota(10UL));
+    assert(a == [0UL, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
 }
 
 /**

--- a/std/array.d
+++ b/std/array.d
@@ -85,6 +85,8 @@ public import std.range.primitives : save, empty, popFront, popBack, front, back
  *      r = range (or aggregate with $(D opApply) function) whose elements are copied into the allocated array
  * Returns:
  *      allocated and initialized array
+ * Throws:
+ *      Exception if Range has a length field, and Range.length is greater than size_t.max (only on 32-bit systems)
  */
 ForeachType!Range[] array(Range)(Range r)
 if (isIterable!Range && !isNarrowString!Range && !isInfinite!Range)


### PR DESCRIPTION
Basically, we need the cast to `size_t` on 32-bit systems, because you can't create an array with greater than `size_t.max` elements.

I throw an exception when the condition is incorrect (i.e. `r.length > size_t.max`), because I don't think it's a good idea to cast the length to a `size_t` that truncates (which would happen in release mode if I used an assert instead). It means that on 32-bit systems, such function calls (which were previously illegal) are now allowed, but not `nothrow`. However, they'd be `nothrow` still on 64-bit. Opinions on this welcome.

https://issues.dlang.org/show_bug.cgi?id=14832