### PR TITLE
std.variant: don't assert that target address != null if type size is 0

### DIFF
--- a/std/variant.d
+++ b/std/variant.d
@@ -303,7 +303,8 @@ private:
                     auto zat = cast(T*) target;
                     if (src)
                     {
-                        assert(target, "target must be non-null");
+                        static if (T.sizeof > 0)
+                            assert(target, "target must be non-null");
                         *zat = *src;
                     }
                 }
@@ -315,7 +316,8 @@ private:
                     auto zat = cast(U*) target;
                     if (src)
                     {
-                        assert(target, "target must be non-null");
+                        static if (U.sizeof > 0)
+                            assert(target, "target must be non-null");
                         *zat = *(cast(UA*) (src));
                     }
                 }


### PR DESCRIPTION
A unittest triggers in line 1918 when testing `Variant!(void[0])` with LDC (current `merge-2.068` branch).

When taking the address of a truly empty type, such as `T[0]`, LDC always returns a null constant; nothing is allocated on the stack.
Disabling this assert in case the target type's size is 0 should be safe, there's no private state which could be modified by the following assignment (it may still have side effects though) - right? ;)