### PR TITLE
Mention lambda predicates in std.algorithm

### DIFF
--- a/std/algorithm/package.d
+++ b/std/algorithm/package.d
@@ -132,9 +132,9 @@ $(TR $(TDNW Mutation)
 )
 ))
 
-Many functions in this package are parameterized with a function or a
-$(GLOSSARY predicate). The predicate may be passed either as a
-function name, a delegate name, a $(GLOSSARY functor) name, or a
+Many functions in this package are parameterized with a $(GLOSSARY predicate).
+The predicate may be any suitable callable type
+(a function, a delegate, a $(GLOSSARY functor), or a lambda), or a
 compile-time string. The string may consist of $(B any) legal D
 expression that uses the symbol $(D a) (for unary functions) or the
 symbols $(D a) and $(D b) (for binary functions). These names will NOT
@@ -151,10 +151,11 @@ static bool greater(int a, int b)
 {
     return a > b;
 }
-sort!(greater)(a);  // predicate as alias
-sort!("a > b")(a);  // predicate as string
-                    // (no ambiguity with array name)
-sort(a);            // no predicate, "a < b" is implicit
+sort!(greater)(a);         // predicate as alias
+sort!((a, b) => a > b)(a); // predicate as a lambda.
+sort!("a > b")(a);         // predicate as string
+                           // (no ambiguity with array name)
+sort(a);                   // no predicate, "a < b" is implicit
 ----
 
 Macros:


### PR DESCRIPTION
My understanding is that passing predicates as lambdas is a current best practice for `std.algorithm`. This mentions them in the docs for the package.