### PR TITLE
Issue 14972: Generate Windows docs regardless of host platform

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -199,11 +199,7 @@ EXTRA_MODULES_COMMON := $(addprefix etc/c/,curl odbc/sql odbc/sqlext \
   odbc/sqltypes odbc/sqlucode sqlite3 zlib) $(addprefix std/c/,fenv locale \
   math process stdarg stddef stdio stdlib string time wcharh)
 
-ifeq (,$(findstring win,$(OS)))
-	EXTRA_DOCUMENTABLES := $(EXTRA_MODULES_LINUX) $(EXTRA_MODULES_COMMON)
-else
-	EXTRA_DOCUMENTABLES := $(EXTRA_MODULES_WIN32) $(EXTRA_MODULES_COMMON)
-endif
+EXTRA_DOCUMENTABLES := $(EXTRA_MODULES_LINUX) $(EXTRA_MODULES_WIN32) $(EXTRA_MODULES_COMMON)
 
 EXTRA_MODULES_INTERNAL := $(addprefix			\
 	std/internal/digest/, sha_SSSE3 ) $(addprefix \

--- a/std/c/windows/com.d
+++ b/std/c/windows/com.d
@@ -1,7 +1,7 @@
 // @@@DEPRECATED_2017-06@@@
 
 /++
-    $(RED Deprecated. Use $(D core.sys.windows.com instead. This module will be
+    $(RED Deprecated. Use $(D core.sys.windows.com) instead. This module will be
           removed in June 2017.)
   +/
 deprecated("Import core.sys.windows.com instead")

--- a/std/c/windows/stat.d
+++ b/std/c/windows/stat.d
@@ -5,7 +5,7 @@
 // @@@DEPRECATED_2017-06@@@
 
 /++
-    $(RED Deprecated. Use $(D core.sys.windows.stat instead. This module will be
+    $(RED Deprecated. Use $(D core.sys.windows.stat) instead. This module will be
           removed in June 2017.)
   +/
 deprecated("Import core.sys.windows.stat instead")

--- a/std/c/windows/windows.d
+++ b/std/c/windows/windows.d
@@ -5,7 +5,7 @@ States and other countries. */
 // @@@DEPRECATED_2017-06@@@
 
 /++
-    $(RED Deprecated. Use $(D core.sys.windows.windows instead. This module will
+    $(RED Deprecated. Use $(D core.sys.windows.windows) instead. This module will
           be removed in June 2017.)
   +/
 deprecated("Import core.sys.windows.windows instead")

--- a/std/c/windows/winsock.d
+++ b/std/c/windows/winsock.d
@@ -6,7 +6,7 @@
 // @@@DEPRECATED_2017-06@@@
 
 /++
-    $(RED Deprecated. Use $(D core.sys.windows.winsock2 instead. This module
+    $(RED Deprecated. Use $(D core.sys.windows.winsock2) instead. This module
           will be removed in June 2017.)
   +/
 deprecated("Import core.sys.windows.winsock2 instead")

--- a/std/windows/charset.d
+++ b/std/windows/charset.d
@@ -16,6 +16,41 @@
  *          http://www.boost.org/LICENSE_1_0.txt)
  */
 module std.windows.charset;
+
+version (StdDdoc)
+{
+    /******************************************
+     * Converts the UTF-8 string s into a null-terminated string in a Windows
+     * 8-bit character set.
+     *
+     * Params:
+     * s = UTF-8 string to convert.
+     * codePage = is the number of the target codepage, or
+     *   0 - ANSI,
+     *   1 - OEM,
+     *   2 - Mac
+     *
+     * Authors:
+     *      yaneurao, Walter Bright, Stewart Gordon
+     */
+    const(char)* toMBSz(in char[] s, uint codePage = 0);
+
+    /**********************************************
+     * Converts the null-terminated string s from a Windows 8-bit character set
+     * into a UTF-8 char array.
+     *
+     * Params:
+     * s = UTF-8 string to convert.
+     * codePage = is the number of the source codepage, or
+     *   0 - ANSI,
+     *   1 - OEM,
+     *   2 - Mac
+     * Authors: Stewart Gordon, Walter Bright
+     */
+    string fromMBSz(immutable(char)* s, int codePage = 0);
+}
+else:
+
 version (Windows):
 
 private import std.conv;
@@ -25,21 +60,6 @@ private import std.utf;
 private import std.string;
 
 import std.internal.cstring;
-
-/******************************************
- * Converts the UTF-8 string s into a null-terminated string in a Windows
- * 8-bit character set.
- *
- * Params:
- * s = UTF-8 string to convert.
- * codePage = is the number of the target codepage, or
- *   0 - ANSI,
- *   1 - OEM,
- *   2 - Mac
- *
- * Authors:
- *      yaneurao, Walter Bright, Stewart Gordon
- */
 
 const(char)* toMBSz(in char[] s, uint codePage = 0)
 {
@@ -71,20 +91,6 @@ const(char)* toMBSz(in char[] s, uint codePage = 0)
     }
     return std.string.toStringz(s);
 }
-
-
-/**********************************************
- * Converts the null-terminated string s from a Windows 8-bit character set
- * into a UTF-8 char array.
- *
- * Params:
- * s = UTF-8 string to convert.
- * codePage = is the number of the source codepage, or
- *   0 - ANSI,
- *   1 - OEM,
- *   2 - Mac
- * Authors: Stewart Gordon, Walter Bright
- */
 
 string fromMBSz(immutable(char)* s, int codePage = 0)
 {

--- a/std/windows/iunknown.d
+++ b/std/windows/iunknown.d
@@ -3,7 +3,7 @@
 // @@@DEPRECATED_2017-06@@@
 
 /++
-    $(RED Deprecated. Use $(D core.sys.windows.com instead. This module
+    $(RED Deprecated. Use $(D core.sys.windows.com) instead. This module
           will be removed in June 2017.)
   +/
 deprecated("Import core.sys.windows.com instead")

--- a/std/windows/syserror.d
+++ b/std/windows/syserror.d
@@ -7,8 +7,8 @@
  * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   $(WEB digitalmars.com, Walter Bright)
  * Credits:   Based on code written by Regan Heath
- *
- *          Copyright Digital Mars 2006 - 2013.
+ */
+/*          Copyright Digital Mars 2006 - 2013.
  * Distributed under the Boost Software License, Version 1.0.
  *    (See accompanying file LICENSE_1_0.txt or copy at
  *          http://www.boost.org/LICENSE_1_0.txt)
@@ -24,9 +24,10 @@ version (StdDdoc)
         enum LANG_NEUTRAL = 0, SUBLANG_DEFAULT = 1;
     }
 
-    /// Query the text for a Windows error code (as returned by $(LINK2
-    /// http://msdn.microsoft.com/en-us/library/windows/desktop/ms679360.aspx,
-    /// $(D GetLastError))) as a D string.
+    /** Query the text for a Windows error code, as returned by
+        $(LINK2 http://msdn.microsoft.com/en-us/library/windows/desktop/ms679360.aspx,
+        $(D GetLastError)), as a D string.
+     */
     string sysErrorString(
         DWORD errCode,
         // MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT) is the user's default language
@@ -34,9 +35,9 @@ version (StdDdoc)
         int subLangId = SUBLANG_DEFAULT) @trusted;
 
     /*********************
-     * Thrown if errors that set $(LINK2
-     * http://msdn.microsoft.com/en-us/library/windows/desktop/ms679360.aspx,
-     * $(D GetLastError)) occur.
+       Thrown if errors that set
+       $(LINK2 http://msdn.microsoft.com/en-us/library/windows/desktop/ms679360.aspx,
+       $(D GetLastError)) occur.
      */
     class WindowsException : Exception
     {


### PR DESCRIPTION
This is a blunt-instrument attempt at fixing: https://issues.dlang.org/show_bug.cgi?id=14972

This PR causes docs to be generated from `std.windows.*` modules. It's not perfect, however, as everything under `version(Windows)` is still not generated. But at least `std.windows.syserror` appears to have been specifically written to generate docs on all platforms, so at least this will fix: https://issues.dlang.org/show_bug.cgi?id=13516

There are probably many issues that I overlooked. Please comment.

Depends on: https://github.com/D-Programming-Language/dlang.org/pull/1083