### PR TITLE
Simplify package documentation generation, fux errors in allocator's …

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -383,8 +383,7 @@ clean :
 	rm -rf $(ROOT_OF_THEM_ALL) $(ZIPFILE) $(DOC_OUTPUT_DIR)
 
 zip :
-	zip $(ZIPFILE) $(MAKEFILE) $(ALL_D_FILES) $(ALL_C_FILES) index.d win32.mak win64.mak osmodel.mak \
-	$(addsuffix /package.d,$(STD_PACKAGES))
+	zip $(ZIPFILE) $(MAKEFILE) $(ALL_D_FILES) $(ALL_C_FILES) index.d win32.mak win64.mak osmodel.mak
 
 install2 : all
 	$(eval lib_dir=$(if $(filter $(OS),osx), lib, lib$(MODEL)))
@@ -420,14 +419,12 @@ endif
 ###########################################################
 # html documentation
 
-# Package to html, e.g. std/algorithm -> std_algorithm.html
-P2HTML=$(addsuffix .html,$(subst /,_,$1))
 # D file to html, e.g. std/conv.d -> std_conv.html
-D2HTML=$(subst /,_,$(subst .d,.html,$1))
+# But "package.d" is special cased: std/range/package.d -> std_range.html
+D2HTML=$(foreach p,$1,$(if $(subst package.d,,$(notdir $p)),$(subst /,_,$(subst .d,.html,$p)),$(subst /,_,$(subst /package.d,.html,$p))))
 
 HTMLS=$(addprefix $(DOC_OUTPUT_DIR)/, \
-	$(call D2HTML, $(SRC_DOCUMENTABLES)) \
-	$(call P2HTML, $(STD_PACKAGES)))
+	$(call D2HTML, $(SRC_DOCUMENTABLES)))
 BIGHTMLS=$(addprefix $(BIGDOC_OUTPUT_DIR)/, \
 	$(call D2HTML, $(SRC_DOCUMENTABLES)))
 
@@ -438,12 +435,6 @@ $(DOC_OUTPUT_DIR)/. :
 # ../web/phobos/std_conv.html : std/conv.d $(STDDOC) ; ...
 $(foreach p,$(SRC_DOCUMENTABLES),$(eval \
 $(DOC_OUTPUT_DIR)/$(call D2HTML,$p) : $p $(STDDOC) ;\
-  $(DDOC) project.ddoc $(STDDOC) -Df$$@ $$<))
-
-# For each package, define a rule e.g.:
-# ../web/phobos/std_algorithm.html : std/algorithm/... $(STDDOC) ; ...
-$(foreach p,$(STD_PACKAGES),$(eval \
-$(DOC_OUTPUT_DIR)/$(call P2HTML,$p) : $(addsuffix .d,$(call P2MODULES,$p)) $(STDDOC) ;\
   $(DDOC) project.ddoc $(STDDOC) -Df$$@ $$<))
 
 html : $(DOC_OUTPUT_DIR)/. $(HTMLS) $(STYLECSS_TGT)

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -107,7 +107,7 @@ void fun(size_t n)
 To experiment with alternative allocators, set $(LREF theAllocator) for the
 current thread. For example, consider an application that allocates many 8-byte
 objects. These are not well supported by the default _allocator, so a $(A
-$(JOIN_LINE std,experimental,_allocator,building_blocks,free_list).html, free
+$(MY_JOIN_LINE std,experimental,_allocator,building_blocks,free_list).html, free
 list _allocator) would be recommended. To install one in `main`, the
 application would use:
 
@@ -192,11 +192,11 @@ TDC2 = <td nowrap>$(D $(MYREF $1,$+))</td>
 TDC3 = <td nowrap>$(D $(MYREF2 $1,$+))</td>
 RES = $(I result)
 POST = $(BR)$(SMALL $(I Post:) $(BLUE $(D $0)))
-JOIN_LINE = $1$(JOIN_LINE_TAIL $+)
-JOIN_LINE_TAIL = _$1$(JOIN_LINE_TAIL $+)
+MY_JOIN_LINE = $1$(MY_JOIN_LINE_TAIL $+)
+MY_JOIN_LINE_TAIL = _$1$(MY_JOIN_LINE_TAIL $+)
 JOIN_DOT = $1$(JOIN_DOT_TAIL $+)
 JOIN_DOT_TAIL = .$1$(JOIN_DOT_TAIL $+)
-XREF2 = $(A $(JOIN_LINE $1,$+).html,$(D $(JOIN_DOT $1,$+)))
+XREF2 = $(A $(MY_JOIN_LINE $1,$+).html,$(D $(JOIN_DOT $1,$+)))
 
 Copyright: Andrei Alexandrescu 2013-.
 
@@ -1937,4 +1937,3 @@ unittest
     b = alloc.allocate(101);
     assert(alloc.deallocate(b) == Ternary.yes);
 }
-


### PR DESCRIPTION
…documentation

Now there's no more need to treat packages that do vs. don't contain a "package.d" file separately.