### PR TITLE
std.encoding - optimization of windows-1252

### DIFF
--- a/std/encoding.d
+++ b/std/encoding.d
@@ -2968,12 +2968,12 @@ class EncodingSchemeWindows1250 : EncodingScheme
 
         override size_t encodedLength(dchar c)
         {
-                return std.encoding.encodedLength!(Windows1250Char)(c);
+            return std.encoding.encodedLength!(Windows1250Char)(c);
         }
 
         override size_t encode(dchar c, ubyte[] buffer)
         {
-                auto r = cast(Windows1250Char[])buffer;
+            auto r = cast(Windows1250Char[])buffer;
             return std.encoding.encode(c,r);
         }
 


### PR DESCRIPTION
Modified the same way as in #3626
I'm planning to add more encodings on top of this - let me know if you prefer to add it to this PR or make it separate (for example by encoding usage region).
For now I kept it simple for review.

GenericEncoder is modified to handle narrowed character map as with cp1252 only a small subrange is not mapped directly.

Also modified the gen tool [0] to generate EncoderInstance from encoding mapping files.

[0] https://github.com/chalucha/encgen