### PR TITLE
Modified allocateEligible to prevent memory stomping

### DIFF
--- a/std/experimental/allocator/building_blocks/free_list.d
+++ b/std/experimental/allocator/building_blocks/free_list.d
@@ -269,7 +269,7 @@ struct FreeList(ParentAllocator,
             alias toAllocate = bytes;
         }
         assert(toAllocate == max || max == unbounded);
-        auto result = parent.allocate(bytes);
+        auto result = parent.allocate(toAllocate);
         static if (hasTolerance)
         {
             if (result) result = result.ptr[0 .. bytes];


### PR DESCRIPTION
It seemed apparant that allocateEligible should request 'max' bytes from the parent, otherwise a bigger subsequent allocation that takes the returned memory from the root may request an array slice that's too large for an existing buffer. I tested this by creating a class that was 24 bytes, allocating and then deallocating a number of them (4 at a time) on a free_list (with minSize 24, maxSize 108) on top of a mallocator, then switching to allocating a class that used the max, which caused a crash. This change fixes that case and should prevent this class of error.

This was previously a pull request for andralex's fork for that he requested I move here.