### PR TITLE
Removed typo in std.concurrency, line 1196

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -1193,7 +1193,7 @@ interface Scheduler
     @property ref ThreadInfo thisInfo() nothrow;
 
     /**
-     * Creates a Condition varialbe analog for signaling.
+     * Creates a Condition variable analog for signaling.
      *
      * Creates a new Condition variable analog which is used to check for and
      * to signal the addition of messages to a thread's message queue.  Like


### PR DESCRIPTION
NB: Is the use of "analog" correct here? It sounds a bit odd to me.