### PR TITLE
[dox] Fix broken hyperlinks to std.algorithm submodules.

### DIFF
--- a/std/string.d
+++ b/std/string.d
@@ -134,7 +134,7 @@ See_Also:
 
 Macros: WIKI = Phobos/StdString
         SHORTXREF=$(XREF2 $1, $2, $(TT $2))
-        SHORTXREF_PACK=$(XREF_PACK_NAMED  $2, $(TT $3),$1, $3)
+        SHORTXREF_PACK=$(XREF_PACK_NAMED $1,$2,$3, $(TT $3))
 
 Copyright: Copyright Digital Mars 2007-.
 


### PR DESCRIPTION
The `TT` macro was used in the wrong place, causing HTML tag leakage, and there are extraneous spaces that cause the generated link to be broken even after fixing the tag leakage.