### PR TITLE
Use a central directory for remaining tests that create a temporary file

### DIFF
--- a/std/experimental/logger/core.d
+++ b/std/experimental/logger/core.d
@@ -1797,11 +1797,14 @@ functions.
 /// Ditto
 unittest
 {
+    import std.file : deleteme, remove;
     Logger l = stdThreadLocalLog;
-    stdThreadLocalLog = new FileLogger("someFile.log");
-    scope(exit) remove("someFile.log");
+    stdThreadLocalLog = new FileLogger(deleteme ~ "-someFile.log");
+    scope(exit) remove(deleteme ~ "-someFile.log");
 
+    auto tempLog = stdThreadLocalLog;
     stdThreadLocalLog = l;
+    destroy(tempLog);
 }
 
 @safe unittest
@@ -2072,9 +2075,9 @@ version(unittest) private void testFuncNames(Logger logger) @safe
 
 unittest // default logger
 {
-    import std.file : exists, remove;
+    import std.file : deleteme, exists, remove;
 
-    string filename = __FUNCTION__ ~ ".tempLogFile";
+    string filename = deleteme ~ __FUNCTION__ ~ ".tempLogFile";
     FileLogger l = new FileLogger(filename);
     auto oldunspecificLogger = sharedLog;
     sharedLog = l;
@@ -2110,9 +2113,9 @@ unittest // default logger
 
 unittest
 {
-    import std.file : remove;
+    import std.file : deleteme, remove;
     import core.memory : destroy;
-    string filename = __FUNCTION__ ~ ".tempLogFile";
+    string filename = deleteme ~ __FUNCTION__ ~ ".tempLogFile";
     auto oldunspecificLogger = sharedLog;
 
     scope(exit)

--- a/std/experimental/logger/filelogger.d
+++ b/std/experimental/logger/filelogger.d
@@ -131,11 +131,11 @@ class FileLogger : Logger
 
 unittest
 {
-    import std.file : remove;
+    import std.file : deleteme, remove;
     import std.array : empty;
     import std.string : indexOf;
 
-    string filename = __FUNCTION__ ~ ".tempLogFile";
+    string filename = deleteme ~ __FUNCTION__ ~ ".tempLogFile";
     auto l = new FileLogger(filename);
 
     scope(exit)
@@ -160,11 +160,11 @@ unittest
 
 unittest
 {
-    import std.file : remove;
+    import std.file : deleteme, remove;
     import std.array : empty;
     import std.string : indexOf;
 
-    string filename = __FUNCTION__ ~ ".tempLogFile";
+    string filename = deleteme ~ __FUNCTION__ ~ ".tempLogFile";
     auto file = File(filename, "w");
     auto l = new FileLogger(file);
 

--- a/std/experimental/logger/multilogger.d
+++ b/std/experimental/logger/multilogger.d
@@ -141,9 +141,10 @@ class MultiLogger : Logger
 // Issue #16
 unittest
 {
+    import std.file : deleteme;
     import std.stdio : File;
     import std.string : indexOf;
-    string logName = __FUNCTION__ ~ ".log";
+    string logName = deleteme ~ __FUNCTION__ ~ ".log";
     auto logFileOutput = File(logName, "w");
     scope(exit)
     {

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -4557,9 +4557,10 @@ version(linux)
     }
 }
 
-version(unittest) string testFilename(string file = __FILE__, size_t line = __LINE__) @safe pure
+version(unittest) string testFilename(string file = __FILE__, size_t line = __LINE__) @safe
 {
     import std.conv : text;
+    import std.file : deleteme;
     import std.path : baseName;
 
     // Non-ASCII characters can't be used because of snn.lib @@@BUG8643@@@
@@ -4568,5 +4569,5 @@ version(unittest) string testFilename(string file = __FILE__, size_t line = __LI
     else
 
         // filename intentionally contains non-ASCII (Russian) characters
-        return text("deleteme-детка.", baseName(file), ".", line);
+        return text(deleteme, "-детка.", baseName(file), ".", line);
 }


### PR DESCRIPTION
Finishing up the work from #2393, use `std.file.deleteme` instead.  This is useful on Android, which doesn't allow writing to arbitrary directories and doesn't have a global /tmp directory, so you can [easily hack in the app's absolute path in one place](https://gist.github.com/joakim-noah/5c03801fa6c59b1e90df#file-phobos_ldc_arm-L103).

I had to remove the `pure` attribute for `std.stdio.testFilename` to have it use `std.file.deleteme`, but that didn't matter anywhere in the tests.  I don't think we guarantee such test helper functions will stay the same for users, so I doubt dropping the attribute will matter.