### PR TITLE
Fix Issue 14786 -  std.math.pow sometimes gets the sign of the result wrong.

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -6279,12 +6279,16 @@ Unqual!(Largest!(F, G)) pow(F, G)(F x, G y) @nogc @trusted pure nothrow
         {
             // Result is real only if y is an integer
             // Check for a non-zero fractional part
-            if (y > -1.0 / real.epsilon && y < 1.0 / real.epsilon)
+            enum real maxPrecise = ulong.max;
+            enum real minPrecise = -maxPrecise;
+            if (y >= minPrecise && y <= maxPrecise)
             {
-                long w = cast(long)y;
-                if (w != y)
+                real absY = fabs(y);
+                ulong w = cast(ulong)absY;
+                if (w != absY)
                     return sqrt(x); // Complex result -- create a NaN
-                if (w & 1) sign = -1.0;
+                if (w & 1)
+                    sign = -1.0;
             }
             x = -x;
         }
@@ -6359,6 +6363,10 @@ Unqual!(Largest!(F, G)) pow(F, G)(F x, G y) @nogc @trusted pure nothrow
     assert(isIdentical(pow(-0.0, 5.0), -0.0));
     assert(isIdentical(pow(0.0, 6.0), 0.0));
     assert(isIdentical(pow(-0.0, 6.0), 0.0));
+
+    // Issue #14786 fixed
+    assert(pow(-1.0L, cast(real) ((1UL << 63) + 1UL)) == -1.0L);
+    assert(pow(-1.0L, cast(real) (~0UL)) == -1.0L);
 
     // Now, actual numbers.
     assert(approxEqual(pow(two, three), 8.0));

--- a/std/math.d
+++ b/std/math.d
@@ -6277,6 +6277,7 @@ Unqual!(Largest!(F, G)) pow(F, G)(F x, G y) @nogc @trusted pure nothrow
         double sign = 1.0;
         if (x < 0)
         {
+            static assert(real.mant_dig <= (8 * ulong.sizeof));
             // Result is real only if y is an integer
             // Check for a non-zero fractional part
             enum real maxPrecise = ulong.max;

--- a/std/math.d
+++ b/std/math.d
@@ -6279,18 +6279,30 @@ Unqual!(Largest!(F, G)) pow(F, G)(F x, G y) @nogc @trusted pure nothrow
         {
             // Result is real only if y is an integer
             // Check for a non-zero fractional part
-            enum ulong_dig = 8 * ulong.sizeof;
-            static assert(real.mant_dig <= ulong_dig);
-            enum real maxOdd = ulong.max >> (ulong_dig - real.mant_dig);
-
-            const real absY = fabs(y);
-            if (absY <= maxOdd)
+            enum maxOdd = pow(2.0L, real.mant_dig) - 1.0L;
+            static if(maxOdd > ulong.max)
             {
-                const ulong w = cast(ulong)absY;
-                if (w != absY)
+                // Generic method, for any FP type
+                if(floor(y) != y)
                     return sqrt(x); // Complex result -- create a NaN
-                if (w & 1)
+
+                const hy = ldexp(y, -1);
+                if(floor(hy) != hy)
                     sign = -1.0;
+            }
+            else
+            {
+                // Much faster, if ulong has enough precision
+                const absY = fabs(y);
+                if(absY <= maxOdd)
+                {
+                    const uy = cast(ulong)absY;
+                    if(uy != absY)
+                        return sqrt(x); // Complex result -- create a NaN
+
+                    if(uy & 1)
+                        sign = -1.0;
+                }
             }
             x = -x;
         }


### PR DESCRIPTION
This is a simple fix for Phobos [Issue #14786](https://issues.dlang.org/show_bug.cgi?id=14786).

Negative one raised to any odd power should yield negative one.

However, when using 80-bit real arithmetic, -1 raised to a power greater than 2^^63 and less than 2^^64 yields +1.

This is despite the fact that integers in this range can still (just barely) be represented without loss of precision by an 80-bit real; even and odd can still be distinguished.

```D
/** Test cases that fails without this PR **/
void main(string[] args)
{
    real b = -1;
    real e = long.max;
    e += 2;
    assert(e % 2 == 1);
    real r = b ^^ e;
    assert(r == 1);  // Passes, but shouldn't
    assert(r == -1); // Fails, but shouldn't

    e = ulong.max;
    assert(e % 2 == 1);
    r = b ^^ e;
    assert(r == 1);  // Passes, but shouldn't
    assert(r == -1); // Fails, but shouldn't
}
```

Thanks to @ibuclaw for pointing me to the relevant code.