### PR TITLE
perpetual: new module for mapping value types into memory

### DIFF
--- a/std/experimental/perpetual/perpetual.d
+++ b/std/experimental/perpetual/perpetual.d
@@ -1,31 +1,10 @@
-/**
- * Map variable, POD structure or array to file
- *   to make it shared and persistent between program invocations.
- * Macros:
-  * Source:    $(PHOBOSSRC std/perpetual.d)
- */
 module std.perpetual;
-//import std.stdio;
 
-private import std.file;
-private import core.stdc.stdio;
-private import std.traits;
-private import std.string;
-private import std.conv;
-private import std.algorithm;
+private import std.mmfile;
 private import std.exception;
-version (Windows) {
-private import core.sys.windows.windows;
-private import std.utf;
-private import std.windows.syserror;
-} else version (Posix) {
-private import core.sys.posix.fcntl;
-private import core.sys.posix.unistd;
-private import core.sys.posix.sys.mman;
-private import core.sys.posix.sys.stat;
-} else {
-	static assert(0);
-}
+private import std.conv : to;
+private import std.file : exists;
+private import std.traits : hasIndirections;
 
 
 
@@ -34,28 +13,27 @@ private import core.sys.posix.sys.stat;
  */
 struct Perpetual(T)
 {
-	version (Windows) {
+	private MmFile _heap;
+	private enum _tag="Perpetual!("~T.stringof~")";
 
-	} else version (Posix) {
-		private int _fd;
-		private void* _map;
-	} else
-		static assert(0);
-
-	enum _tag="Perpetual!("~T.stringof~")";
-
-	static if(is(T == Element[],Element)) {
+	static if(is(T == Element[],Element))
+	{
 	// dynamic array 
-		private size_t _size=0;
-		private enum dynamic=true;
+		private Element[] _value;
+		enum bool dynamic=true;
 		static assert(!hasIndirections!Element, Element.stringof~" is reference type");
-		@property ref T Ref() const { return cast(T) _map[0.._size]; }
+		@property Element[] Ref() { return _value; }
+		string toString() { return to!string(_value); }
 
-	} else {
+	}
+	else
+	{
 	// value type
-		private enum dynamic=false;
+		private T *_value;
+		enum bool dynamic=false;
 		static assert(!hasIndirections!T, T.stringof~" is reference type");
-		@property ref T Ref() const {	return *cast(T*)(_map); }
+		@property ref T Ref() {	return *_value; }
+		string toString() { return to!string(*_value); }
 	}
 
 /**
@@ -63,296 +41,153 @@ struct Perpetual(T)
  */
 	alias Ref this;
 
-	private bool _owner=true;
-	@property auto master() { return _owner; }
-	void opAssign(T x) { Ref=x; }
-
-/**
- * Return string representation for wrapped object instead of self.
- */
-	string toString() { return to!string(Ref); }
-
-
 
 /**
  * Open file and assosiate object with it.
  * The file is extended if smaller than requred. Initialized
  *   with T.init if created or extended.
  */
-	this(string path) {
-		map(path);
-		static if(dynamic) {
-			// we don't need initialization here, the file already exists
-			//   so, is to be initialized
-		} else if(master) {
-			*cast(T*)(_map)=T.init;
+	this(string path)
+	{
+		static if(dynamic)
+		{
+			enforce(exists(path), _tag~": dynamic array of zero length");
+			size_t size=0;
 		}
+		else
+		{
+			size_t size=T.sizeof;
+		}
+		_heap=new MmFile(path, MmFile.Mode.readWrite, size, null, 0);
+		static if(dynamic) // at least one element
+			size=Element.sizeof;
+		enforce(_heap.length >= size, _tag~": file is too small");
+
+		static if(dynamic)
+			_value=cast(Element[]) _heap[0.._heap.length];
+		else
+			_value=cast(T*) _heap[].ptr;
  	}
 
-
-
-/**
- * Unmap the file and release resources.
- * The file is left on the disk and may be reopened.
- */
-	~this() {
-		unmap();
-	}
-
-
-
-/**
- * Flash memory to disc.
- */
-	void sync() {
-		version (Windows) {
-
-		} else version (Posix) {
-			int x=msync(_map, T.sizeof, MS_SYNC);
-			errnoEnforce(!x, _tag~": sync failed");
-		} else
-			static assert(0);
-	}
-	
-	
-	
-	
-	
-	
-	private bool map(string path) {
-		version (Windows) {
-
-		} else version (Posix) {
-			_fd=open(path.toStringz(), O_RDWR|O_CREAT|O_EXCL, S_IRUSR|S_IWUSR);
-			if(_fd < 0) {
-				_owner=false;
-				_fd=open(path.toStringz(), O_RDWR, S_IRUSR|S_IWUSR);
-				if(_fd < 0)
-					errnoEnforce(_fd >= 0, _tag~"("~path~")");
-			}
-
-			static if(dynamic) {
-				//_size=fileSize(path)/Element.sizeof;
-				_size=fileSize(path);
-
-			} else {
-				if(fileSize(path) < T.sizeof) {
-					fileExpand(path);
-					_owner=true;
-				}
-			}
-
-			_map=mmap(null, T.sizeof, PROT_READ|PROT_WRITE, MAP_SHARED, _fd, 0);
-			if(_map == MAP_FAILED) {
-				close(_fd);
-				errnoEnforce(false, _tag~"("~path~")");
-			}
-
-			return _owner;
-
-		} else
-			static assert(0);
-	}
-
-
-	private void unmap() {
-		version (Windows) {
-
-		} else version (Posix) {
-			sync();
-			munmap(_map, T.sizeof);
-			close(_fd);
-
-		} else
-			static assert(0);
-	}
-
-	
-	private size_t fileSize(string path) {
-		version (Windows) {
-
-		} else version (Posix) {
-			stat_t st;
-			if(fstat(_fd, &st)) {
-				close(_fd);
-				errnoEnforce(false, _tag~"("~path~")");
-			}
-			return st.st_size;
-	
-		} else
-			static assert(0);
-	}
-
-	private void fileExpand(string path) {
-		version (Windows) {
-
-		} else version (Posix) {
-			lseek(_fd, T.sizeof-1, SEEK_SET);
-			char c=0;
-			core.sys.posix.unistd.write(_fd, &c, 1);
-		} else
-			static assert(0);
-	}
-
-}
-
-
-/**
- * Convenience helper, equivalent to new Persistent!T
- */
-auto perpetual(T)(string path)
-{
-	return Perpetual!T(path);
-}
-
-
-
-/**
- * Single argument helper,
- *  uses copy ctor/assignment for initialization
- */
-auto perpetual(T, U)(string path, U seed)
-{
-	Perpetual!T p=path;
-	if(p.master) {
-		static if(isArray!T) {
-			static if(isArray!U) {
-				auto l=min(T.length, seed.length);
-				p[0..l]=seed[0..l];
-			} else {
-				p[]=seed;
-			}
+	this(size_t len, string path) {
+		static if(dynamic) {
+			size_t size=len*Element.sizeof;
 		} else {
-			p=seed;
+			size_t size=len*T.sizeof;
 		}
-	}
-	return p;
+		_heap=new MmFile(path, MmFile.Mode.readWrite, size, null, 0);
+		enforce(_heap.length >= size, _tag~": file is too small");
+
+		static if(dynamic) {
+			_value=cast(Element[]) _heap[0.._heap.length];
+		} else {
+			_value=cast(T*) _heap[].ptr;
+		}
+ 	}
 }
 
-
-/**
- * Multi-argument helper,
- *  forwards arguments to ctor
- */
-auto perpetual(T, Args...)(string path, Args args)
-{
-	Perpetual!T p(path);
-	if(p.master)
-		p=T(args);
-	return p;
-}
-
-
-package @property string deleteme() @safe
-{
-    import std.process : thisProcessID;
-    import std.path : buildPath;
-    static _deleteme = "perpetual.unittest.";
-    static _first = true;
-
-    if(_first)
-    {
-        _deleteme=buildPath(tempDir(), _deleteme)~to!string(thisProcessID)~".";
-        _first=false;
-    }
-
-    return _deleteme;
-}
 
 ///
-unittest
-{
-	import std.stdio;
-	import std.conv;
-	import std.string;
-	import std.math : isNaN;
-	import std.perpetual;
+unittest {
+import std.stdio;
+import std.conv;
+import std.string;
+import std.file : remove;
 
-	struct A { int x; }
-	class B {};
-	enum Color { black, red, green, blue, white };
-	
-	//, deleteme~""
-	auto mapped=[deleteme~"0", deleteme~"1", deleteme~"2", deleteme~"3"];
-    scope(exit) foreach(file; mapped) { assert(file.exists); remove(file.toStringz); }
+struct A { int x; };
+class B {};
+enum Color { black, red, green, blue, white };
 
-	// simple built-in values
-	auto p0=perpetual!int(mapped[0]);
-	assert(p0 == int.init);
-	p0=24;
-	assert(p0 == 24);
-	assert(p0 < 25);
+string deleteme="utest.";
 
-	auto p1=perpetual!double(mapped[1]);
-	assert(isNaN(cast(double) p1));
-	p1=3.14159;
-	assert(p1 == 3.14159);
+	string[] file;
+	foreach(i; 1..8) file~=deleteme~to!string(i);
+	scope(exit) foreach(f; file[]) remove(f);
 
-	// struct
-	auto p2=perpetual!A(mapped[2]);
-	assert(p2 == A.init);
-	p2=A(7);
-	assert(p2.x == 7);
+	// create mapped variables
+	{
+		auto p0=Perpetual!int(file[0]);
+		assert(p0 == 0);
+		p0=7;
 
-	// static array of integers
-	auto p3=perpetual!(int[5])(mapped[3], [7,5,3,1]);
-	// view only, map above as array of shorts
-	auto p4=perpetual!(immutable(short[]))(mapped[3]);
-	
+		auto p1=Perpetual!double(file[1]);
+		p1=3.14159;
 
-/*
-	// view only, map above as array of shorts
-	auto p4=perpetual!(immutable(short[]))("Q4");
-	// enum
-	auto p5=perpetual!Color("Q5", Color.white);
-	// character string, reinitialize if new file created
-	auto p6=perpetual!(char[])("Q6");
-	if(p6.length ==0) {
-	// the file wasn't initialized, do with static array
-		perpetual!(char[32])("Q6", '_');
-		p6=perpetual!(char[])("Q6");
+		// struct
+		auto p2=Perpetual!A(file[2]);
+		assert(p2.x == int.init);
+		p2=A(22);		
+		
+		// static array of integers
+		auto p3=Perpetual!(int[5])(file[3]);
+		assert(p3[0] == 0);
+		p3=[1,3,5,7,9];
+
+		// enum
+		auto p4=Perpetual!Color(file[4]);
+		assert(p4 == Color.black);
+		p4=Color.red;
+		
+
+		// character string, reinitialize if new file created
+		auto p5=Perpetual!(char[32])(file[5]);
+		p5="hello world";
+
+		// double static array with initailization
+		auto p8=Perpetual!(char[3][5])(file[6]);
+		foreach(ref x; p8) x="..."; p8[0]="one"; p8[2]="two";
+
+		//auto pX=Perpetual!(char*)("?");     //ERROR: "char* is reference type"
+		//auto pX=Perpetual!B("?");           //ERROR: "B is reference type"
+		//auto pX=Perpetual!(char*[])("?");   //ERROR: "char* is reference type"
+		//auto pX=Perpetual!(char*[12])("?");  //ERROR: "char*[12] is reference type"
+		//auto pX=Perpetual!(char[string])("?"); //ERROR: "char[string] is reference type"
+		//auto pX=Perpetual!(char[][])("?");    //ERROR: "char[] is reference type"
+		//auto pX=Perpetual!(char[][3])("?");   //ERROR: "char[][3] is reference type"
 	}
-	// view only variant of above
-	auto p7=perpetual!string("Q6");
-	// double static array with initailization
- 	auto p8=perpetual!(char[3][5])("Q7");
-	if(p8.master) { foreach(ref x; p8) x="..."; p8[0]="one"; p8[2]="two"; }
-	// map of above as plain array
-	auto p9=perpetual!(const(char[]))("Q7");
-	// map again as dynamic array
-	auto pA=perpetual!(char[3][])("Q7");
+	// destroy everything and unmap files
+	
+	
+	// map again and check the values are preserved
+	{
+		auto p0=Perpetual!int(file[0]);
+		assert(p0 == 7);
 
-	//auto pX=new Perpetual!(char*)("Q?"); //ERROR: "char* is reference type"
-	//auto pX=new Perpetual!B("Q?"); //ERROR: "B is reference type"
-	//auto pX=new Perpetual!(char*[])("Q?"); //ERROR: "char* is reference type"
-	//auto pX=new Perpetual!(char*[12])("Q?"); //ERROR: "char*[12] is reference type"
-	//auto pX=new Perpetual!(char[string])("Q?"); //ERROR: "char[string] is reference type"
-	//auto pX=new Perpetual!(char[][])("Q?"); //ERROR: "char[] is reference type"
-	//auto pX=new Perpetual!(char[][3])("Q?"); //ERROR: "char[][3] is reference type"
+		auto p1=Perpetual!double(file[1]);
+		assert(p1 == 3.14159);
+
+		// struct
+		auto p2=Perpetual!A(file[2]);
+		assert(p2 == A(22));
+		
+		// map int[] as view only of array shorts
+		auto p3=Perpetual!(immutable(short[]))(file[3]);
+		// Attention: LSB only!
+		assert(p3[0] == 1 && p3[2] == 3 && p3[4] == 5);
+		//p3[1]=111; //ERROR: cannot modify immutable expression p3.Ref()[1]
+
+		// enum
+		auto p4=Perpetual!Color(file[4]);
+		assert(p4 == Color.red);
+
+		// view only variant of char[4]
+		auto p5=Perpetual!string(4, file[5]);
+		assert(p5 == "hell");
+		//p5[0]='A'; //ERROR: cannot modify immutable expression p5.Ref()[0]
+		//p5[]="1234"; //ERROR: slice p5.Ref()[] is not mutable
 
 
-	getopt(arg
-		 , "int", delegate(string key, string val){ p0=to!int(val); }
-		 , "real", delegate(string key, string val){ p1=to!double(val); }
-		 , "struct", delegate(string key, string val){ p2.x=to!int(val); }
-		 , "array", delegate(string key, string val){
-		 		auto lst=split(val,",");
-				p3[0..lst.length]=to!(int[])(lst);
-			}
-		 , "color", delegate(string key, string val){ p5=to!Color(val); }
-		 , "string", delegate(string key, string val){ p6[0..val.length]=val; }
-		);
+		// map of double array as plain array
+		auto p6=Perpetual!(const(char[]))(file[6]);
+		assert(p6[0..3] == "one");
+		// map again as dynamic array
+		auto p7=Perpetual!(char[3][])(file[6]);
+		assert(p7.length == 5);
+		assert(p7[2] == "two");
+		//p7[0]="null"; //ERROR: Array lengths don't match for copy: 4 != 3
+		p7[0]="nil";
+	}
 
-	writefln("%-32s: %s", typeof(p0).stringof, p0);
-	writefln("%-32s: %s", typeof(p1).stringof, p1);
-	writefln("%-32s: %s", typeof(p2).stringof, p2);
-	writefln("%-32s: %s", typeof(p3).stringof, p3);
-	writefln("%-32s: %s", typeof(p4).stringof, p4);
-	writefln("%-32s: %s", typeof(p5).stringof, p5);
-	writefln("%-32s: %s", typeof(p6).stringof, p6);
-	writefln("%-32s: %s", typeof(p7).stringof, p7);
-	writefln("%-32s: %s", typeof(p8).stringof, p8);
-	writefln("%-32s: %s", typeof(p9).stringof, p9);
-	writefln("%-32s: %s", typeof(pA).stringof, pA);
-*/
 }
+
+

--- a/std/persistent.d
+++ b/std/persistent.d
@@ -1,0 +1,244 @@
+/**
+ * Map variable, static array or POD structure to file
+ *   to make it shared and persistent between program invocations.
+ * Macros:
+  * Source:    $(PHOBOSSRC std/persistent.d)
+ */
+module std.persistent;
+
+private import std.file;
+private import core.stdc.stdio;
+private import core.stdc.stdlib;
+private import core.stdc.errno;
+private import std.path;
+private import std.string;
+import std.conv, std.exception, std.stdio;
+version (Windows) {
+	private import core.sys.windows.windows;
+	private import std.utf;
+	private import std.windows.syserror;
+} else version (Posix) {
+	private import core.sys.posix.fcntl;
+	private import core.sys.posix.unistd;
+	private import core.sys.posix.sys.mman;
+	private import core.sys.posix.sys.stat;
+} else {
+	static assert(0);
+}
+
+
+
+/**
+ * Persistent maps value type object to file
+ */
+class Persistent(T)
+{
+	version (Windows) {
+
+	} else version (Posix) {
+
+	} else
+		static assert(0);
+
+/**
+ * Open file and assosiate object with it.
+ * The file is extended if smaller than requred. Initialized
+ *   with T.init if created or extended.
+ */
+	this(string path) {
+		auto owner=map(path);
+       _ref=cast(T*)(_map);
+	   if(owner)
+	   	*_ref=T.init;
+ 	}
+
+
+
+/**
+ * Unmap the file and release resources.
+ * The file is left on the disk and may be reopened.
+ */
+	~this() {
+		unmap();
+	}
+
+
+
+/**
+ * Flash memory to disc.
+ */
+	void sync() {
+		version (Windows) {
+			FlushViewOfFile(data.ptr, data.length);
+		} else version (Posix) {
+			int x=msync(_ref, T.sizeof, MS_SYNC);
+			errnoEnforce(!x, _tag~": sync failed");
+		} else
+			static assert(0);
+	}
+	
+	
+/**
+ * Return string representation for wrapped object instead of self.
+ */
+	override string toString() { return to!string(*_ref); }
+	
+/**
+ * Get reference to wrapped object.
+ */
+	@property ref T Ref() {	return *_ref; }
+/**
+ * Silently convert to reference to wrapped object.
+ */
+	alias Ref this;
+
+	
+	
+	
+	private bool map(string path) {
+		bool owner=true;
+		version (Windows) {
+
+		} else version (Posix) {
+			_fd=open(path.toStringz(), O_RDWR|O_CREAT|O_EXCL, S_IRUSR|S_IWUSR);
+			if(_fd < 0) {
+				owner=false;
+				_fd=open(path.toStringz(), O_RDWR, S_IRUSR|S_IWUSR);
+				if(_fd < 0)
+					errnoEnforce(_fd >= 0, _tag~"("~path~")");
+			}
+
+			if(fileSize(path) < T.sizeof) {
+				fileExpand(path);
+				owner=true;
+			}
+
+			_map=mmap(null, T.sizeof, PROT_READ|PROT_WRITE, MAP_SHARED, _fd, 0);
+			if(_map == MAP_FAILED) {
+				close(_fd);
+				errnoEnforce(false, _tag~"("~path~")");
+			}
+
+			return owner;
+
+		} else
+			static assert(0);
+	}
+
+
+	private void unmap() {
+		bool owner=true;
+		version (Windows) {
+
+		} else version (Posix) {
+			sync();
+			munmap(_map, T.sizeof);
+			close(_fd);
+
+		} else
+			static assert(0);
+	}
+
+	
+	private size_t fileSize(string path) {
+		version (Windows) {
+
+		} else version (Posix) {
+			stat_t st;
+			if(fstat(_fd, &st)) {
+				close(_fd);
+				errnoEnforce(false, _tag~"("~path~")");
+			}
+			return st.st_size;
+	
+		} else
+			static assert(0);
+	}
+
+	private void fileExpand(string path) {
+		version (Windows) {
+
+		} else version (Posix) {
+			lseek(_fd, T.sizeof-1, SEEK_SET);
+			char c=0;
+			core.sys.posix.unistd.write(_fd, &c, 1);
+		} else
+			static assert(0);
+	}
+
+private:
+	version (Windows) {
+		HANDLE hFile = INVALID_HANDLE_VALUE;
+		HANDLE hFileMap = null;
+		uint dwDesiredAccess;
+	} else version (Posix) {
+		int _fd;
+		void* _map=null;
+		enum _tag="Persistent!("~T.stringof~")";
+		T* _ref=null;
+	} else
+		static assert(0);
+}
+
+
+///
+unittest
+{
+	import std.stdio;
+	import std.conv;
+	import std.string;
+	import std.getopt;
+	import std.persistent;
+
+	struct A { int x; };
+	enum Color { black, red, green, blue, white };
+
+	// Usage: test
+	// Output:
+	//	Persistent!int          : 0
+	//	Persistent!double       : nan
+	//	Persistent!(A)          : A(0)
+	//	Persistent!(int[5])     : [0, 0, 0, 0, 0]
+	//	Persistent!(Color)      : black
+	//
+	// Usage: test --int=12 --real=3.14159 --struct=5 --array=1,2 --color=red
+	// Output:
+	// Persistent!int          : 12
+	// Persistent!double       : 3.14159
+	// Persistent!(A)          : A(5)
+	// Persistent!(int[5])     : [1, 2, 0, 0, 0]
+	// Persistent!(Color)      : red
+	void main(string[] argv)
+	{
+		// persistent int
+		auto p0=new Persistent!int("Q1");
+		// persistent double
+		auto p1=new Persistent!double("Q2");
+		// persistent struct
+		auto p2=new Persistent!A("Q3");
+		// persistent static array of 5 ints
+		auto p3=new Persistent!(int[5])("Q4");
+		// persistent enum
+		auto p4=new Persistent!Color("Q5");
+
+		getopt(arg
+			 , "int", delegate(string key, string val){ p0=to!int(val); }
+			 , "real", delegate(string key, string val){ p1=to!double(val); }
+			 , "struct", delegate(string key, string val){ p2.x=to!int(val); }
+			 , "array", delegate(string key, string val){
+		 			auto lst=split(val,",");
+					p3[0..lst.length]=to!(int[])(lst);
+				}
+			 , "color", delegate(string key, string val){ p4=to!Color(val); } 
+			);
+
+
+		writefln("%-24s: %s", typeof(p0).stringof, p0);
+		writefln("%-24s: %s", typeof(p1).stringof, p1);
+		writefln("%-24s: %s", typeof(p2).stringof, p2);
+		writefln("%-24s: %s", typeof(p3).stringof, p3);
+		writefln("%-24s: %s", typeof(p4).stringof, p4);
+	}
+}
+
+


### PR DESCRIPTION
I suggests a new module for mapping  files into memory. Instead of viewing the file as array of bytes, it directly maps the object onto file allowing to handle it as regular in-memory object. The data remain persistent after the program exits and may be re-opened and used again or shared between processes.
Dynamic arrays are also supported with some limitations.
