### PR TITLE
proposal for the EnumSet template

### DIFF
--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -7,14 +7,15 @@ Macros:
 
 WIKI = StdBitarray
 
-Copyright: Copyright Digital Mars 2007 - 2011.
+Copyright: Copyright Digital Mars 2007 - 2015.
 License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   $(WEB digitalmars.com, Walter Bright),
            $(WEB erdani.org, Andrei Alexandrescu),
            Jonathan M Davis,
            Alex Rønne Petersen,
-           Damian Ziemba
-           Amaury SECHET
+           Damian Ziemba,
+           Amaury SECHET,
+		   Basile Burg
 Source: $(PHOBOSSRC std/_bitmanip.d)
 */
 /*

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -4594,12 +4594,12 @@ public:
     {
         return (rhs._container == _container);
     }
-    
+
     /// see range()
     nothrow @safe Range opSlice()
     {
         return Range(_container);
-    }    
+    }
 
     /**
      * Support for the in operator.

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -3987,3 +3987,1073 @@ unittest
     foreach (i; 0..63)
         assert(bitsSet(1UL << i).equal([i]));
 }
+
+
+private enum hasInt128 = is(ucent);
+
+/// Container for a EnumSet based on an enum which has up to 8 members.
+alias Set8 = ubyte;
+/// Container for a EnumSet based on an enum which has up to 16 members.
+alias Set16 = ushort;
+/// Container for a EnumSet based on an enum which has up to 32 members.
+alias Set32 = uint;
+/// Container for a EnumSet based on an enum which has up to 64 members.
+alias Set64 = ulong;
+/// Container for a EnumSet based on an enum which has up to 128 members (not working, relies on ucent).
+static if (hasInt128) alias Set128 = ucent;
+
+
+static if (hasInt128)
+    private alias BigestSet = Set128;
+else
+    private alias BigestSet = Set64;
+
+
+/**
+ * Returns true if the parameter is suitable for being used as a EnumSet container.
+ * Params:
+ * S = a enumset container type.
+ */
+static bool isSetSuitable(S)()
+{
+    static if (isSigned!S) return false;
+    else static if (is(S==Set8)) return true;
+    else static if (is(S==Set16)) return true;
+    else static if (is(S==Set32)) return true;
+    else static if (is(S==Set64)) return true;
+    else static if (hasInt128 && is(S==Set128)) return true;
+    else return false;
+}
+
+/**
+ * Returns the member count of an enum.
+ * Params:
+ * E = an enum.
+ */
+static ulong enumMemberCount(E)() if (is(E==enum))
+{
+    ulong result;
+    foreach(member; EnumMembers!E) result++;
+    return result;
+}
+
+/**
+ * Provides the information about the rank of the members of an enum.
+ * The properties are all static and can be retrieved from a template alias.
+ * Params:
+ * E = an enum.
+ */
+static struct EnumRankInfo(E) if (is(E==enum))
+{
+
+private:
+
+    static immutable size_t[E] _rankLUT;
+    static immutable E[size_t] _membLUT;
+    static immutable size_t _count;
+
+public:
+
+    nothrow @safe static this()
+    {
+        if (__ctfe){}
+        else foreach(member; EnumMembers!E)
+        {
+            _rankLUT[member] = _count;
+            _membLUT[_count] = member;
+            _count++;
+        }
+    }
+
+    /// Returns the rank of the last member.
+    nothrow @safe @nogc static @property size_t max()
+    {
+        return _count-1;
+    }
+
+    /// Returns the member count. It's always equal to max + 1.
+    nothrow @safe @nogc static @property size_t count()
+    {
+        return _count;
+    }
+
+    /// Always returns 0.
+    nothrow @safe @nogc static @property size_t min()
+    {
+        return 0;
+    }
+
+    /// Returns the rank of aMember.
+    nothrow @safe static size_t opIndex(E aMember)
+    {
+        if (__ctfe)
+        {
+            size_t result;
+            foreach(member; EnumMembers!E)
+            {
+                if (member == aMember)
+                    return result;
+                ++result;
+            }
+            assert(0);
+        }
+        else return _rankLUT[aMember];
+    }
+
+    /// Returns the member at aRank.
+    nothrow @safe static E opIndex(size_t aRank)
+    {
+        if (__ctfe)
+        {
+            size_t rank;
+            foreach(member; EnumMembers!E)
+            {
+                if (rank == aRank)
+                    return member;
+                ++rank;
+            }
+            assert(0);
+        }
+        else return _membLUT[aRank];
+    }
+}
+
+/**
+ * Indicates if the members of an enum fit in a container.
+ * Params:
+ * E = an enum.
+ * S = a container, either a Set8, a Set16, a Set32 or Set64.
+ */
+static bool enumFitsInSet(E, S)() if (is(E==enum) && isSetSuitable!S)
+{
+    S top = S.max;
+    ulong max;
+    foreach(i, member; EnumMembers!E)
+    {
+        max +=  cast(S) 1 << i;
+    }
+    return (max <= top) & (max > 0);
+}
+
+/**
+ * An EnumSet allows to create a bit field using the members of an enum.
+ *
+ * It's designed similarly to the Pascal built-in sets (the "Set Of" construct).
+ * It's also related to the phobos type EnumFlag, except that it has no constraint
+ * related to the enum member values since it's based on the enum members rank.
+ *
+ * It's efficient as function parameter since the size of an EnumSet is
+ * equal to the size of its container (so from 1 to 8 bytes). Since manipulating
+ * an EnumSet set is mostly about making bitwise operations an EnumSet is completly
+ * safe. Another notable characteristic is that an EnumSet is ordered, so if a
+ * range is implemented to allow the usage of std.algorithm.searching functions
+ * it's always more simple and efficient to use the "in" operator.
+ *
+ * There are two ways to use an EnumSet:
+ * * using the C-like operators, "+" and "-" to add or remove members, "^" and "&" to get the difference and the intersection.
+ * * using the Pascal-like intrinsics (here some functions): include(), exclude() and the 'in' operator.
+ *
+ * Params:
+ * S = a Set8, Set16, Set32 or Set64. It must be wide enough to contain all the enum members,
+ * otherwise the template is not instantiated.
+ * E = an enum, which must have at least one members.
+ *
+ * Example:
+ * ---
+ * enum Employee {jhon, steve, sophia, douglas, clarice, mitch}
+ * alias Team = EnumSet!(Employee, Set8);
+ * auto team1 = Team(Employee.jhon, Employee.sophia, Employee.douglas);
+ * auto team2 = Team(Employee.jhon, Employee.clarice, Employee.mitch);
+ * if (Employee.sophia in team1) writeln("Sophia works in team1");
+ * Team overzealous = team1.intersection(team2);
+ * if (overzealous != 0)
+ * {
+ *     writeln(overzealous, " work(s) too much !");
+ *     team1 -= overzealous;
+ *     assert(team1 == [Employee.sophia, Employee.douglas]);
+ * }
+ * if (team1.memberCount != team2.memberCount)
+ *     writeln("teams are not well balanced !");
+ * ---
+ */
+struct EnumSet(E, S) if (enumFitsInSet!(E, S))
+{
+        
+    alias SetType = S;
+    alias EnumSetType = typeof(this);
+    
+    //static if (S.sizeof > size_t.sizeof) pragma(msg, 
+    //    "warning, '" ~ SetType.stringof ~ "' does not support built-in AA");    
+
+private:
+
+    SetType _container;
+    static immutable SetType _max;
+    static immutable EnumRankInfo!E _infs;
+    static immutable SetType _1 = cast(SetType) 1;
+    
+    struct Range
+    {
+        private SetType frontIndex;
+        private SetType backIndex;
+        private EnumSet!(E,S) set;
+        private alias infs = EnumRankInfo!E;
+
+        private void toNextMember()
+        {
+            while (!set[infs[cast(size_t)frontIndex]])
+            {
+                ++frontIndex;
+                if (frontIndex == infs.count)
+                    break;
+            }
+        }
+
+        private void toPrevMember()
+        {
+            while (!set[infs[cast(size_t)backIndex]])
+            {
+                --backIndex;
+                if (backIndex == 0)
+                    break;
+            }
+        }
+
+        nothrow @safe this(T)(T t)
+        {
+            set = SetType(t);
+            backIndex = cast(set.SetType) infs.max;
+            toNextMember;
+            toPrevMember;
+        }
+
+        nothrow @safe @property bool empty()
+        {
+            return set.none;
+        }
+
+        nothrow @safe @property E front()
+        in
+        {
+            assert(frontIndex >= 0 && frontIndex <= infs.max);
+        }
+        body
+        {
+            return infs[cast(size_t) frontIndex];
+        }
+
+        nothrow @safe void popFront()
+        in
+        {
+            assert(frontIndex >= 0 && frontIndex <= infs.max);
+        }
+        body
+        {
+            set.exclude(infs[cast(size_t) frontIndex]);
+            toNextMember;
+        }
+
+        nothrow @safe @property E back()
+        in
+        {
+            assert(backIndex >= 0 && backIndex <= infs.max);
+        }
+        body
+        {
+            return infs[cast(size_t) backIndex];
+        }
+
+        nothrow @safe void popBack()
+        in
+        {
+            assert(backIndex >= 0 && backIndex <= infs.max);
+        }
+        body
+        {
+            set.exclude(infs[cast(size_t) backIndex]);
+            toPrevMember;
+        }
+
+        nothrow @safe auto save()
+        {
+            return Range(set._container);
+        }
+    }    
+
+public:
+
+    
+
+// constructors ---------------------------------------------------------------+
+
+    ///
+    nothrow @safe @nogc static this()
+    {
+        foreach(i, member; EnumMembers!E)
+            _max +=  _1 << i;
+    }
+
+    /**
+     * Initializes the set with some stuff.
+     * Params:
+     * stuff = either some E member(s), an E input range, an E array
+     * or a string representation.
+     */
+    nothrow @safe this(Stuff...)(Stuff stuff)
+    {
+        _container = 0;
+        static if (stuff.length == 1)
+        {
+            alias T = typeof(stuff[0]);
+            static if (is(T == SetType)) _container = stuff[0];
+            else static if (is(T == E)) include(stuff[0]);
+            else static if (is(T == E[])) foreach(s; stuff) include(s);
+            else static if (is(T == string)) fromString(stuff[0]);
+            else static if (isInputRange!T && is(ElementType!T == E))
+                foreach(E e;stuff[0]) include(e);
+            else static assert(0, "unsupported _ctor argument");
+        }
+        else include(stuff);
+    }
+// -----------------------------------------------------------------------------
+// string representation ------------------------------------------------------+
+
+    /**
+     * Returns the string representation of the set as a binary representation.
+     * Note that the result is preffixed with "0b", as a binary litteral.
+     */
+    nothrow @safe string asBitString()
+    {
+        static immutable char[2] bitsCh = ['0', '1'];
+        string result = "";
+        foreach_reverse(member; EnumMembers!E)
+            result ~= bitsCh[isIncluded(member)];
+
+        return "0b" ~ result;
+    }
+
+    /**
+     * Returns the string representation of the set.
+     * The format is the same as the one used in this() and fromString(),
+     * similar to an array litteral.
+     */
+    @safe string toString()
+    {
+        import std.conv: to;
+        scope(failure){}
+        string result = "[";
+        bool first;
+        foreach(i, member; EnumMembers!E)
+        {
+            if ((!first) & (isIncluded(member)))
+            {
+                result ~= to!string(member);
+                first = true;
+            }
+            else if (isIncluded(member))
+                result ~= ", " ~ to!string(member);
+        }
+        return result ~ "]";
+    }
+
+    /**
+     * Defines the set with a string representation.
+     * Params:
+     * str = a string representing one or several E members. It must have the 
+     * form that's similar to an array litteral. Binary litterals are not handled 
+     * by this function.
+     */
+    @trusted void fromString(string str)
+    {
+        import std.conv: to;
+        if (str.length < 2) return;
+
+        _container = 0;
+        if (str == "[]") return;
+
+        auto representation = str.dup;
+
+        char[] identifier;
+        char* reader = representation.ptr;
+        while(true)
+        {
+            if ((*reader != ',') & (*reader != '[') & (*reader != ']')
+                & (*reader != ' ')) identifier ~= *reader;
+
+            if ((*reader == ',') | (*reader == ']') )
+            {
+                scope(failure){break;}
+                auto member = to!E(identifier);
+                include(member);
+                identifier = identifier.init;
+            }
+
+            if (reader == representation.ptr + representation.length)
+                break;
+
+            ++reader;
+        }
+    }
+// -----------------------------------------------------------------------------
+// operators ------------------------------------------------------------------+
+
+    /**
+     * Support for the assignment operator.
+     * Params:
+     * rhs = a setXX, an array of E members, an InputRange of E
+     * or an EnumSet with the same type.
+     */
+    nothrow @safe @nogc void opAssign(S rhs)
+    {
+        _container = (rhs <= _max) ? rhs : _max;
+    }
+
+    /// ditto
+    nothrow @safe void opAssign(E[] rhs)
+    {
+        _container = 0;
+        foreach(elem; rhs) include(elem);
+    }
+
+    /// ditto
+    nothrow @safe @nogc void opAssign(EnumSetType rhs)
+    {
+        _container = rhs._container;
+    }
+
+    /// ditto
+    nothrow @safe void opAssign(R)(R rhs)
+    if (!(isArray!R) && isInputRange!R && is(ElementType!R == E))
+    {
+        _container = 0;
+        foreach(E e; rhs) include(e);
+    }
+
+    /**
+     * Support for the array syntax.
+     * Params:
+     * index = either an unsigned integer or an E member.
+     */
+    nothrow @safe @nogc bool opIndex(I)(I index)
+    {
+        static if (isSigned!I || is(I == SetType))
+            return (_container == (_container | _1 << index));
+        else static if (is(I == E))
+            return isIncluded(index);
+        else static assert(0, "opIndex not implemented when indexer is " ~ I.stringof);
+    }
+
+    /**
+     * Support for "+" and "-" operators.
+     * Params:
+     * rhs = either an E member, an E array or another EnumSet (or its container) 
+     * with the same type.
+     */
+    nothrow @safe EnumSetType opBinary(string op)(E rhs)
+    {
+        static if (op == "+")
+        {
+            EnumSetType s = EnumSetType(_container);
+            s.include(rhs);
+            return s;
+        }
+        else static if (op == "-")
+        {
+            EnumSetType s = EnumSetType(_container);
+            s.exclude(rhs);
+            return s;
+        }
+        else static assert(0, "opBinary not implemented for " ~ op);
+    }
+
+    /// ditto
+    nothrow @safe EnumSetType opBinary(string op)(E[] rhs)
+    {
+        static if (op == "+")
+        {
+            EnumSetType s = EnumSetType(_container);
+            s.include(rhs);
+            return s;
+        }
+        else static if (op == "-")
+        {
+            EnumSetType s = EnumSetType(_container);
+            s.exclude(rhs);
+            return s;
+        }
+        else static assert(0, "opBinary not implemented for " ~ op);
+    }
+
+    /// ditto
+    nothrow @safe @nogc EnumSetType opBinary(string op)(EnumSetType rhs)
+    {
+        static if (op == "+")
+        {
+            SetType s = _container | rhs._container;
+            return EnumSetType(s);
+        }
+        else static if (op == "-")
+        {
+            SetType s = _container;
+            s &= s ^ rhs._container;
+            return EnumSetType(s);
+        }
+        else static if (op == "^")
+        {
+            return difference(rhs);
+        }
+        else static if (op == "&")
+        {
+            return intersection(rhs);
+        }
+        else static assert(0, "opBinary not implemented for " ~ op);
+    }
+    
+    /// ditto
+    nothrow @safe @nogc EnumSetType opBinary(string op)(SetType rhs)
+    {
+        static if (op == "+")
+        {
+            SetType s = _container | rhs;
+            return EnumSetType(s);
+        }
+        else static if (op == "-")
+        {
+            SetType s = _container;
+            s &= s ^ rhs;
+            return EnumSetType(s);
+        }
+        else static if (op == "^")
+        {
+            return difference(EnumSetType(rhs));
+        }
+        else static if (op == "&")
+        {
+            return intersection(EnumSetType(rhs));
+        }
+        else static assert(0, "opBinary not implemented for " ~ op);
+    }    
+
+    /**
+     * Support for "+=" and "-=" operators.
+     * Params:
+     * rhs = either some E member(s), an E array or an EnumSet with the same type.
+     */
+    nothrow @safe void opOpAssign(string op)(E[] rhs)
+    {
+        static if (op == "+") include(rhs);
+        else static if (op == "-") exclude(rhs);
+        else static assert(0, "opOpAssign not implemented for " ~ op);
+    }
+
+    /// ditto
+    nothrow @safe void opOpAssign(string op, E...)(E rhs)
+    {
+        static if (op == "+") include(rhs);
+        else static if (op == "-") exclude(rhs);
+        else static assert(0, "opOpAssign not implemented for " ~ op);
+    }
+
+    /// ditto
+    nothrow @safe @nogc void opOpAssign(string op)(EnumSetType rhs)
+    {
+        static if (op == "+") _container |= rhs._container;
+        else static if (op == "-") _container &= _container ^ rhs._container;
+        else static assert(0, "opOpAssign not implemented for " ~ op);
+    }
+
+    /// Support for built-in AA.
+    size_t toHash() const nothrow @safe
+    {
+        static if (S.max <= size_t.max)
+            return cast(size_t) _container;
+        else
+            assert(0, "toHash() not supported if the container size is greater than size_t");
+    }
+
+    /// Support for comparison "=" and "!=" operators.
+    nothrow @safe bool opEquals(T)(T rhs)
+    {
+        static if (is(T == SetType))
+            return (_container == rhs);
+        else static if (isIntegral!T && T.max >= SetType.max)
+            return (_container == rhs);
+        else static if (is(T == EnumSetType))
+            return (_container == rhs._container);
+        else static if (is(T == E[])){
+            auto rhsset = EnumSetType(rhs);
+            return (rhsset._container == _container);
+        }
+        else
+            static assert(0, "opEquals not implemented when rhs is " ~ T.stringof);
+    }
+
+    /// Support for built-in AA.
+    nothrow @safe bool opEquals(ref const EnumSetType rhs) const
+    {
+        return (rhs._container == _container);
+    }
+
+    /** 
+     * Support for the in operator.
+     *
+     * Indicates if the right hand side is included in the set.
+     * Params:
+     * rhs = either an E member or a set (or its container) with the same type,
+     * in the last case, calling opIn_r is equivalent to test for greater or equal.
+     */
+    nothrow @safe bool opIn_r(T)(T rhs)
+    {
+        static if (is(T == E))
+            return isIncluded(rhs);
+        else static if (is(T == EnumSetType))
+            return (_container & rhs._container) >= rhs._container;
+        else static if (is(T == SetType))
+            return (_container & rhs) >= rhs;
+        else
+            static assert(0, "opIn_r not implemented when rhs is " ~ T.stringof);
+    }
+// -----------------------------------------------------------------------------
+// set operations -------------------------------------------------------------+
+
+    /**
+     * Returns a set representing the difference between this set and the argument.
+     * Params:
+     * rhs = either a set with the same type or a set container with the same size.
+     */
+    nothrow @safe EnumSetType difference(R)(R rhs)
+    if (is(R == EnumSetType) || is(R == SetType))
+    {
+        SetType s;
+        static if (is(R == EnumSetType))
+            s = _container ^ rhs._container;
+        else
+            s = _container ^ rhs;
+        return EnumSetType(s);
+    }
+    
+    /**
+     * Returns a set representing the intersection between this set and the argument.
+     * Params:
+     * rhs = either a set with the same type or a set container with the same size.
+     */
+    nothrow @safe EnumSetType intersection(R)(R rhs)
+    if (is(R == EnumSetType) || is(R == SetType))
+    {
+        SetType s;
+        static if (is(R == EnumSetType))
+            s = _container & rhs._container;
+        else
+            s = _container & rhs;
+        return EnumSetType(s);
+    }
+// -----------------------------------------------------------------------------
+// Pascal-ish primitives ------------------------------------------------------+
+
+    /**
+     * Includes someMembers in the set.
+     * This is the primitive used for to the operator "+".     
+     * Params:
+     * someMembers = a list of E members or an array of E members
+     */
+    nothrow @safe void include(E...)(E someMembers)
+    {
+        static if (someMembers.length == 1)
+            _container += _1 << _infs[someMembers];
+        else foreach(member; someMembers)
+            _container += _1 << _infs[member];
+    }
+
+    /// ditto
+    nothrow @safe void include(E[] someMembers)
+    {
+        foreach(member; someMembers)
+            _container += _1 << _infs[member];
+    }
+
+    /**
+     * Excludes someMembers from the set.
+     * This is the primitive used for to the operator "-".
+     * Params:
+     * someMembers = a list of E members or an array of E members.
+     */
+    nothrow @safe void exclude(E...)(E someMembers)
+    {
+        static if (someMembers.length == 1)
+            _container &= _container ^ (_1 << _infs[someMembers]);
+        else foreach(member; someMembers)
+            _container &= _container ^ (_1 << _infs[member]);
+    }
+
+    /// ditto
+    nothrow @safe void exclude(E[] someMembers)
+    {
+        foreach(member; someMembers)
+            _container &= _container ^ (_1 << _infs[member]);
+    }
+
+    /**
+     * Returns true if aMember is in the set.
+     * This is the primitive used for to the operator "in".     
+     * Params:
+     * aMember = an  E member.
+     */
+    nothrow @safe bool isIncluded(E aMember)
+    {
+        return (_container == (_container | _1 << _infs[aMember]));
+    }
+//------------------------------------------------------------------------------
+// misc helpers ---------------------------------------------------------------+
+
+    /// Returns a range allowing to iterate for each member included in the set.
+    @safe Range range()
+    {
+        return Range(_container);
+    }
+
+    /// Returns true if the set is empty.
+    nothrow @safe @nogc bool none()
+    {
+        return _container == 0;
+    }
+
+    /// Returns true if at least one member is included.
+    nothrow @safe @nogc bool any()
+    {
+        return _container != 0;
+    }
+
+    /// Returns true if all the members are included.
+    nothrow @safe @nogc bool all()
+    {
+        return _container == _max;
+    }
+
+    /// Returns the count of member included
+    nothrow @safe size_t memberCount()
+    {
+        size_t result;
+        foreach(e; EnumMembers!E)
+            result += e in this;
+        return result;
+    }
+
+    /// Returns the maximal value the set can have.
+    nothrow @safe @nogc static const(S) max()
+    {
+        return _max;
+    }
+
+    /// Returns a lookup table that can be used to retrieve the rank of a member.
+    nothrow @safe @nogc static ref const(EnumRankInfo!E) rankInfo()
+    {
+        return _infs;
+    }
+
+    /// Returns the enum count
+    nothrow @safe @nogc static const(S) maxMemberCount()
+    {
+        return cast(S) rankInfo.count;
+    }
+
+//------------------------------------------------------------------------------
+}
+
+/**
+ * Aliases the smallest set in which E fits.
+ */
+template SmallestSet(E)
+if (enumFitsInSet!(E, BigestSet))
+{
+    static if (enumFitsInSet!(E, Set8))
+        alias SmallestSet = Set8;
+    else static if (enumFitsInSet!(E, Set16))
+        alias SmallestSet = Set16;
+    else static if (enumFitsInSet!(E, Set32))
+        alias SmallestSet = Set32;
+    else static if (enumFitsInSet!(E, Set64))
+        alias SmallestSet = Set64;
+    else static if (hasInt128 && enumFitsInSet!(E, Set128))
+        alias SmallestSet = Set128;
+}
+
+/**
+ * Returns an EnumSet using the smallest container possible.
+ * Params:
+ * E = an enum
+ * a = the parameters passed to the EnumSet constructor.
+ */
+static auto enumSet(E, A...)(A a) @property @safe
+if (enumFitsInSet!(E, BigestSet))
+{
+    return EnumSet!(E, SmallestSet!E)(a);
+}
+
+version(unittest)
+{
+    import std.stdio: writeln;
+
+    enum a0;
+    enum a4     {a0,a1,a2,a3}
+    enum a8     {a0,a1,a2,a3,a4,a5,a6,a7}
+    enum a9     {a0,a1,a2,a3,a4,a5,a6,a7,a8}
+    enum a16    {a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15}
+    enum a17    {a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16}
+
+    /// Constraints
+    static unittest
+    {
+        static assert( isSetSuitable!ubyte );
+        static assert( isSetSuitable!ushort );
+        static assert( isSetSuitable!uint );
+        static assert( isSetSuitable!ulong );
+        static assert( !isSetSuitable!byte );
+    }
+
+    static unittest
+    {
+        static assert( enumFitsInSet!(a8, Set8));
+        static assert( !enumFitsInSet!(a9, Set8));
+        static assert( enumFitsInSet!(a16, Set16));
+        static assert( !enumFitsInSet!(a17, Set16));
+        static assert( !enumFitsInSet!(a0, Set64));
+    }
+
+    /// CTFE
+    unittest
+    {
+        static assert(EnumSet!(a8, Set8)(a8.a0,a8.a1) == 0b00000011);
+        enum set = EnumSet!(a8, Set8)(a8.a0,a8.a1);
+        set.include(a8.a2);
+        //static assert(set == 0b00000111, set);
+    }
+
+    /// EnumSet
+    unittest
+    {
+        alias bs8 = EnumSet!(a8, Set8);
+        bs8 set = bs8(a8.a0,a8.a1,a8.a2,a8.a3,a8.a4,a8.a5,a8.a6,a8.a7);
+        assert(set == 0b1111_1111);
+        assert(set.all);
+        set = set - a8.a0;
+        assert(set == 0b1111_1110);
+        set = set - a8.a1;
+        assert(set == 0b1111_1100);
+        set = set - a8.a7;
+        assert(set == 0b0111_1100);
+        set = 0;
+        assert(set.none);
+        assert(set == 0b0000_0000);
+        set = set + a8.a4;
+        assert(set == 0b0001_0000);
+        set = set + a8.a5;
+        assert(set != 0b0001_0000);
+        set = 0;
+        assert(set == 0b0000_0000);
+        set = set + [a8.a0, a8.a1, a8.a3];
+        assert(set == 0b0000_1011);
+        set = set - [a8.a1, a8.a3];
+        assert(set == 0b0000_001);
+        set = set.max;
+        set = set - [a8.a5,a8.a6,a8.a7];
+        assert(set == [a8.a0,a8.a1,a8.a2,a8.a3,a8.a4]);
+        set = [a8.a0,a8.a2,a8.a4];
+        assert(set == 0b0001_0101);
+        set = [a8.a0,a8.a1];
+        assert(set == 0b0000_0011);
+        set += [a8.a2,a8.a3];
+        assert(set == 0b0000_1111);
+        set -= [a8.a0,a8.a1];
+        assert(set == 0b0000_1100);
+        set = 0;
+        set.exclude([a8.a0,a8.a1,a8.a2,a8.a3,a8.a4]);
+        assert( set == 0);
+        set -= a8.a0;
+        assert( set == 0);
+
+        bs8 set1 = bs8(a8.a0,a8.a1);
+        bs8 set2 = bs8(a8.a1,a8.a2);
+        set1 += set2;
+        assert( set1 == 0b0000_0111);
+        set1 = bs8(a8.a0,a8.a1,a8.a2);
+        set2 = bs8(a8.a1,a8.a2,a8.a3);
+        set1 -= set2;
+        assert( set1 == 0b0000_0001);
+
+        set1 = bs8(a8.a0);
+        set2 = bs8(a8.a1);
+        auto set3 = set1 + set2;
+        assert(set3 == 0b0000_0011);
+        assert(set1 == 0b0000_0001);
+        assert(set2 == 0b0000_0010);
+    }
+
+    unittest
+    {
+        EnumSet!(a17, Set32) set;
+        set.include(a17.a8,a17.a9);
+        assert(!set.isIncluded(a17.a7));
+        assert(set.isIncluded(a17.a8));
+        assert(set.isIncluded(a17.a9));
+        assert(!set.isIncluded(a17.a10));
+        assert(!(a17.a7 in set));
+        assert(a17.a8 in set);
+        assert(a17.a9 in set);
+        assert(!(a17.a10 in set));
+        set = 0;
+        set += [a17.a5, a17.a6, a17.a7];
+        EnumSet!(a17, Set32) set2;
+        set2 += [a17.a5,a17.a6];
+        assert(set2 in set);
+        set -= [a17.a5];
+        assert(!(set2 in set));
+        set2 -= [a17.a5];
+        assert(set2 in set);
+    }
+
+    unittest
+    {
+        auto bs = EnumSet!(a17, Set32)(a17.a0, a17.a1, a17.a16);
+        assert(bs[0]);
+        assert(bs[1]);
+        assert(bs[16]);
+        assert(bs[a17.a0]);
+        assert(bs[a17.a1]);
+        assert(bs[a17.a16]);
+        assert(!bs[8]);
+        assert(!bs[a17.a8]);
+    }
+
+    unittest
+    {
+        auto set = EnumSet!(a8, Set8)(a8.a3, a8.a5);
+        assert(set == 0b0010_1000);
+        auto rep = set.toString;
+        set = 0;
+        assert(set == 0);
+        set = EnumSet!(a8, Set8)(rep);
+        assert(set == 0b0010_1000);
+        // test asBitString
+        auto brep = set.asBitString;
+        assert( brep == "0b00101000", brep );
+        set = 0b1111_0000;
+        brep = set.asBitString;
+        assert( brep == "0b11110000", brep );
+
+        //set = 0;
+        //set = to!Set8(brep);
+        //assert(set == 0b1111_0000);
+    }
+
+    unittest
+    {
+        auto set = EnumSet!(a17, Set32)(a17.a0);
+        assert( set.rankInfo[a17.a16] == 16);
+        assert( set.rankInfo[a17.a15] == 15);
+    }
+
+    unittest
+    {
+        import std.range;
+
+        static assert(isInputRange!((EnumSet!(a17, Set32)).Range));
+        static assert(isForwardRange!((EnumSet!(a17, Set32)).Range));
+        static assert(isBidirectionalRange!((EnumSet!(a17, Set32)).Range));
+
+        auto set = EnumSet!(a17, Set32)(a17.a0, a17.a8 , a17.a16);
+        auto rng = set.range;
+        assert(rng.front == a17.a0);
+        rng.popFront;
+        assert(rng.front == a17.a8);
+        rng.popFront;
+        assert(rng.front == a17.a16);
+        rng.popFront;
+        assert(rng.empty);
+
+        with (a17) set = [a0, a8, a16, a13];
+        size_t i;
+        foreach(a17 a; set.range) {++i;}
+        assert(i == 4);
+
+        // bidir & forward ranges are not that usefull since an EnumSet is ordered
+        import std.algorithm;
+        with (a17) set = [a8, a16, a13];
+        assert(startsWith(set.range, a17.a8));
+        with (a17) set += [a2, a4];
+        assert(startsWith(set.range, a17.a2));
+
+        auto set1 = set;
+        set1 = 0;
+        assert(set1.none);
+        set1 = set.range;
+        assert(set1 == set);
+    }
+
+    unittest
+    {
+        enum E {e1, e2}
+        alias ESet = EnumSet!(E, Set8);
+        ESet eSet1 = ESet(E.e1);
+        ESet eSet2 = ESet(E.e1, E.e2);
+        assert(eSet1 != eSet2);
+        eSet2 -= E.e2;
+        assert(eSet1 == eSet2);
+    }
+
+    unittest
+    {
+        alias Set = EnumSet!(a8, Set8);
+        Set set1 = Set([a8.a0, a8.a1]);
+        Set set2 = Set([a8.a1, a8.a3]);
+        assert(set1.intersection(set2) == Set(a8.a1));
+        assert(set1.difference(set2) == Set([a8.a0,a8.a3]));
+        set1 = 0b1010_1010;
+        assert(set1.intersection(cast(ubyte)0b0000_1010) == 0b0000_1010);
+        assert(set1.difference(cast(ubyte)0b0000_1010) == 0b1010_0000);
+        
+        set1 = Set([a8.a0, a8.a1]);
+        assert((set1 & cast(Set8)0b1110) == Set(a8.a1));  
+        assert((set1 ^ cast(Set8)0b1010) == Set([a8.a0,a8.a3]));       
+    }
+
+    unittest
+    {
+        enum E {e1, e2}
+        alias ESet = EnumSet!(E, Set8);
+
+        ESet eSet1;
+        ESet eSet2 = [E.e1];
+        ESet eSet3 = [E.e2];
+        ESet eSet4 = [E.e1, E.e2];
+
+        string[ESet] setDescription;
+
+        setDescription[eSet1] = "empty";
+        setDescription[eSet2] = "e1";
+        setDescription[eSet3] = "e2";
+        setDescription[eSet4] = "e1 and e2";
+
+        // AA with EnumSet as key is about the set value, not the instance.
+        assert( setDescription[* new ESet] == "empty");
+        ESet eSet5 = [E.e1, E.e2];
+        assert( setDescription[eSet5] == "e1 and e2");
+        eSet5 -= E.e1;
+        assert( setDescription[eSet5] == "e2");
+        eSet5 -= E.e2;
+        assert( setDescription[eSet5] == "empty");
+        eSet5 -= E.e2; eSet5 -= E.e1;
+        assert( setDescription[eSet5] == "empty");
+    }
+
+    /// enumSet
+    unittest
+    {
+        assert( is(typeof(enumSet!a4) == EnumSet!(a4,Set8)) );
+        assert( is(typeof(enumSet!a8) == EnumSet!(a8,Set8)) );
+        assert( is(typeof(enumSet!a9) == EnumSet!(a9,Set16))) ;
+        assert( is(typeof(enumSet!a16) == EnumSet!(a16,Set16)) );
+        assert( is(typeof(enumSet!a17) == EnumSet!(a17,Set32)) );
+    }
+}
+
+

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -4435,7 +4435,7 @@ public:
      * Params:
      * index = either an unsigned integer or an E member.
      */
-    nothrow @safe @nogc bool opIndex(I)(I index)
+    nothrow @safe bool opIndex(I)(I index)
     {
         static if (isSigned!I || is(I == SetType))
             return (_container == (_container | _1 << index));

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -4178,12 +4178,12 @@ static bool enumFitsInSet(E, S)() if (is(E==enum) && isSetSuitable!S)
  */
 struct EnumSet(E, S) if (enumFitsInSet!(E, S))
 {
-        
+
     alias SetType = S;
     alias EnumSetType = typeof(this);
-    
-    //static if (S.sizeof > size_t.sizeof) pragma(msg, 
-    //    "warning, '" ~ SetType.stringof ~ "' does not support built-in AA");    
+
+    //static if (S.sizeof > size_t.sizeof) pragma(msg,
+    //    "warning, '" ~ SetType.stringof ~ "' does not support built-in AA");
 
 private:
 
@@ -4191,7 +4191,7 @@ private:
     static immutable SetType _max;
     static immutable EnumRankInfo!E _infs;
     static immutable SetType _1 = cast(SetType) 1;
-    
+
     struct Range
     {
         private SetType frontIndex;
@@ -4278,11 +4278,11 @@ private:
         {
             return Range(set._container);
         }
-    }    
+    }
 
 public:
 
-    
+
 
 // constructors ---------------------------------------------------------------+
 
@@ -4359,8 +4359,8 @@ public:
     /**
      * Defines the set with a string representation.
      * Params:
-     * str = a string representing one or several E members. It must have the 
-     * form that's similar to an array litteral. Binary litterals are not handled 
+     * str = a string representing one or several E members. It must have the
+     * form that's similar to an array litteral. Binary litterals are not handled
      * by this function.
      */
     @trusted void fromString(string str)
@@ -4446,7 +4446,7 @@ public:
     /**
      * Support for "+" and "-" operators.
      * Params:
-     * rhs = either an E member, an E array or another EnumSet (or its container) 
+     * rhs = either an E member, an E array or another EnumSet (or its container)
      * with the same type.
      */
     nothrow @safe EnumSetType opBinary(string op)(E rhs)
@@ -4508,7 +4508,7 @@ public:
         }
         else static assert(0, "opBinary not implemented for " ~ op);
     }
-    
+
     /// ditto
     nothrow @safe @nogc EnumSetType opBinary(string op)(SetType rhs)
     {
@@ -4532,7 +4532,7 @@ public:
             return intersection(EnumSetType(rhs));
         }
         else static assert(0, "opBinary not implemented for " ~ op);
-    }    
+    }
 
     /**
      * Support for "+=" and "-=" operators.
@@ -4594,7 +4594,7 @@ public:
         return (rhs._container == _container);
     }
 
-    /** 
+    /**
      * Support for the in operator.
      *
      * Indicates if the right hand side is included in the set.
@@ -4631,7 +4631,7 @@ public:
             s = _container ^ rhs;
         return EnumSetType(s);
     }
-    
+
     /**
      * Returns a set representing the intersection between this set and the argument.
      * Params:
@@ -4652,7 +4652,7 @@ public:
 
     /**
      * Includes someMembers in the set.
-     * This is the primitive used for to the operator "+".     
+     * This is the primitive used for to the operator "+".
      * Params:
      * someMembers = a list of E members or an array of E members
      */
@@ -4694,7 +4694,7 @@ public:
 
     /**
      * Returns true if aMember is in the set.
-     * This is the primitive used for to the operator "in".     
+     * This is the primitive used for to the operator "in".
      * Params:
      * aMember = an  E member.
      */
@@ -5010,10 +5010,10 @@ version(unittest)
         set1 = 0b1010_1010;
         assert(set1.intersection(cast(ubyte)0b0000_1010) == 0b0000_1010);
         assert(set1.difference(cast(ubyte)0b0000_1010) == 0b1010_0000);
-        
+
         set1 = Set([a8.a0, a8.a1]);
-        assert((set1 & cast(Set8)0b1110) == Set(a8.a1));  
-        assert((set1 ^ cast(Set8)0b1010) == Set([a8.a0,a8.a3]));       
+        assert((set1 & cast(Set8)0b1110) == Set(a8.a1));
+        assert((set1 ^ cast(Set8)0b1010) == Set([a8.a0,a8.a3]));
     }
 
     unittest

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -4015,7 +4015,7 @@ else
  * Params:
  * S = a enumset container type.
  */
-static bool isSetSuitable(S)()
+bool isSetSuitable(S)()
 {
     static if (isSigned!S) return false;
     else static if (is(S==Set8)) return true;
@@ -4031,7 +4031,7 @@ static bool isSetSuitable(S)()
  * Params:
  * E = an enum.
  */
-static ulong enumMemberCount(E)() if (is(E==enum))
+ulong enumMemberCount(E)() if (is(E==enum))
 {
     ulong result;
     foreach(member; EnumMembers!E) result++;
@@ -4125,7 +4125,7 @@ public:
  * E = an enum.
  * S = a container, either a Set8, a Set16, a Set32 or Set64.
  */
-static bool enumFitsInSet(E, S)() if (is(E==enum) && isSetSuitable!S)
+bool enumFitsInSet(E, S)() if (is(E==enum) && isSetSuitable!S)
 {
     S top = S.max;
     ulong max;
@@ -4784,7 +4784,7 @@ if (enumFitsInSet!(E, BigestSet))
  * E = an enum
  * a = the parameters passed to the EnumSet constructor.
  */
-static auto enumSet(E, A...)(A a) @property @safe
+auto enumSet(E, A...)(A a) @property @safe
 if (enumFitsInSet!(E, BigestSet))
 {
     return EnumSet!(E, SmallestSet!E)(a);

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -4594,6 +4594,12 @@ public:
     {
         return (rhs._container == _container);
     }
+    
+    /// see range()
+    nothrow @safe Range opSlice()
+    {
+        return Range(_container);
+    }    
 
     /**
      * Support for the in operator.
@@ -4981,7 +4987,7 @@ version(unittest)
         with (a17) set = [a8, a16, a13];
         assert(startsWith(set.range, a17.a8));
         with (a17) set += [a2, a4];
-        assert(startsWith(set.range, a17.a2));
+        assert(startsWith(set[], a17.a2));
 
         auto set1 = set;
         set1 = 0;

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -15,7 +15,7 @@ Authors:   $(WEB digitalmars.com, Walter Bright),
            Alex Rønne Petersen,
            Damian Ziemba,
            Amaury SECHET,
-		   Basile Burg
+           Basile Burg
 Source: $(PHOBOSSRC std/_bitmanip.d)
 */
 /*


### PR DESCRIPTION
**proposal for the EnumSet template**

An EnumSet allows to create a bitfield using the members of an enum, whatever is the members type or the members values. In other languages this is often used to define a set of options, easily identifiable in the code.

This proposal contains a comprehensive template that covers the concept in a D flavor
- type safety: constraints.
- efficiency: the set is packed in a _value type_ that's efficient to use as parameter (e.g as ref)
- inclusion, exclusion, constructor using several parameter kinds, input range to iterate the members that are included and much more.
- well tested.

[Code](https://github.com/BBasile/iz/blob/master/import/iz/enumset.d), it's part of a bigger library. It's kept in sync with this PR.
[Doc](http://bbasile.github.io/iz/iz/enumset.html), rendered with harbored.