### PR TITLE
[dox] Improve docs for std.exception.{does,may}PointTo

### DIFF
--- a/std/exception.d
+++ b/std/exception.d
@@ -1059,7 +1059,7 @@ $(D source) does not point to $(D target). It may produce false positives, but n
 false negatives. This function should be prefered for defensively choosing a
 code path.
 
-Note: Evaluating $(D pointsTo(x, x)) checks whether $(D x) has
+Note: Evaluating $(D doesPointTo(x, x)) checks whether $(D x) has
 internal pointers. This should only be done as an assertive test,
 as the language is free to assume objects don't have internal pointers
 (TDPL 7.1.3.5).

--- a/std/exception.d
+++ b/std/exception.d
@@ -1027,9 +1027,14 @@ unittest
 }
 
 /**
-The "pointsTo" functions, $(D doesPointTo) and $(D mayPointTo).
+Checks whether a given source object contains pointers or references to a given
+target object.
 
-Returns $(D true) if $(D source)'s representation embeds a pointer
+Params:
+    source = The source object
+    target = The target object
+
+Returns: $(D true) if $(D source)'s representation embeds a pointer
 that points to $(D target)'s representation or somewhere inside
 it.
 
@@ -1094,6 +1099,14 @@ bool doesPointTo(S, T, Tdummy=void)(auto ref const S source, ref const T target)
     }
 }
 
+// for shared objects
+/// ditto
+bool doesPointTo(S, T)(auto ref const shared S source, ref const shared T target) @trusted pure nothrow
+{
+    return doesPointTo!(shared S, shared T, void)(source, target);
+}
+
+/// ditto
 bool mayPointTo(S, T, Tdummy=void)(auto ref const S source, ref const T target) @trusted pure nothrow
     if (__traits(isRef, source) || isDynamicArray!S ||
         isPointer!S || is(S == class))
@@ -1129,10 +1142,7 @@ bool mayPointTo(S, T, Tdummy=void)(auto ref const S source, ref const T target) 
 }
 
 // for shared objects
-bool doesPointTo(S, T)(auto ref const shared S source, ref const shared T target) @trusted pure nothrow
-{
-    return doesPointTo!(shared S, shared T, void)(source, target);
-}
+/// ditto
 bool mayPointTo(S, T)(auto ref const shared S source, ref const shared T target) @trusted pure nothrow
 {
     return mayPointTo!(shared S, shared T, void)(source, target);

--- a/std/exception.d
+++ b/std/exception.d
@@ -1041,7 +1041,7 @@ it.
 If $(D source) is or contains a dynamic array, then, then these functions will check
 if there is overlap between the dynamic array and $(D target)'s representation.
 
-If $(D source) is a class, then pointsTo will handle it as a pointer.
+If $(D source) is a class, then it will be handled as a pointer.
 
 If $(D target) is a pointer, a dynamic array or a class, then these functions will only
 check if $(D source) points to $(D target), $(I not) what $(D target) references.
@@ -1148,63 +1148,6 @@ bool mayPointTo(S, T)(auto ref const shared S source, ref const shared T target)
     return mayPointTo!(shared S, shared T, void)(source, target);
 }
 
-deprecated ("pointsTo is ambiguous. Please use either of doesPointTo or mayPointTo")
-alias pointsTo = doesPointTo;
-
-/+
-Returns true if the field at index $(D i) in ($D T) shares its address with another field.
-
-Note: This does not merelly check if the field is a member of an union, but also that
-it is not a single child.
-+/
-package enum isUnionAliased(T, size_t i) = isUnionAliasedImpl!T(T.tupleof[i].offsetof);
-private bool isUnionAliasedImpl(T)(size_t offset)
-{
-    int count = 0;
-    foreach (i, U; typeof(T.tupleof))
-        if (T.tupleof[i].offsetof == offset)
-            ++count;
-    return count >= 2;
-}
-//
-unittest
-{
-    static struct S
-    {
-        int a0; //Not aliased
-        union
-        {
-            int a1; //Not aliased
-        }
-        union
-        {
-            int a2; //Aliased
-            int a3; //Aliased
-        }
-        union A4
-        {
-            int b0; //Not aliased
-        }
-        A4 a4;
-        union A5
-        {
-            int b0; //Aliased
-            int b1; //Aliased
-        }
-        A5 a5;
-    }
-
-    static assert(!isUnionAliased!(S, 0)); //a0;
-    static assert(!isUnionAliased!(S, 1)); //a1;
-    static assert( isUnionAliased!(S, 2)); //a2;
-    static assert( isUnionAliased!(S, 3)); //a3;
-    static assert(!isUnionAliased!(S, 4)); //a4;
-        static assert(!isUnionAliased!(S.A4, 0)); //a4.b0;
-    static assert(!isUnionAliased!(S, 5)); //a5;
-        static assert( isUnionAliased!(S.A5, 0)); //a5.b0;
-        static assert( isUnionAliased!(S.A5, 1)); //a5.b1;
-}
-
 /// Pointers
 unittest
 {
@@ -1226,14 +1169,14 @@ unittest
     int i;
     auto s = S(0, &i);
 
-    //structs and unions "own" their members
-    //pointsTo will answer true if one of the members pointsTo.
+    // structs and unions "own" their members
+    // pointsTo will answer true if one of the members pointsTo.
     assert(!s.doesPointTo(s.v)); //s.v is just v member of s, so not pointed.
     assert( s.p.doesPointTo(i)); //i is pointed by s.p.
     assert( s  .doesPointTo(i)); //which means i is pointed by s itself.
 
-    //Unions will behave exactly the same. Points to will check each "member"
-    //individually, even if they share the same memory
+    // Unions will behave exactly the same. Points to will check each "member"
+    // individually, even if they share the same memory
 }
 
 /// Arrays (dynamic and static)
@@ -1245,20 +1188,23 @@ unittest
     int*[]  slicep = [&i];
     int*[1] arrp   = [&i];
 
-    //A slice points to all of its members:
+    // A slice points to all of its members:
     assert( slice.doesPointTo(slice[3]));
-    assert(!slice[0 .. 2].doesPointTo(slice[3])); //Object 3 is outside of the slice [0 .. 2]
+    assert(!slice[0 .. 2].doesPointTo(slice[3])); // Object 3 is outside of the
+                                                  // slice [0 .. 2]
 
-    //Note that a slice will not take into account what its members point to.
+    // Note that a slice will not take into account what its members point to.
     assert( slicep[0].doesPointTo(i));
     assert(!slicep   .doesPointTo(i));
 
-    //static arrays are objects that own their members, just like structs:
-    assert(!arr.doesPointTo(arr[0])); //arr[0] is just a member of arr, so not pointed.
-    assert( arrp[0].doesPointTo(i));  //i is pointed by arrp[0].
-    assert( arrp   .doesPointTo(i));  //which means i is pointed by arrp itslef.
+    // static arrays are objects that own their members, just like structs:
+    assert(!arr.doesPointTo(arr[0])); // arr[0] is just a member of arr, so not
+                                      // pointed.
+    assert( arrp[0].doesPointTo(i));  // i is pointed by arrp[0].
+    assert( arrp   .doesPointTo(i));  // which means i is pointed by arrp
+                                      // itself.
 
-    //Notice the difference between static and dynamic arrays:
+    // Notice the difference between static and dynamic arrays:
     assert(!arr  .doesPointTo(arr[0]));
     assert( arr[].doesPointTo(arr[0]));
     assert( arrp  .doesPointTo(i));
@@ -1276,10 +1222,11 @@ unittest
     int i;
     C a = new C(&i);
     C b = a;
-    //Classes are a bit particular, as they are treated like simple pointers
-    //to a class payload.
-    assert( a.p.doesPointTo(i)); //a.p points to i.
-    assert(!a  .doesPointTo(i)); //Yet a itself does not point i.
+
+    // Classes are a bit particular, as they are treated like simple pointers
+    // to a class payload.
+    assert( a.p.doesPointTo(i)); // a.p points to i.
+    assert(!a  .doesPointTo(i)); // Yet a itself does not point i.
 
     //To check the class payload itself, iterate on its members:
     ()
@@ -1290,9 +1237,10 @@ unittest
         assert(0);
     }();
 
-    //To check if a class points a specific payload, a direct memmory check can be done:
+    // To check if a class points a specific payload, a direct memmory check
+    // can be done:
     auto aLoc = cast(ubyte[__traits(classInstanceSize, C)]*) a;
-    assert(b.doesPointTo(*aLoc)); //b points to where a is pointing
+    assert(b.doesPointTo(*aLoc)); // b points to where a is pointing
 }
 
 unittest
@@ -1476,6 +1424,63 @@ unittest //more alias this opCast
     }
     assert(!doesPointTo(A.init, p));
     assert(!mayPointTo(A.init, p));
+}
+
+deprecated ("pointsTo is ambiguous. Please use either of doesPointTo or mayPointTo")
+alias pointsTo = doesPointTo;
+
+/+
+Returns true if the field at index $(D i) in ($D T) shares its address with another field.
+
+Note: This does not merelly check if the field is a member of an union, but also that
+it is not a single child.
++/
+package enum isUnionAliased(T, size_t i) = isUnionAliasedImpl!T(T.tupleof[i].offsetof);
+private bool isUnionAliasedImpl(T)(size_t offset)
+{
+    int count = 0;
+    foreach (i, U; typeof(T.tupleof))
+        if (T.tupleof[i].offsetof == offset)
+            ++count;
+    return count >= 2;
+}
+//
+unittest
+{
+    static struct S
+    {
+        int a0; //Not aliased
+        union
+        {
+            int a1; //Not aliased
+        }
+        union
+        {
+            int a2; //Aliased
+            int a3; //Aliased
+        }
+        union A4
+        {
+            int b0; //Not aliased
+        }
+        A4 a4;
+        union A5
+        {
+            int b0; //Aliased
+            int b1; //Aliased
+        }
+        A5 a5;
+    }
+
+    static assert(!isUnionAliased!(S, 0)); //a0;
+    static assert(!isUnionAliased!(S, 1)); //a1;
+    static assert( isUnionAliased!(S, 2)); //a2;
+    static assert( isUnionAliased!(S, 3)); //a3;
+    static assert(!isUnionAliased!(S, 4)); //a4;
+        static assert(!isUnionAliased!(S.A4, 0)); //a4.b0;
+    static assert(!isUnionAliased!(S, 5)); //a5;
+        static assert( isUnionAliased!(S.A5, 0)); //a5.b0;
+        static assert( isUnionAliased!(S.A5, 1)); //a5.b1;
 }
 
 /*********************


### PR DESCRIPTION
Add `Params:` and `Returns:`.

Reorder function overloads to appear consecutively so that ddoc will merge them correctly in the output. The original order causes ddoc to produce funky output.

Replaced the doc reference to `pointsTo` with `doesPointTo` based on the current definition of `pointsTo`, which has been marked deprecated.  I think this is correct...?