### PR TITLE
Fix issue 15033 -  Element type of float iota is double

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -4625,9 +4625,9 @@ body
 
 /// Ditto
 auto iota(B, E)(B begin, E end)
-if (isFloatingPoint!(CommonType!(B, E)))
+    if (isFloatingPoint!(CommonType!(B, E)))
 {
-    return iota(begin, end, 1.0);
+    return iota(begin, end, CommonType!(B, E)(1));
 }
 
 /// Ditto
@@ -4832,6 +4832,8 @@ unittest
 {
     import std.math : approxEqual, nextUp, nextDown;
     import std.algorithm : count, equal;
+
+    static assert(is(ElementType!(typeof(iota(0f))) == float));
 
     static assert(hasLength!(typeof(iota(0, 2))));
     auto r = iota(0, 10, 1);


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=15033

Use CommonType in iota()

See also: http://forum.dlang.org/post/ahjmgdslmiakoxszynty@forum.dlang.org

