### PR TITLE
fix Issue 14760 - Clear content-length for libcurl

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -768,7 +768,6 @@ private auto _basicHTTP(T)(const(char)[] url, const(void)[] sendData, HTTP clien
         {
             client.onSend = null;
             client.handle.onSeek = null;
-            client.clearContentLength();
         }
     }
     client.url = url;
@@ -2815,35 +2814,6 @@ struct HTTP
         else
         {
             p.curl.set(lenOpt, len);
-        }
-    }
-
-    // Clear ContentLength depending on method.
-    void clearContentLength()
-    {
-        CurlOption lenOpt;
-        if (p.method == Method.put)
-            lenOpt = CurlOption.infilesize_large;
-        else
-            lenOpt = CurlOption.postfieldsize_large;
-        p.curl.clear(lenOpt);
-    }
-
-    // segmentation fault test
-    unittest
-    {
-        if (!netAllowed()) return;
-        auto http = HTTP();
-        {
-            string data = "Hello world";
-            auto res = post(testUrl2, data, http);
-            assert(res == data,
-                   "post!HTTP() returns unexpected content " ~ res);
-        }
-        {
-            auto res = trace(testUrl1, http);
-            assert(res == "Hello world\n",
-                   "trace!HTTP() returns unexpected content " ~ res);
         }
     }
 

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -768,6 +768,7 @@ private auto _basicHTTP(T)(const(char)[] url, const(void)[] sendData, HTTP clien
         {
             client.onSend = null;
             client.handle.onSeek = null;
+            client.contentLength = 0;
         }
     }
     client.url = url;
@@ -844,6 +845,24 @@ unittest
     if (!netAllowed()) return;
     auto e = collectException!CurlException(get(testUrl1 ~ "nonexisting"));
     assert(e.msg == "HTTP request returned status code 404 (Not Found)");
+}
+
+// Bugzilla 14760 - content length must be reset after post
+unittest
+{
+    //if (!netAllowed()) return;
+    auto http = HTTP();
+    {
+        string data = "Hello world";
+        auto res = post(testUrl2, data, http);
+        assert(res == data,
+               "post!HTTP() returns unexpected content " ~ res);
+    }
+    {
+        auto res = trace(testUrl1, http);
+        assert(res == "Hello world\n",
+               "trace!HTTP() returns unexpected content " ~ res);
+    }
 }
 
 /*


### PR DESCRIPTION
- content-length must be set to allow follow-up
  post/put/trace requests with empty body

- reset content-length to 0 after _basicHTTP