### PR TITLE
std.concurrency: receiveTimeout: allow negative timeout

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -2077,7 +2077,7 @@ private
                             m_notFull.notifyAll();
                         static if( timedWait )
                         {
-                            if( period.isNegative || !m_putMsg.wait( period ) )
+                            if( period <= Duration.zero || !m_putMsg.wait( period ) )
                                 return false;
                         }
                         else

--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -1907,7 +1907,6 @@ private
             {
                 alias Ops = TypeTuple!(T[1 .. $]);
                 alias ops = vals[1 .. $];
-                assert( vals[0] >= msecs(0) );
                 enum timedWait = true;
                 Duration period = vals[0];
             }


### PR DESCRIPTION
Related #3516.

This assert was introduced in #1910, which contradicts #1279.