### PR TITLE
[dox] Add deprecation message to std.syserror module.

### DIFF
--- a/std/syserror.d
+++ b/std/syserror.d
@@ -5,6 +5,9 @@
 /**
  Convert Win32 error code to string
 
+ $(RED This module has been deprecated. Please see
+    $(LINK2 std_windows_syserror.html, std.windows._syserror) instead).
+
  Source:    $(PHOBOSSRC std/_syserror.d)
 */
 


### PR DESCRIPTION
Yes, I'm quite aware that the link is a broken one; that's because of [issue 13516](https://issues.dlang.org/show_bug.cgi?id=13516). I think that's outside the scope of this PR. Nevertheless, I think we should put in this deprecation message, otherwise people reading the docs will only see a blank page for the module's docs, which is confusing.