### PR TITLE
Fix 14832: iota should have size_t length.

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -4610,11 +4610,12 @@ body
 
         @property size_t length() const
         {
-            auto l = this.rawLength;
-            if (l > size_t.max)
-                throw new Exception("Length of iota cannot be expressed as "~
-                                    "size_t");
-            return cast(size_t)l;
+            import std.exception : enforce;
+
+            auto len = this.rawLength;
+            enforce(len <= size_t.max, "Length of iota cannot be expressed "~
+                                       "as size_t");
+            return cast(size_t) len;
         }
 
         alias opDollar = rawLength;
@@ -4688,9 +4689,10 @@ if (isIntegral!(CommonType!(B, E)) || isPointer!(CommonType!(B, E)))
         }
         @property size_t length() const
         {
+            import std.exception : enforce;
+
             auto len = this.rawLength;
-            if (len > size_t.max)
-                throw new Exception("Length of iota exceeds size_t");
+            enforce(len <= size_t.max, "Length of iota exceeds size_t");
             return cast(size_t) len;
         }
 

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -4581,7 +4581,7 @@ body
 
         inout(Value) opIndex(ulong n) inout
         {
-            assert(n < this.length);
+            assert(n < this.rawLength);
 
             // Just cast to Value here because doing so gives overflow behavior
             // consistent with calling popFront() n times.
@@ -4590,13 +4590,13 @@ body
         inout(Result) opSlice() inout { return this; }
         inout(Result) opSlice(ulong lower, ulong upper) inout
         {
-            assert(upper >= lower && upper <= this.length);
+            assert(upper >= lower && upper <= this.rawLength);
 
             return cast(inout Result)Result(cast(Value)(current + lower * step),
-                                            cast(Value)(pastLast - (length - upper) * step),
+                                            cast(Value)(pastLast - (rawLength - upper) * step),
                                             step);
         }
-        @property IndexType length() const
+        @property IndexType rawLength() const
         {
             if (step > 0)
             {
@@ -4608,7 +4608,16 @@ body
             }
         }
 
-        alias opDollar = length;
+        @property size_t length() const
+        {
+            auto l = this.rawLength;
+            if (l > size_t.max)
+                throw new Exception("Length of iota cannot be expressed as "~
+                                    "size_t");
+            return cast(size_t)l;
+        }
+
+        alias opDollar = rawLength;
     }
 
     return Result(begin, end, step);
@@ -4659,7 +4668,7 @@ if (isIntegral!(CommonType!(B, E)) || isPointer!(CommonType!(B, E)))
 
         inout(Value) opIndex(ulong n) inout
         {
-            assert(n < this.length);
+            assert(n < this.rawLength);
 
             // Just cast to Value here because doing so gives overflow behavior
             // consistent with calling popFront() n times.
@@ -4668,17 +4677,24 @@ if (isIntegral!(CommonType!(B, E)) || isPointer!(CommonType!(B, E)))
         inout(Result) opSlice() inout { return this; }
         inout(Result) opSlice(ulong lower, ulong upper) inout
         {
-            assert(upper >= lower && upper <= this.length);
+            assert(upper >= lower && upper <= this.rawLength);
 
             return cast(inout Result)Result(cast(Value)(current + lower),
-                                            cast(Value)(pastLast - (length - upper)));
+                                            cast(Value)(pastLast - (rawLength - upper)));
         }
-        @property IndexType length() const
+        @property IndexType rawLength() const
         {
             return unsigned(pastLast - current);
         }
+        @property size_t length() const
+        {
+            auto len = this.rawLength;
+            if (len > size_t.max)
+                throw new Exception("Length of iota exceeds size_t");
+            return cast(size_t) len;
+        }
 
-        alias opDollar = length;
+        alias opDollar = rawLength;
     }
 
     return Result(begin, end);
@@ -4991,6 +5007,25 @@ unittest
         const s2 = cRange[0 .. 3];
         const l = cRange.length;
     }
+}
+
+unittest
+{
+    // Issue 14832: iota(10UL).array should work on 32-bit platforms.
+    import std.array : array;
+    auto r1 = iota(10UL).array;
+    assert(r1 == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+    // Also test 3-argument overload for the same case
+    auto r2 = iota(0UL, 10UL, 2UL).array;
+    assert(r2 == [0, 2, 4, 6, 8]);
+
+    // Make sure we didn't break opDollar
+    auto r1b = iota(ulong.max);
+    assert(r1b[$-1] == ulong.max - 1);
+
+    auto r2b = iota(0, ulong.max-1, 2);
+    assert(r2b[$-1] == ulong.max - 3);
 }
 
 /* Generic overload that handles arbitrary types that support arithmetic


### PR DESCRIPTION
On 32-bit, `iota(10UL)` produces a range whose length is not convertible to `size_t`, causing `array()` to fail, even though its actual length is well within the range of `size_t`.

This fix makes `iota` always return `size_t` as the length. It will throw an exception if the length is not representable as `size_t`.