### PR TITLE
Port std.zip tests from the dmd test suite to std.zip.

### DIFF
--- a/std/zip.d
+++ b/std/zip.d
@@ -890,3 +890,63 @@ unittest
         }
     }
 }
+
+unittest
+{
+    import std.zlib;
+
+    ubyte[] src = cast(ubyte[])
+"the quick brown fox jumps over the lazy dog\r
+the quick brown fox jumps over the lazy dog\r
+";
+    auto dst = cast(ubyte[])compress(cast(void[])src);
+    auto after = cast(ubyte[])uncompress(cast(void[])dst);
+    assert(src == after);
+}
+
+unittest
+{
+    import std.datetime;
+    ubyte[] buf = [1, 2, 3, 4, 5, 0, 7, 8, 9];
+
+    auto ar = new ZipArchive;
+    auto am = new ArchiveMember;  // 10
+    am.name = "buf";
+    am.expandedData = buf;
+    am.compressionMethod = CompressionMethod.deflate;
+    am.time = SysTimeToDosFileTime(Clock.currTime());
+    ar.addMember(am);            // 15
+
+    auto zip1 = ar.build();
+    auto arAfter = new ZipArchive(zip1);
+    assert(arAfter.directory.length == 1);
+    auto amAfter = arAfter.directory["buf"];
+    arAfter.expand(amAfter);
+    assert(amAfter.name == am.name);
+    assert(amAfter.expandedData == am.expandedData);
+    assert(amAfter.time == am.time);
+}
+
+// Posix-only, because we can't rely on the unzip command being available on Windows
+version(Posix) unittest
+{
+    import std.datetime, std.file, std.format, std.path, std.process, std.stdio;
+
+    auto zr = new ZipArchive();
+    auto am = new ArchiveMember();
+    am.compressionMethod = CompressionMethod.deflate;
+    am.name = "foo.bar";
+    am.time = SysTimeToDosFileTime(Clock.currTime());
+    am.expandedData = cast(ubyte[])"We all live in a yellow submarine, a yellow submarine";
+    zr.addMember(am);
+    auto data2 = zr.build();
+
+    mkdirRecurse(deleteme);
+    scope(exit) rmdirRecurse(deleteme);
+    string zipFile = buildPath(deleteme, "foo.zip");
+    std.file.write(zipFile, cast(byte[])data2);
+
+    auto result = executeShell(format("unzip -l %s", zipFile));
+    scope(failure) writeln(result.output);
+    assert(result.status == 0);
+}


### PR DESCRIPTION
For whatever reason, the dmd test suite has tests for std.zip, though
for the most part, they seem to just run it without actually checking
the results, making them of questionable value. But this commit ports
them to std.zip (to remove a Phobos dependency in the dmd test suite)
and attempts to make it so that they actually check the results. So, the
tests are not identical by any means, but they're similar. Perhaps the
most significant test is the one that tests a file that's written with
std.zip against the unzip utility, since that's testing against
something that we didn't write.

The corresponding PR for dmd to remove the tests from the dmd test suite is here: https://github.com/D-Programming-Language/dmd/pull/4987