### PR TITLE
Remove workaround for unittests failing with compiler change

### DIFF
--- a/std/traits.d
+++ b/std/traits.d
@@ -1382,17 +1382,8 @@ unittest
     static assert(functionAttributes!(S.sharedF) == (FA.shared_ | FA.system));
     static assert(functionAttributes!(typeof(S.sharedF)) == (FA.shared_ | FA.system));
 
-    static if ([__traits(getFunctionAttributes, S.refF)] == ["ref", "@system"])
-    {
-        // Bugzilla 14874: __traits(getFunctionAttributes) does not support the new `return` attribute
-        static assert(functionAttributes!(S.refF) == (FA.ref_ | FA.system));
-        static assert(functionAttributes!(typeof(S.refF)) == (FA.ref_ | FA.system));
-    }
-    else
-    {
-        static assert(functionAttributes!(S.refF) == (FA.ref_ | FA.system | FA.return_));
-        static assert(functionAttributes!(typeof(S.refF)) == (FA.ref_ | FA.system | FA.return_));
-    }
+    static assert(functionAttributes!(S.refF) == (FA.ref_ | FA.system | FA.return_));
+    static assert(functionAttributes!(typeof(S.refF)) == (FA.ref_ | FA.system | FA.return_));
 
     static assert(functionAttributes!(S.propertyF) == (FA.property | FA.system));
     static assert(functionAttributes!(typeof(&S.propertyF)) == (FA.property | FA.system));


### PR DESCRIPTION
I had to introduce a workaround in https://github.com/D-Programming-Language/phobos/pull/3547 because the unittests would not pass without the matching compiler change https://github.com/D-Programming-Language/dmd/pull/4868. Now that the compiler fix is merged, the workaround can be removed.