### PR TITLE
std.getopt: Re-add constructor removed in PR #3489

### DIFF
--- a/std/getopt.d
+++ b/std/getopt.d
@@ -46,12 +46,21 @@ $(UL
 class GetOptException : Exception
 {
     @safe pure nothrow
+    this(string msg, string file = __FILE__,
+        size_t line = __LINE__)
+    {
+        super(msg, file, line);
+    }
+    @safe pure nothrow
     this(string msg, Exception next, string file = __FILE__,
         size_t line = __LINE__)
     {
         super(msg, file, line, next);
     }
 }
+
+static assert(is(typeof(new GetOptException("message"))));
+static assert(is(typeof(new GetOptException("message", Exception.init))));
 
 /**
    Parse and remove command line options from an string array.


### PR DESCRIPTION
https://github.com/D-Programming-Language/phobos/commit/6c8b8232c30c38cd2140625225e0b7211a4319ae#commitcomment-13600264