### PR TITLE
Adjust deprecation messages for std.stream.

### DIFF
--- a/std/cstream.d
+++ b/std/cstream.d
@@ -1,8 +1,8 @@
 // Written in the D programming language.
 
 /**
- * $(RED Warning: This module is considered out-dated and not up to Phobos'
- *       current standards. It will be removed by phobos version 2.070.)
+ * $(RED Deprecated: This module is considered out-dated and not up to Phobos'
+ *       current standards. It will be remove in October 2016.)
  *
  * The std.cstream module bridges core.stdc.stdio (or std.stdio) and std.stream.
  * Both core.stdc.stdio and std.stream are publicly imported by std.cstream.
@@ -20,7 +20,8 @@
  *    (See accompanying file LICENSE_1_0.txt or copy at
  *          http://www.boost.org/LICENSE_1_0.txt)
  */
-deprecated("Will be removed by phobos version 2.070") module std.cstream;
+deprecated("It will be removed from Phobos in October 2016. If you still need it, go to https://github.com/DigitalMars/undeaD") module std.cstream;
+// @@@DEPRECATED_2016-10@@@
 
 public import core.stdc.stdio;
 public import std.stream;

--- a/std/socketstream.d
+++ b/std/socketstream.d
@@ -21,8 +21,8 @@
 */
 
 /**************
- * $(RED Warning: This module is considered out-dated and not up to Phobos'
- *       current standards. It will be removed by phobos version 2.070.)
+ * $(RED Deprecated: This module is considered out-dated and not up to Phobos'
+ *       current standards. It will be remove in October 2016.)
  *
  * $(D SocketStream) is a stream for a blocking,
  * connected $(D Socket).
@@ -35,8 +35,8 @@
  * Source:    $(PHOBOSSRC std/_socketstream.d)
  * Macros: WIKI=Phobos/StdSocketstream
  */
-
-deprecated("Will be removed by phobos version 2.070") module std.socketstream;
+deprecated("It will be removed from Phobos in October 2016. If you still need it, go to https://github.com/DigitalMars/undeaD") module std.socketstream;
+// @@@DEPRECATED_2016-10@@@
 
 private import std.stream;
 private import std.socket;

--- a/std/stream.d
+++ b/std/stream.d
@@ -1,8 +1,8 @@
 // Written in the D programming language
 
 /**
- * $(RED Warning: This module is considered out-dated and not up to Phobos'
- *       current standards. It will be removed by phobos version 2.070.)
+ * $(RED Deprecated: This module is considered out-dated and not up to Phobos'
+ *       current standards. It will be remove in October 2016.)
  *
  * Source:    $(PHOBOSSRC std/_stream.d)
  * Macros:
@@ -25,8 +25,8 @@
  * the suitability of this software for any purpose. It is provided
  * "as is" without express or implied warranty.
  */
-
-deprecated("Will be removed by phobos version 2.070") module std.stream;
+deprecated("It will be removed from Phobos in October 2016. If you still need it, go to https://github.com/DigitalMars/undeaD") module std.stream;
+// @@@DEPRECATED_2016-10@@@
 
 
 import std.internal.cstring;


### PR DESCRIPTION
2.070 is too early to remove std.stream. Our normal policy has been to deprecate something for a year and leave it documented and then remove its documentation but leave it deprecated for another year before removing it. So, folks have about two years to update their code, and we minimize how often someone goes to update their compiler and finds that their code doesn't compile anymore, because a symbol that they were using is now gone, and they never saw the deprecation message for it, because they were slow to upgrade. std.stream has been marked for years as being intended for deprecation but not actually deprecated. With 2.068, it was removed from the documentation but not deprecated. For 2.069, it's been deprecated but was marked for removal in 2.070, meaning that it would have been deprecated for one release only rather than two years, making it _very_ likely that many folks who have ignored the warning in the documentation of about std.stream going away will miss the deprecation messages entirely. This PR changes it so that std.stream will be deprecated for about a year before being removed, which is much more in line with how we normally do deprecations, except that it wasn't ever deprecated while its documentation was still public.

Here is a recent forum thread on the topic: http://forum.dlang.org/post/gdmydpmrxfgtvrkpyfcv@forum.dlang.org

And std.stream and friends were added to the undead project with this PR: https://github.com/DigitalMars/undeaD/pull/6