### PR TITLE
[DMD 2.069][allocators] Fix issue 15187

### DIFF
--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -1056,7 +1056,7 @@ void dispose(A, T)(auto ref A alloc, T* p)
     {
         destroy(*p);
     }
-    alloc.deallocate(p[0 .. T.sizeof]);
+    alloc.deallocate((cast(void*)p)[0 .. T.sizeof]);
 }
 
 /// Ditto


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=15187
Duplicate of #3687

The bug can cause memory leaks when `dispose` is used with blocks like FreeList.