### PR TITLE
Fix unittests that ignore the return attribute

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -1382,8 +1382,17 @@ unittest
     static assert(functionAttributes!(S.sharedF) == (FA.shared_ | FA.system));
     static assert(functionAttributes!(typeof(S.sharedF)) == (FA.shared_ | FA.system));
 
-    static assert(functionAttributes!(S.refF) == (FA.ref_ | FA.system));
-    static assert(functionAttributes!(typeof(S.refF)) == (FA.ref_ | FA.system));
+    static if ([__traits(getFunctionAttributes, S.refF)] == ["ref", "@system"])
+    {
+        // Bugzilla 14874: __traits(getFunctionAttributes) does not support the new `return` attribute
+        static assert(functionAttributes!(S.refF) == (FA.ref_ | FA.system));
+        static assert(functionAttributes!(typeof(S.refF)) == (FA.ref_ | FA.system));
+    }
+    else
+    {
+        static assert(functionAttributes!(S.refF) == (FA.ref_ | FA.system | FA.return_));
+        static assert(functionAttributes!(typeof(S.refF)) == (FA.ref_ | FA.system | FA.return_));
+    }
 
     static assert(functionAttributes!(S.propertyF) == (FA.property | FA.system));
     static assert(functionAttributes!(typeof(&S.propertyF)) == (FA.property | FA.system));


### PR DESCRIPTION
This pull request is necessary for https://github.com/D-Programming-Language/dmd/pull/4868.