### PR TITLE
Tuple's toString made useful

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ GNUmakefile
 .DS_Store
 .*.sw*
 Makefile
+*.lst
 
 # Rules for Xamarin Studio project data/build output
 *.dproj

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,7 @@ Guidelines for Contributing
 
 Welcome to the D community and thanks for your interest in contributing!
 
+## [Starting as a Contributor](http://wiki.dlang.org/Starting_as_a_Contributor)
 ## [How to contribute pull requests?](http://wiki.dlang.org/Pull_Requests)
 ## [How to build dmd/druntime/phobos/docs?](http://wiki.dlang.org/Building_DMD)
 

--- a/changelog.dd
+++ b/changelog.dd
@@ -7,6 +7,7 @@ $(COMMENT Pending changelog for 2.069. This will get copied to dlang.org and
 $(BUGSTITLE Library Changes,
 
 $(LI $(RELATIVE_LINK2 std-algorithm-moveEmplace, `moveEmplace` was added))
+$(LI $(RELATIVE_LINK2 curl-dynamic-loading, libcurl is now loaded dynamically))
 
 )
 
@@ -33,6 +34,26 @@ $(LI $(LNAME2 std-algorithm-moveEmplace, A combined `moveEmplace` was added.)
     $(P There are also $(XREF algorithm_mutation, moveEmplaceAll)
         and $(XREF algorithm_mutation, moveEmplaceSome) as counterparts of
         $(XREF algorithm_mutation, moveAll) and $(XREF algorithm_mutation, moveSome).
+    )
+)
+
+$(LI $(RELATIVE_LINK2 curl-dynamic-loading, libcurl is now loaded dynamically)
+
+    $(P $(STDMODREF net_curl, std.net.curl) was changed to load curl as shared
+        library at runtime.  This simplifies the usage as it's no longer
+        necessary to link against libcurl or to install any development
+        libraries.
+    )
+
+    $(P The implementation will also try to get the needed curl symbols from the
+        executable itself. So it remains possible to link with a specific
+        version of libcurl or with a static libcurl library.
+    )
+
+    $(P To make this work you have to link with $(I --export-dynamic) respectively
+        use a $(I .DEF) file on Windows (see $(LINK2
+        http://wiki.dlang.org/Curl_on_Windows#Using_the_static_lib, wiki) for
+        more info on the latter).
     )
 )
 

--- a/etc/c/curl.d
+++ b/etc/c/curl.d
@@ -35,8 +35,6 @@
 
 module etc.c.curl;
 
-version (Windows) pragma(lib, "curl");
-
 import core.stdc.time;
 import core.stdc.config;
 import std.socket;

--- a/index.d
+++ b/index.d
@@ -89,6 +89,7 @@ $(BOOKTABLE ,
         $(TD
             Cyclic Redundancy Check (32-bit) implementation$(BR)
             Compute digests such as md5, sha1 and crc32$(BR)
+            Compute HMAC of arbitrary data using a user-specified hash algorithm$(BR)
             Compute MD5 hash of arbitrary data$(BR)
             Compute RIPEMD-160 hash of arbitrary data$(BR)
             Compute SHA1 and SHA2 hashes of arbitrary data

--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -73,7 +73,7 @@ Returns:
     found value plus one is returned.
 
 See_Also:
-$(LREF find) and $(LREF canFind) for finding a value in a
+$(XREF_PACK_NAMED algorithm,searching,find,find) and $(XREF_PACK_NAMED algorithm,searching,canFind, canFind) for finding a value in a
 range.
 */
 uint among(alias pred = (a, b) => a == b, Value, Values...)

--- a/std/array.d
+++ b/std/array.d
@@ -49,6 +49,14 @@ $(TR $(TH Function Name) $(TH Description)
     $(TR $(TD $(D $(LREF replicate)))
         $(TD Creates a new _array out of several copies of an input _array or range.
     ))
+    $(TR $(TD $(D $(LREF sameHead)))
+        $(TD Checks if the initial segments of two arrays refer to the same
+        place in memory.
+    ))
+    $(TR $(TD $(D $(LREF sameTail)))
+        $(TD Checks if the final segments of two arrays refer to the same place
+        in memory.
+    ))
     $(TR $(TD $(D $(LREF split)))
         $(TD Eagerly split a range or string into an _array.
     ))
@@ -3571,6 +3579,12 @@ unittest
     const app3 = app2;
     assert(app3.capacity >= 3);
     assert(app3.data == [1, 2, 3]);
+}
+
+unittest // issue 14605
+{
+    static assert(isOutputRange!(Appender!(int[]), int));
+    static assert(isOutputRange!(RefAppender!(int[]), int));
 }
 
 unittest

--- a/std/container/package.d
+++ b/std/container/package.d
@@ -234,7 +234,7 @@ $(TR $(TDNW $(D x ~ c)) $(TDNW $(D n$(SUBSCRIPT c) + n$(SUBSCRIPT x))) $(TD
 Returns the concatenation of $(D x) and $(D c).  $(D x) may be a
 single element or an input range type.))
 
-$(LEADINGROW Iteration)
+$(LEADINGROWN 3, Iteration)
 
 $(TR  $(TD $(D c.Range)) $(TD) $(TD The primary range
 type associated with the _container.))
@@ -245,7 +245,7 @@ iterating over the entire _container, in a _container-defined order.))
 $(TR $(TDNW $(D c[a .. b])) $(TDNW $(D log n$(SUBSCRIPT c))) $(TD Fetches a
 portion of the _container from key $(D a) to key $(D b).))
 
-$(LEADINGROW Capacity)
+$(LEADINGROWN 3, Capacity)
 
 $(TR $(TD $(D c.empty)) $(TD $(D 1)) $(TD Returns $(D true) if the
 _container has no elements, $(D false) otherwise.))
@@ -265,7 +265,7 @@ without triggering a reallocation.))
 $(TR $(TD $(D c.reserve(x))) $(TD $(D n$(SUBSCRIPT c))) $(TD Forces $(D
 capacity) to at least $(D x) without reducing it.))
 
-$(LEADINGROW Access)
+$(LEADINGROWN 3, Access)
 
 $(TR $(TDNW $(D c.front)) $(TDNW $(D log n$(SUBSCRIPT c))) $(TD Returns the
 first element of the _container, in a _container-defined order.))
@@ -308,7 +308,7 @@ $(TR  $(TDNW $(D c[x] $(I op)= v)) $(TDNW $(D log n$(SUBSCRIPT c)))
 $(TD Performs read-modify-write operation at specified index into the
 _container.))
 
-$(LEADINGROW Operations)
+$(LEADINGROWN 3, Operations)
 
 $(TR $(TDNW $(D e in c)) $(TDNW $(D log n$(SUBSCRIPT c))) $(TD
 Returns nonzero if e is found in $(D c).))
@@ -322,7 +322,7 @@ Returns a range of all elements strictly greater than $(D v).))
 $(TR  $(TDNW $(D c.equalRange(v))) $(TDNW $(D log n$(SUBSCRIPT c))) $(TD
 Returns a range of all elements in $(D c) that are equal to $(D v).))
 
-$(LEADINGROW Modifiers)
+$(LEADINGROWN 3, Modifiers)
 
 $(TR $(TDNW $(D c ~= x)) $(TDNW $(D n$(SUBSCRIPT c) + n$(SUBSCRIPT x)))
 $(TD Appends $(D x) to $(D c). $(D x) may be a single element or an

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -199,7 +199,6 @@ version(unittest)
 }
 version(StdDdoc) import std.stdio;
 
-version (Windows) pragma(lib, "curl");
 extern (C) void exit(int);
 
 // Default data timeout for Protocols
@@ -447,8 +446,7 @@ unittest
  * postData = data to send as the body of the request. An array
  *            of an arbitrary type is accepted and will be cast to ubyte[]
  *            before sending it.
- * conn = connection to use e.g. FTP or HTTP. The default AutoProtocol will
- *        guess connection type and create a new instance for this call only.
+ * conn = HTTP connection to use
  *
  * The template parameter $(D T) specifies the type to return. Possible values
  * are $(D char) and $(D ubyte) to return $(D char[]) or $(D ubyte[]). If asking
@@ -624,22 +622,17 @@ unittest
  *
  * Params:
  * url = resource make a option call to
- * optionsData = options data to send as the body of the request. An array
- *               of an arbitrary type is accepted and will be cast to ubyte[]
- *               before sending it.
  * conn = connection to use e.g. FTP or HTTP. The default AutoProtocol will
  *        guess connection type and create a new instance for this call only.
  *
  * The template parameter $(D T) specifies the type to return. Possible values
  * are $(D char) and $(D ubyte) to return $(D char[]) or $(D ubyte[]).
- * Currently the HTTP RFC does not specify any usage of the optionsData and
- * for this reason the example below does not send optionsData to the server.
  *
  * Example:
  * ----
  * import std.net.curl;
  * auto http = HTTP();
- * options("d-lang.appspot.com/testUrl2", null, http);
+ * options("d-lang.appspot.com/testUrl2", http);
  * writeln("Allow set to " ~ http.responseHeaders["Allow"]);
  * ----
  *
@@ -648,19 +641,26 @@ unittest
  *
  * See_Also: $(LREF HTTP.Method)
  */
+T[] options(T = char)(const(char)[] url, HTTP conn = HTTP())
+    if (is(T == char) || is(T == ubyte))
+{
+    conn.method = HTTP.Method.options;
+    return _basicHTTP!(T)(url, null, conn);
+}
+
+deprecated("options does not send any data")
 T[] options(T = char, OptionsUnit)(const(char)[] url,
                                    const(OptionsUnit)[] optionsData = null,
                                    HTTP conn = HTTP())
-if (is(T == char) || is(T == ubyte))
+    if (is(T == char) || is(T == ubyte))
 {
-    conn.method = HTTP.Method.options;
-    return _basicHTTP!(T)(url, optionsData, conn);
+    return options!T(url, conn);
 }
 
 unittest
 {
     if (!netAllowed()) return;
-    auto res = options(testUrl2, "Hello world");
+    auto res = options(testUrl2);
     assert(res == "Hello world",
            "options!HTTP() returns unexpected content " ~ res);
 }
@@ -668,7 +668,7 @@ unittest
 unittest
 {
     if (!netAllowed()) return;
-    auto res = options(testUrl1, []);
+    auto res = options(testUrl1);
     assert(res == "Hello world\n",
            "options!HTTP() returns unexpected content " ~ res);
 }
@@ -715,8 +715,7 @@ unittest
  *
  * Params:
  * url = resource make a connect to
- * conn = connection to use e.g. FTP or HTTP. The default AutoProtocol will
- *        guess connection type and create a new instance for this call only.
+ * conn = HTTP connection to use
  *
  * The template parameter $(D T) specifies the type to return. Possible values
  * are $(D char) and $(D ubyte) to return $(D char[]) or $(D ubyte[]).
@@ -2112,7 +2111,7 @@ struct HTTP
         ~this()
         {
             if (headersOut !is null)
-                curl_slist_free_all(headersOut);
+                Curl.curl.slist_free_all(headersOut);
             if (curl.handle !is null) // work around RefCounted/emplace bug
                 curl.shutdown();
         }
@@ -2227,7 +2226,7 @@ struct HTTP
         curl_slist* newlist = null;
         while (cur)
         {
-            newlist = curl_slist_append(newlist, cur.data);
+            newlist = Curl.curl.slist_append(newlist, cur.data);
             cur = cur.next;
         }
         copy.p.headersOut = newlist;
@@ -2537,7 +2536,7 @@ struct HTTP
     void clearRequestHeaders()
     {
         if (p.headersOut !is null)
-            curl_slist_free_all(p.headersOut);
+            Curl.curl.slist_free_all(p.headersOut);
         p.headersOut = null;
         p.curl.clear(CurlOption.httpheader);
     }
@@ -2560,8 +2559,8 @@ struct HTTP
         if (icmp(name, "User-Agent") == 0)
             return setUserAgent(value);
         string nv = format("%s: %s", name, value);
-        p.headersOut = curl_slist_append(p.headersOut,
-                                         nv.tempCString().buffPtr);
+        p.headersOut = Curl.curl.slist_append(p.headersOut,
+                                              nv.tempCString().buffPtr);
         p.curl.set(CurlOption.httpheader, p.headersOut);
     }
 
@@ -2569,9 +2568,7 @@ struct HTTP
      * The default "User-Agent" value send with a request.
      * It has the form "Phobos-std.net.curl/$(I PHOBOS_VERSION) (libcurl/$(I CURL_VERSION))"
      */
-    static immutable string defaultUserAgent;
-
-    shared static this()
+    static string defaultUserAgent() @property
     {
         import std.compiler : version_major, version_minor;
 
@@ -2579,12 +2576,17 @@ struct HTTP
         enum fmt = "Phobos-std.net.curl/%d.%03d (libcurl/%d.%d.%d)";
         enum maxLen = fmt.length - "%d%03d%d%d%d".length + 10 + 10 + 3 + 3 + 3;
 
-        __gshared char[maxLen] buf = void;
+        static char[maxLen] buf = void;
+        static string userAgent;
 
-        auto curlVer = curl_version_info(CURLVERSION_NOW).version_num;
-        defaultUserAgent = cast(immutable)sformat(
-            buf, fmt, version_major, version_minor,
-            curlVer >> 16 & 0xFF, curlVer >> 8 & 0xFF, curlVer & 0xFF);
+        if (!userAgent.length)
+        {
+            auto curlVer = Curl.curl.version_info(CURLVERSION_NOW).version_num;
+            userAgent = cast(immutable)sformat(
+                buf, fmt, version_major, version_minor,
+                curlVer >> 16 & 0xFF, curlVer >> 8 & 0xFF, curlVer & 0xFF);
+        }
+        return userAgent;
     }
 
     /** Set the value of the user agent request header field.
@@ -2942,7 +2944,7 @@ struct FTP
         ~this()
         {
             if (commands !is null)
-                curl_slist_free_all(commands);
+                Curl.curl.slist_free_all(commands);
             if (curl.handle !is null) // work around RefCounted/emplace bug
                 curl.shutdown();
         }
@@ -2981,7 +2983,7 @@ struct FTP
         curl_slist* newlist = null;
         while (cur)
         {
-            newlist = curl_slist_append(newlist, cur.data);
+            newlist = Curl.curl.slist_append(newlist, cur.data);
             cur = cur.next;
         }
         copy.p.commands = newlist;
@@ -3197,7 +3199,7 @@ struct FTP
     void clearCommands()
     {
         if (p.commands !is null)
-            curl_slist_free_all(p.commands);
+            Curl.curl.slist_free_all(p.commands);
         p.commands = null;
         p.curl.clear(CurlOption.postquote);
     }
@@ -3218,8 +3220,8 @@ struct FTP
      */
     void addCommand(const(char)[] command)
     {
-        p.commands = curl_slist_append(p.commands,
-                                       command.tempCString().buffPtr);
+        p.commands = Curl.curl.slist_append(p.commands,
+                                            command.tempCString().buffPtr);
         p.curl.set(CurlOption.postquote, p.commands);
     }
 
@@ -3324,7 +3326,7 @@ struct SMTP
         curl_slist* newlist = null;
         while (cur)
         {
-            newlist = curl_slist_append(newlist, cur.data);
+            newlist = Curl.curl.slist_append(newlist, cur.data);
             cur = cur.next;
         }
         copy.p.commands = newlist;
@@ -3558,7 +3560,7 @@ struct SMTP
         foreach(recipient; recipients)
         {
             recipients_list =
-                curl_slist_append(recipients_list,
+                Curl.curl.slist_append(recipients_list,
                                   recipient.tempCString().buffPtr);
         }
         p.curl.set(CurlOption.mail_rcpt, recipients_list);
@@ -3625,6 +3627,119 @@ import std.typecons : Flag;
 /// Flag to specify whether or not an exception is thrown on error.
 alias ThrowOnError = Flag!"throwOnError";
 
+private struct CurlAPI
+{
+    static struct API
+    {
+    extern(C):
+        import core.stdc.config : c_long;
+        CURLcode function(c_long flags) global_init;
+        void function() global_cleanup;
+        curl_version_info_data * function(CURLversion) version_info;
+        CURL* function() easy_init;
+        CURLcode function(CURL *curl, CURLoption option,...) easy_setopt;
+        CURLcode function(CURL *curl) easy_perform;
+        CURL* function(CURL *curl) easy_duphandle;
+        char* function(CURLcode) easy_strerror;
+        CURLcode function(CURL *handle, int bitmask) easy_pause;
+        void function(CURL *curl) easy_cleanup;
+        curl_slist* function(curl_slist *, char *) slist_append;
+        void function(curl_slist *) slist_free_all;
+    }
+    __gshared API _api;
+    __gshared void* _handle;
+
+    static ref API instance() @property
+    {
+        import std.concurrency;
+        initOnce!_handle(loadAPI());
+        return _api;
+    }
+
+    static void* loadAPI()
+    {
+        version (Posix)
+        {
+            import core.sys.posix.dlfcn;
+            alias loadSym = dlsym;
+        }
+        else version (Windows)
+        {
+            import core.sys.windows.windows;
+            alias loadSym = GetProcAddress;
+        }
+        else
+            static assert(0, "unimplemented");
+
+        void* handle;
+        version (Posix)
+            handle = dlopen(null, RTLD_LAZY);
+        else version (Windows)
+            handle = GetModuleHandleA(null);
+        assert(handle !is null);
+
+        // try to load curl from the executable to allow static linking
+        if (loadSym(handle, "curl_global_init") is null)
+        {
+            version (Posix)
+                dlclose(handle);
+
+            version (OSX)
+                static immutable names = ["libcurl.4.dylib"];
+            else version (Posix)
+                static immutable names = ["libcurl.so", "libcurl.so.4", "libcurl-gnutls.so.4", "libcurl-nss.so.4", "libcurl.so.3"];
+            else version (Windows)
+                static immutable names = ["libcurl.dll", "curl.dll"];
+
+            foreach (name; names)
+            {
+                version (Posix)
+                    handle = dlopen(name.ptr, RTLD_LAZY);
+                else version (Windows)
+                    handle = LoadLibraryA(name.ptr);
+                if (handle !is null) break;
+            }
+
+            enforce!CurlException(handle !is null, "Failed to load curl, tried %(%s, %).".format(names));
+        }
+
+        foreach (mem; __traits(allMembers, API))
+        {
+            void* p = loadSym(handle, "curl_"~mem);
+
+            __traits(getMember, _api, mem) = cast(typeof(__traits(getMember, _api, mem)))
+                enforce!CurlException(p, "Couldn't load curl_"~mem~" from libcurl.");
+        }
+
+        enforce!CurlException(!_api.global_init(CurlGlobal.all),
+                              "Failed to initialize libcurl");
+
+        return handle;
+    }
+
+    shared static ~this()
+    {
+        if (_handle is null) return;
+
+        _api.global_cleanup();
+        version (Posix)
+        {
+            import core.sys.posix.dlfcn;
+            dlclose(_handle);
+        }
+        else version (Windows)
+        {
+            import core.sys.windows.windows;
+            FreeLibrary(_handle);
+        }
+        else
+            static assert(0, "unimplemented");
+
+        _api = API.init;
+        _handle = null;
+    }
+}
+
 /**
   Wrapper to provide a better interface to libcurl than using the plain C API.
   It is recommended to use the $(D HTTP)/$(D FTP) etc. structs instead unless
@@ -3637,21 +3752,11 @@ alias ThrowOnError = Flag!"throwOnError";
 */
 struct Curl
 {
-    shared static this()
-    {
-        // initialize early to prevent thread races
-        enforce!CurlException(!curl_global_init(CurlGlobal.all),
-                                "Couldn't initialize libcurl");
-    }
-
-    shared static ~this()
-    {
-        curl_global_cleanup();
-    }
-
     alias OutData = void[];
     alias InData = ubyte[];
     bool stopped;
+
+    private static auto ref curl() @property { return CurlAPI.instance(); }
 
     // A handle should not be used by two threads simultaneously
     private CURL* handle;
@@ -3674,7 +3779,7 @@ struct Curl
     void initialize()
     {
         enforce!CurlException(!handle, "Curl instance already initialized");
-        handle = curl_easy_init();
+        handle = curl.easy_init();
         enforce!CurlException(handle, "Curl instance couldn't be initialized");
         stopped = false;
         set(CurlOption.nosignal, 1);
@@ -3691,7 +3796,7 @@ struct Curl
     Curl dup()
     {
         Curl copy;
-        copy.handle = curl_easy_duphandle(handle);
+        copy.handle = curl.easy_duphandle(handle);
         copy.stopped = false;
 
         with (CurlOption) {
@@ -3756,7 +3861,7 @@ struct Curl
     {
         import core.stdc.string : strlen;
 
-        auto msgZ = curl_easy_strerror(code);
+        auto msgZ = curl.easy_strerror(code);
         // doing the following (instead of just using std.conv.to!string) avoids 1 allocation
         return format("%s on handle %s", msgZ[0 .. core.stdc.string.strlen(msgZ)], handle);
     }
@@ -3776,7 +3881,7 @@ struct Curl
     {
         throwOnStopped();
         stopped = true;
-        curl_easy_cleanup(this.handle);
+        curl.easy_cleanup(this.handle);
         this.handle = null;
     }
 
@@ -3786,7 +3891,7 @@ struct Curl
     void pause(bool sendingPaused, bool receivingPaused)
     {
         throwOnStopped();
-        _check(curl_easy_pause(this.handle,
+        _check(curl.easy_pause(this.handle,
                                (sendingPaused ? CurlPause.send_cont : CurlPause.send) |
                                (receivingPaused ? CurlPause.recv_cont : CurlPause.recv)));
     }
@@ -3800,7 +3905,7 @@ struct Curl
     void set(CurlOption option, const(char)[] value)
     {
         throwOnStopped();
-        _check(curl_easy_setopt(this.handle, option, value.tempCString().buffPtr));
+        _check(curl.easy_setopt(this.handle, option, value.tempCString().buffPtr));
     }
 
     /**
@@ -3812,7 +3917,7 @@ struct Curl
     void set(CurlOption option, long value)
     {
         throwOnStopped();
-        _check(curl_easy_setopt(this.handle, option, value));
+        _check(curl.easy_setopt(this.handle, option, value));
     }
 
     /**
@@ -3824,7 +3929,7 @@ struct Curl
     void set(CurlOption option, void* value)
     {
         throwOnStopped();
-        _check(curl_easy_setopt(this.handle, option, value));
+        _check(curl.easy_setopt(this.handle, option, value));
     }
 
     /**
@@ -3835,7 +3940,7 @@ struct Curl
     void clear(CurlOption option)
     {
         throwOnStopped();
-        _check(curl_easy_setopt(this.handle, option, null));
+        _check(curl.easy_setopt(this.handle, option, null));
     }
 
     /**
@@ -3847,7 +3952,7 @@ struct Curl
     void clearIfSupported(CurlOption option)
     {
         throwOnStopped();
-        auto rval = curl_easy_setopt(this.handle, option, null);
+        auto rval = curl.easy_setopt(this.handle, option, null);
         if (rval != CurlError.unknown_telnet_option)
         {
             _check(rval);
@@ -3864,7 +3969,7 @@ struct Curl
     CurlCode perform(ThrowOnError throwOnError = ThrowOnError.yes)
     {
         throwOnStopped();
-        CurlCode code = curl_easy_perform(this.handle);
+        CurlCode code = curl.easy_perform(this.handle);
         if (throwOnError)
             _check(code);
         return code;

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -2447,7 +2447,7 @@ $(D Range) that locks the file and allows fast writing to it.
             import core.stdc.wchar_ : fwide;
             import std.exception : enforce;
 
-            enforce(f._p && f._p.handle);
+            enforce(f._p && f._p.handle, "Attempting to write to closed File");
             fps_ = f._p.handle;
             orientation_ = fwide(fps_, 0);
             FLOCK(fps_);
@@ -2795,6 +2795,13 @@ unittest
         writer.put(repeat('#', 12)); // BUG 11945
     }
     assert(File(deleteme).readln() == "日本語日本語日本語日本語############");
+}
+
+@safe unittest
+{
+    import std.exception: collectException;
+    auto e = collectException({ File f; f.writeln("Hello!"); }());
+    assert(e && e.msg == "Attempting to write to closed File");
 }
 
 /// Used to specify the lock type for $(D File.lock) and $(D File.tryLock).

--- a/std/string.d
+++ b/std/string.d
@@ -134,7 +134,7 @@ See_Also:
 
 Macros: WIKI = Phobos/StdString
         SHORTXREF=$(XREF2 $1, $2, $(TT $2))
-        SHORTXREF_PACK=$(XREF_PACK_NAMED  $2, $(TT $3),$1, $3)
+        SHORTXREF_PACK=$(XREF_PACK_NAMED $1,$2,$3, $(TT $3))
 
 Copyright: Copyright Digital Mars 2007-.
 

--- a/std/traits.d
+++ b/std/traits.d
@@ -134,6 +134,7 @@
  *           $(LREF getSymbolsByUDA)
  * ))
  * )
+ * )
  *
  * Macros:
  *  WIKI = Phobos/StdTraits
@@ -3280,19 +3281,7 @@ alias Identity(alias A) = A;
    Yields $(D true) if and only if $(D T) is an aggregate that defines
    a symbol called $(D name).
  */
-template hasMember(T, string name)
-{
-    static if (is(T == struct) || is(T == class) || is(T == union) || is(T == interface))
-    {
-        enum bool hasMember =
-            staticIndexOf!(name, __traits(allMembers, T)) != -1 ||
-            __traits(compiles, { mixin("alias Sym = Identity!(T."~name~");"); });
-    }
-    else
-    {
-        enum bool hasMember = false;
-    }
-}
+enum hasMember(T, string name) = __traits(hasMember, T, name);
 
 ///
 unittest
@@ -3338,6 +3327,15 @@ unittest
     static assert(hasMember!(R2!S, "f"));
     static assert(hasMember!(R2!S, "t"));
     static assert(hasMember!(R2!S, "T"));
+}
+
+unittest
+{
+    static struct S
+    {
+        void opDispatch(string n, A)(A dummy) {}
+    }
+    static assert(hasMember!(S, "foo"));
 }
 
 /**

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -291,6 +291,18 @@ unittest
     assert(!uf2.isEmpty);
 }
 
+// Used in Tuple.toString
+private template sharedToString(alias field)
+    if(is(typeof(field) == shared))
+{
+    static immutable sharedToString = typeof(field).stringof;
+}
+
+private template sharedToString(alias field)
+    if(!is(typeof(field) == shared))
+{
+    alias sharedToString = field;
+}
 
 /**
 Tuple of values, for example $(D Tuple!(int, string)) is a record that
@@ -760,43 +772,134 @@ template Tuple(Specs...)
             return h;
         }
 
-        void toString(DG)(scope DG sink)
+        ///
+        template toString()
         {
-            enum header = typeof(this).stringof ~ "(",
-                 footer = ")",
-                 separator = ", ";
-            sink(header);
-            foreach (i, Type; Types)
+            import std.format : FormatSpec;
+
+            /**
+             * Formats `Tuple` with either `%s`, `%(inner%)` or `%(inner%|sep%)`.
+             *
+             * `%s` is the original format.
+             * `%(inner%)` where `inner` is the format applied the expanded `Tuple`,
+             * so `inner` may contain as many formats as the `Tuple` has fields.
+             * `%(inner%|sep%)`, where `inner` is one format, that is applied
+             * on all fields of the `Tuple`. The inner format must be compatible to all
+             * of them.
+             * ---
+             *  Tuple!(int, double)[3] tupList = [ tuple(1, 1.0), tuple(2, 4.0), tuple(3, 9.0) ];
+             *
+             *  // Default format
+             *  assert(format("%s", tuple("a", 1)) == `Tuple!(string, int)("a", 1)`);
+             *
+             *  // One Format for each individual component
+             *  assert(format("%(%#x v %.4f w %#x%)", tuple(1, 1.0, 10))         == `0x1 v 1.0000 w 0xa`);
+             *  assert(format(  "%#x v %.4f w %#x"  , tuple(1, 1.0, 10).expand)  == `0x1 v 1.0000 w 0xa`);
+             *
+             *  // One Format for all components
+             *  assert(format("%(>%s<%| & %)", tuple("abc", 1, 2.3, [4, 5])) == `>abc< & >1< & >2.3< & >[4, 5]<`);
+             *
+             *  // Array of Tuples
+             *  assert(format("%(%(f(%d) = %.1f%);  %)", tupList) == `f(1) = 1.0;  f(2) = 4.0;  f(3) = 9.0`);
+             *
+             *
+             *  // Intuition: Tuple is identical to its components. Error: %( %) missing.
+             *  assertThrown!FormatException(
+             *      format("%d, %f", tuple(1, 2.0)) == `1, 2.0`
+             *  );
+             *
+             *  // Intuition: Tuple is like an Array. Error: %( %| %) missing.
+             *  assertThrown!FormatException(
+             *      format("%d", tuple(1, 2)) == `1, 2`
+             *  );
+             *
+             *  // Error: %d inadequate for double
+             *  assertThrown!FormatException(
+             *      format("%(%d%|, %)", tuple(1, 2.0)) == `1, 2.0`
+             *  );
+             * ---
+             */
+            void toString(DG)(scope DG sink) const pure @safe
             {
-                static if (i > 0)
+                toString(sink, FormatSpec!char());
+            }
+
+            /// ditto
+            void toString(DG, Char)(scope DG sink, FormatSpec!Char fmt) const pure @safe
+            {
+                import std.format : formatElement, formattedWrite, FormatException;
+                if (fmt.nested)
                 {
-                    sink(separator);
+                    if (fmt.sep)
+                    {
+                        foreach (i, Type; Types)
+                        {
+                            static if (i > 0)
+                            {
+                                sink(fmt.sep);
+                            }
+                            // TODO: Change this once toString() works for shared objects.
+                            static if (is(Type == class) && is(Type == shared))
+                            {
+                                sink(Type.stringof);
+                            }
+                            else
+                            {
+                                formattedWrite(sink, fmt.nested, this.field[i]);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        formattedWrite(sink, fmt.nested, staticMap!(sharedToString, this.expand));
+                    }
                 }
-                // TODO: Change this once toString() works for shared objects.
-                static if (is(Type == class) && is(typeof(Type.init) == shared))
+                else if (fmt.spec == 's')
                 {
-                    sink(Type.stringof);
+                    enum header = Unqual!(typeof(this)).stringof ~ "(",
+                         footer = ")",
+                         separator = ", ";
+                    sink(header);
+                    foreach (i, Type; Types)
+                    {
+                        static if (i > 0)
+                        {
+                            sink(separator);
+                        }
+                        // TODO: Change this once toString() works for shared objects.
+                        static if (is(Type == class) && is(Type == shared))
+                        {
+                            sink(Type.stringof);
+                        }
+                        else
+                        {
+                            FormatSpec!Char f;
+                            formatElement(sink, field[i], f);
+                        }
+                    }
+                    sink(footer);
                 }
                 else
                 {
-                    import std.format : FormatSpec, formatElement;
-                    FormatSpec!char f;
-                    formatElement(sink, field[i], f);
+                    throw new FormatException(
+                        "Expected '%s' or '%(...%)' or '%(...%|...%)' format specifier for type '" ~
+                            Unqual!(typeof(this)).stringof ~ "', not '%" ~ fmt.spec ~ "'.");
                 }
             }
-            sink(footer);
-        }
 
-        /**
-         * Converts to string.
-         *
-         * Returns:
-         *     The string representation of this `Tuple`.
-         */
-        string toString()()
-        {
-            import std.conv : to;
-            return this.to!string;
+            /**
+             * Converts to string.
+             *
+             * Returns:
+             *     The string representation of this `Tuple`.
+             */
+            string toString() const pure @safe
+            {
+                import std.array : appender;
+                auto app = appender!string();
+                this.toString((const(char)[] chunk) => app ~= chunk);
+                return app.data;
+            }
         }
     }
 }
@@ -1276,6 +1379,46 @@ unittest
     alias T = Tuple!(string, "s");
     T x;
     x = T.init;
+}
+
+@safe unittest
+{
+    import std.format : format, FormatException;
+    import std.exception : assertThrown;
+
+    // enum tupStr = tuple(1, 1.0).toString; // assert toString is unpure.
+    //static assert (tupStr == `Tuple!(int, double)(1, 1)`);
+
+    Tuple!(int, double)[3] tupList = [ tuple(1, 1.0), tuple(2, 4.0), tuple(3, 9.0) ];
+
+    // Default format
+    assert(format("%s", tuple("a", 1)) == `Tuple!(string, int)("a", 1)`);
+
+    // One Format for each individual component
+    assert(format("%(%#x v %.4f w %#x%)", tuple(1, 1.0, 10))         == `0x1 v 1.0000 w 0xa`);
+    assert(format(  "%#x v %.4f w %#x"  , tuple(1, 1.0, 10).expand)  == `0x1 v 1.0000 w 0xa`);
+
+    // One Format for all components
+    assert(format("%(>%s<%| & %)", tuple("abc", 1, 2.3, [4, 5])) == `>abc< & >1< & >2.3< & >[4, 5]<`);
+
+    // Array of Tuples
+    assert(format("%(%(f(%d) = %.1f%);  %)", tupList) == `f(1) = 1.0;  f(2) = 4.0;  f(3) = 9.0`);
+
+
+    // Intuition: Tuple is identical to its components. Error: %( %) missing.
+    assertThrown!FormatException(
+        format("%d, %f", tuple(1, 2.0)) == `1, 2.0`
+    );
+
+    // Intuition: Tuple is like an Array. Error: %( %| %) missing.
+    assertThrown!FormatException(
+        format("%d", tuple(1, 2)) == `1, 2`
+    );
+
+    // Error: %d inadequate for double
+    assertThrown!FormatException(
+        format("%(%d%|, %)", tuple(1, 2.0)) == `1, 2.0`
+    );
 }
 
 /**

--- a/std/variant.d
+++ b/std/variant.d
@@ -2243,7 +2243,7 @@ private auto visitImpl(bool Strict, VariantType, Handler...)(VariantType variant
 
     foreach(idx, T; AllowedTypes)
     {
-        if (T* ptr = variant.peek!T)
+        if (auto ptr = variant.peek!T)
         {
             enum dgIdx = HandlerOverloadMap.indices[idx];
 
@@ -2267,6 +2267,22 @@ private auto visitImpl(bool Strict, VariantType, Handler...)(VariantType variant
     }
 
     assert(false);
+}
+
+unittest
+{
+    // validate that visit can be called with a const type
+    struct Foo { int depth; }
+    struct Bar { int depth; }
+    alias FooBar = Algebraic!(Foo, Bar);
+
+    int depth(in FooBar fb) {
+        return fb.visit!((Foo foo) => foo.depth,
+                         (Bar bar) => bar.depth);
+    }
+
+    FooBar fb = Foo(3);
+    assert(depth(fb) == 3);
 }
 
 unittest

--- a/unittest.d
+++ b/unittest.d
@@ -59,6 +59,7 @@ public import std.digest.digest;
 public import std.digest.crc;
 public import std.digest.sha;
 public import std.digest.md;
+public import std.digest.hmac;
 
 int main(string[] args)
 {

--- a/win32.mak
+++ b/win32.mak
@@ -328,6 +328,7 @@ DOCS=	$(DOC)\object.html \
 	$(DOC)\std_digest_sha.html \
 	$(DOC)\std_digest_md.html \
 	$(DOC)\std_digest_ripemd.html \
+	$(DOC)\std_digest_hmac.html \
 	$(DOC)\std_digest_digest.html \
 	$(DOC)\std_cstream.html \
 	$(DOC)\std_csv.html \

--- a/win64.mak
+++ b/win64.mak
@@ -349,6 +349,7 @@ DOCS=	$(DOC)\object.html \
 	$(DOC)\std_digest_sha.html \
 	$(DOC)\std_digest_md.html \
 	$(DOC)\std_digest_ripemd.html \
+	$(DOC)\std_digest_hmac.html \
 	$(DOC)\std_digest_digest.html \
 	$(DOC)\std_cstream.html \
 	$(DOC)\std_csv.html \


### PR DESCRIPTION
From http://forum.dlang.org/thread/srofuqyrdzphgzylbwds@forum.dlang.org
With this, you can easily format a Tuple from its content, similar how to do with an array.
The `toString(delegate, FormatSpec)` function takes the formats ``%(``nested``%)`` and ``%(``nested``%|``separator``%)`` a bit different: The second one treats the Tuple as it was an array. The first one applies the nested format to the expanded fields, like ``format(nested, tup.expand)`` did.
With this, the question http://forum.dlang.org/post/ntqawkupddjcijwtwovp@forum.dlang.org gets a trivial answer: Use ``"%(%(%s%| %)\n%)"`` insted of ``"%(%(%s %)\n%)"``.
It can be expected not to break any existing code.