### PR TITLE
stream deprecation

### DIFF
--- a/std/cstream.d
+++ b/std/cstream.d
@@ -2,8 +2,7 @@
 
 /**
  * $(RED Warning: This module is considered out-dated and not up to Phobos'
- *       current standards. It will remain until we have a suitable replacement,
- *       but be aware that it will not remain long term.)
+ *       current standards. It will be removed by phobos version 2.070.)
  *
  * The std.cstream module bridges core.stdc.stdio (or std.stdio) and std.stream.
  * Both core.stdc.stdio and std.stream are publicly imported by std.cstream.
@@ -21,7 +20,7 @@
  *    (See accompanying file LICENSE_1_0.txt or copy at
  *          http://www.boost.org/LICENSE_1_0.txt)
  */
-module std.cstream;
+deprecated("Will be removed by phobos version 2.070") module std.cstream;
 
 public import core.stdc.stdio;
 public import std.stream;

--- a/std/socketstream.d
+++ b/std/socketstream.d
@@ -22,8 +22,7 @@
 
 /**************
  * $(RED Warning: This module is considered out-dated and not up to Phobos'
- *       current standards. It will remain until we have a suitable replacement,
- *       but be aware that it will not remain long term.)
+ *       current standards. It will be removed by phobos version 2.070.)
  *
  * $(D SocketStream) is a stream for a blocking,
  * connected $(D Socket).
@@ -37,7 +36,7 @@
  * Macros: WIKI=Phobos/StdSocketstream
  */
 
-module std.socketstream;
+deprecated("Will be removed by phobos version 2.070") module std.socketstream;
 
 private import std.stream;
 private import std.socket;

--- a/std/stream.d
+++ b/std/stream.d
@@ -2,8 +2,7 @@
 
 /**
  * $(RED Warning: This module is considered out-dated and not up to Phobos'
- *       current standards. It will remain until we have a suitable replacement,
- *       but be aware that it will not remain long term.)
+ *       current standards. It will be removed by phobos version 2.070.)
  *
  * Source:    $(PHOBOSSRC std/_stream.d)
  * Macros:
@@ -27,7 +26,7 @@
  * "as is" without express or implied warranty.
  */
 
-module std.stream;
+deprecated("Will be removed by phobos version 2.070") module std.stream;
 
 
 import std.internal.cstring;


### PR DESCRIPTION
stream needs to go

as discussed at dconf15:

* remove streams from docs 2.068
* deprecate streams 2.069
* remove streams 2.071 ( move to undead)
