### PR TITLE
Fixed Some Imports In std.algorithm

### DIFF
--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -50,12 +50,10 @@ T2=$(TR $(TDNW $(LREF $1)) $(TD $+))
  */
 module std.algorithm.comparison;
 
-// FIXME
-import std.functional; // : unaryFun, binaryFun;
+import std.functional : unaryFun, binaryFun;
 import std.range.primitives;
 import std.traits;
-// FIXME
-import std.typecons; // : tuple, Tuple;
+import std.typecons : tuple, Tuple;
 
 /**
 Find $(D value) _among $(D values), returning the 1-based index

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -60,8 +60,7 @@ T2=$(TR $(TDNW $(LREF $1)) $(TD $+))
  */
 module std.algorithm.iteration;
 
-// FIXME
-import std.functional; // : unaryFun, binaryFun;
+import std.functional : unaryFun, binaryFun;
 import std.range.primitives;
 import std.traits;
 

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -72,8 +72,7 @@ module std.algorithm.mutation;
 
 import std.range.primitives;
 import std.traits : isBlitAssignable, isNarrowString;
-// FIXME
-import std.typecons; // : tuple, Tuple;
+import std.typecons : tuple, Tuple;
 
 // FIXME: somehow deleting this breaks the bringToFront() unittests.
 import std.range;

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -87,12 +87,10 @@ T2=$(TR $(TDNW $(LREF $1)) $(TD $+))
  */
 module std.algorithm.searching;
 
-// FIXME
-import std.functional; // : unaryFun, binaryFun;
+import std.functional : unaryFun, binaryFun;
 import std.range.primitives;
 import std.traits;
-// FIXME
-import std.typecons; // : Tuple;
+import std.typecons : tuple, Tuple;
 
 /++
 Checks if $(I _all) of the elements verify $(D pred).

--- a/std/algorithm/setops.d
+++ b/std/algorithm/setops.d
@@ -42,12 +42,9 @@ T2=$(TR $(TDNW $(LREF $1)) $(TD $+))
 module std.algorithm.setops;
 
 import std.range.primitives;
-
-// FIXME
-import std.functional; // : unaryFun, binaryFun;
+import std.functional : unaryFun, binaryFun;
 import std.traits;
-// FIXME
-import std.typetuple; // : TypeTuple, staticMap, allSatisfy, anySatisfy;
+import std.typetuple : TypeTuple, staticMap, allSatisfy, anySatisfy;
 
 // cartesianProduct
 /**

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -68,10 +68,9 @@ T2=$(TR $(TDNW $(LREF $1)) $(TD $+))
 module std.algorithm.sorting;
 
 import std.algorithm.mutation : SwapStrategy;
-import std.functional; // : unaryFun, binaryFun;
+import std.functional : unaryFun, binaryFun;
 import std.range.primitives;
-// FIXME
-import std.range; // : SortedRange;
+import std.range : SortedRange;
 import std.traits;
 
 /**


### PR DESCRIPTION
I'm not sure why the correct solutions were commented out, as none of the unit tests fail after adding them in.

Eventually, std.algorithm should have these imports in each of the templates and have no global imports, but one step at a time.