### PR TITLE
fix issue 14920 - [REG2.067.0] SList.insertAfter on uninitialized list triggers assertion in _first targeting stable branch

### DIFF
--- a/std/container/slist.d
+++ b/std/container/slist.d
@@ -430,6 +430,7 @@ assert(std.algorithm.equal(sl[], ["a", "b", "c", "d", "e"]));
 
     size_t insertAfter(Stuff)(Range r, Stuff stuff)
     {
+        initialize();
         if (!_first)
         {
             enforce(!r._head);
@@ -760,4 +761,12 @@ unittest
     auto r = s[];
     r.front = 1; //test frontAssign
     assert(r.front == 1);
+}
+
+unittest
+{
+    // issue 14920
+    SList!int s;
+    s.insertAfter(s[], 1);
+    assert(s.front == 1);
 }


### PR DESCRIPTION
same as https://github.com/D-Programming-Language/phobos/pull/3554 but targeting the stable branch. I can't edit the target branch. More information about desired target branch on http://wiki.dlang.org/Pull_Requests would help:)

fix https://issues.dlang.org/show_bug.cgi?id=14920
- add a call to initialize() (similar to other insert* functions)
- add unit test

