### PR TITLE
Rename obsolete TypeTuple to AliasSeq

### DIFF
--- a/std/algorithm/comparison.d
+++ b/std/algorithm/comparison.d
@@ -136,7 +136,7 @@ efficient search, but one that only supports matching on equality:
 
 @safe unittest
 {
-    import std.typetuple : TypeTuple;
+    import std.meta : AliasSeq;
 
     if (auto pos = 3.among(1, 2, 3))
         assert(pos == 3);
@@ -148,7 +148,7 @@ efficient search, but one that only supports matching on equality:
     assert(position);
     assert(position == 1);
 
-    alias values = TypeTuple!("foo", "bar", "baz");
+    alias values = AliasSeq!("foo", "bar", "baz");
     auto arr = [values];
     assert(arr[0 .. "foo".among(values)] == ["foo"]);
     assert(arr[0 .. "bar".among(values)] == ["foo", "bar"]);
@@ -173,8 +173,8 @@ efficient search, but one that only supports matching on equality:
 // in a tuple.
 private template indexOfFirstOvershadowingChoiceOnLast(choices...)
 {
-    alias firstParameterTypes = ParameterTypeTuple!(choices[0]);
-    alias lastParameterTypes = ParameterTypeTuple!(choices[$ - 1]);
+    alias firstParameterTypes = Parameters!(choices[0]);
+    alias lastParameterTypes = Parameters!(choices[$ - 1]);
 
     static if (lastParameterTypes.length == 0)
     {
@@ -256,7 +256,7 @@ auto castSwitch(choices...)(Object switchObject)
             static assert(isCallable!choice,
                     "A choice handler must be callable");
 
-            alias choiceParameterTypes = ParameterTypeTuple!choice;
+            alias choiceParameterTypes = Parameters!choice;
             static assert(choiceParameterTypes.length <= 1,
                     "A choice handler can not have more than one argument.");
 
@@ -272,7 +272,7 @@ auto castSwitch(choices...)(Object switchObject)
                 static assert(indexOfOvershadowingChoice == index,
                         "choice number %d(type %s) is overshadowed by choice number %d(type %s)".format(
                             index + 1, CastClass.stringof, indexOfOvershadowingChoice + 1,
-                            ParameterTypeTuple!(choices[indexOfOvershadowingChoice])[0].stringof));
+                            Parameters!(choices[indexOfOvershadowingChoice])[0].stringof));
 
                 if (classInfo == typeid(CastClass))
                 {
@@ -299,7 +299,7 @@ auto castSwitch(choices...)(Object switchObject)
         // Checking for derived matches:
         foreach (choice; choices)
         {
-            alias choiceParameterTypes = ParameterTypeTuple!choice;
+            alias choiceParameterTypes = Parameters!choice;
             static if (choiceParameterTypes.length == 1)
             {
                 if (auto castedObject = cast(choiceParameterTypes[0]) switchObject)
@@ -329,7 +329,7 @@ auto castSwitch(choices...)(Object switchObject)
         // Checking for null matches:
         foreach (index, choice; choices)
         {
-            static if (ParameterTypeTuple!(choice).length == 0)
+            static if (Parameters!(choice).length == 0)
             {
                 immutable indexOfOvershadowingChoice =
                     indexOfFirstOvershadowingChoiceOnLast!(choices[0..index + 1]);

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -302,15 +302,15 @@ private struct _Cache(R, bool bidir)
     private
     {
         import std.algorithm.internal : algoFormat;
-        import std.typetuple : TypeTuple;
+        import std.meta : AliasSeq;
 
         alias E  = ElementType!R;
         alias UE = Unqual!E;
 
         R source;
 
-        static if (bidir) alias CacheTypes = TypeTuple!(UE, UE);
-        else              alias CacheTypes = TypeTuple!UE;
+        static if (bidir) alias CacheTypes = AliasSeq!(UE, UE);
+        else              alias CacheTypes = AliasSeq!UE;
         CacheTypes caches;
 
         static assert(isAssignable!(UE, E) && is(UE : E),
@@ -446,14 +446,14 @@ template map(fun...) if (fun.length >= 1)
 {
     auto map(Range)(Range r) if (isInputRange!(Unqual!Range))
     {
-        import std.typetuple : staticMap;
+        import std.meta : staticMap;
 
         alias AppliedReturnType(alias f) = typeof(f(r.front));
 
         static if (fun.length > 1)
         {
             import std.functional : adjoin;
-            import std.typetuple : staticIndexOf;
+            import std.meta : staticIndexOf;
 
             alias _funs = staticMap!(unaryFun, fun);
             alias _fun = adjoin!_funs;
@@ -815,8 +815,8 @@ See_Also: $(XREF range,tee)
  */
 template each(alias pred = "a")
 {
-    import std.typetuple : TypeTuple;
-    alias BinaryArgs = TypeTuple!(pred, "i", "a");
+    import std.meta : AliasSeq;
+    alias BinaryArgs = AliasSeq!(pred, "i", "a");
 
     enum isRangeUnaryIterable(R) =
         is(typeof(unaryFun!pred(R.init.front)));
@@ -2450,7 +2450,7 @@ See_Also:
 +/
 template reduce(fun...) if (fun.length >= 1)
 {
-    import std.typetuple : staticMap;
+    import std.meta : staticMap;
 
     alias binfuns = staticMap!(binaryFun, fun);
     static if (fun.length > 1)
@@ -3780,8 +3780,8 @@ if (isSomeChar!C)
 @safe pure unittest
 {
     import std.algorithm.comparison : equal;
-    import std.typetuple : TypeTuple;
-    foreach(S; TypeTuple!(string, wstring, dstring))
+    import std.meta : AliasSeq;
+    foreach(S; AliasSeq!(string, wstring, dstring))
     {
         import std.conv : to;
         S a = " a     bcd   ef gh ";

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -460,8 +460,8 @@ $(WEB sgi.com/tech/stl/copy_backward.html, STL's copy_backward'):
 @safe unittest
 {
     // Issue 13650
-    import std.typecons : TypeTuple;
-    foreach (Char; TypeTuple!(char, wchar, dchar))
+    import std.meta : AliasSeq;
+    foreach (Char; AliasSeq!(char, wchar, dchar))
     {
         Char[3] a1 = "123";
         Char[6] a2 = "456789";
@@ -775,8 +775,8 @@ unittest
 unittest
 {
     import std.algorithm.iteration : filter;
+    import std.meta : AliasSeq;
     import std.traits : hasElaborateAssign;
-    import std.typetuple : TypeTuple;
 
     debug(std_algorithm) scope(success)
         writeln("unittest @", __FILE__, ":", __LINE__, " done.");
@@ -827,7 +827,7 @@ unittest
     assert (!typeid(S3).init().ptr);
     assert ( typeid(S4).init().ptr);
 
-    foreach(S; TypeTuple!(S1, S2, S3, S4))
+    foreach(S; AliasSeq!(S1, S2, S3, S4))
     {
         //initializeAll
         {

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -491,9 +491,9 @@ if (isNarrowString!R1 && isNarrowString!R2)
     import std.algorithm.iteration : filter;
     import std.conv : to;
     import std.exception : assertThrown;
-    import std.utf : UTFException;
+    import std.meta : AliasSeq;
     import std.range;
-    import std.typetuple : TypeTuple;
+    import std.utf : UTFException;
 
     assert(commonPrefix([1, 2, 3], [1, 2, 3, 4, 5]) == [1, 2, 3]);
     assert(commonPrefix([1, 2, 3, 4, 5], [1, 2, 3]) == [1, 2, 3]);
@@ -504,11 +504,11 @@ if (isNarrowString!R1 && isNarrowString!R2)
     assert(commonPrefix(cast(int[])null, [1, 2, 3]).empty);
     assert(commonPrefix(cast(int[])null, cast(int[])null).empty);
 
-    foreach (S; TypeTuple!(char[], const(char)[], string,
-                           wchar[], const(wchar)[], wstring,
-                           dchar[], const(dchar)[], dstring))
+    foreach (S; AliasSeq!(char[], const(char)[], string,
+                          wchar[], const(wchar)[], wstring,
+                          dchar[], const(dchar)[], dstring))
     {
-        foreach(T; TypeTuple!(string, wstring, dstring))
+        foreach(T; AliasSeq!(string, wstring, dstring))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             assert(commonPrefix(to!S(""), to!T("")).empty);
             assert(commonPrefix(to!S(""), to!T("hello")).empty);
@@ -1091,13 +1091,13 @@ if (isBidirectionalRange!R &&
 @safe unittest
 {
     import std.algorithm.iteration : filterBidirectional;
-    import std.typetuple : TypeTuple;
+    import std.meta : AliasSeq;
     import std.conv : to;
 
     debug(std_algorithm) scope(success)
         writeln("unittest @", __FILE__, ":", __LINE__, " done.");
 
-    foreach (S; TypeTuple!(char[], wchar[], dchar[], string, wstring, dstring))
+    foreach (S; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
     {
         assert(!endsWith(to!S("abc"), 'a'));
         assert(endsWith(to!S("abc"), 'a', 'c') == 2);
@@ -1105,7 +1105,7 @@ if (isBidirectionalRange!R &&
         assert(endsWith(to!S("abc"), 'x', 'n', 'c') == 3);
         assert(endsWith(to!S("abc\uFF28"), 'a', '\uFF28', 'c') == 2);
 
-        foreach (T; TypeTuple!(char[], wchar[], dchar[], string, wstring, dstring))
+        foreach (T; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             //Lots of strings
             assert(endsWith(to!S("abc"), to!T("")));
@@ -1139,7 +1139,7 @@ if (isBidirectionalRange!R &&
         }();
     }
 
-    foreach (T; TypeTuple!(int, short))
+    foreach (T; AliasSeq!(int, short))
     {
         immutable arr = cast(T[])[0, 1, 2, 3, 4, 5];
 
@@ -1394,10 +1394,10 @@ if (isInputRange!InputRange &&
 
 @safe pure unittest
 {
-    import std.typetuple : TypeTuple;
-    foreach(R; TypeTuple!(string, wstring, dstring))
+    import std.meta : AliasSeq;
+    foreach(R; AliasSeq!(string, wstring, dstring))
     {
-        foreach(E; TypeTuple!(char, wchar, dchar))
+        foreach(E; AliasSeq!(char, wchar, dchar))
         {
             R r1 = "hello world";
             E e1 = 'w';
@@ -1438,15 +1438,15 @@ if (isInputRange!InputRange &&
 @safe unittest
 {
     import std.exception : assertCTFEable;
-    import std.typetuple : TypeTuple;
+    import std.meta : AliasSeq;
 
     void dg() @safe pure nothrow
     {
         byte[]  sarr = [1, 2, 3, 4];
         ubyte[] uarr = [1, 2, 3, 4];
-        foreach(arr; TypeTuple!(sarr, uarr))
+        foreach(arr; AliasSeq!(sarr, uarr))
         {
-            foreach(T; TypeTuple!(byte, ubyte, int, uint))
+            foreach(T; AliasSeq!(byte, ubyte, int, uint))
             {
                 assert(find(arr, cast(T) 3) == arr[2 .. $]);
                 assert(find(arr, cast(T) 9) == arr[$ .. $]);
@@ -1989,7 +1989,7 @@ if (Ranges.length > 1 && is(typeof(startsWith!pred(haystack, needles))))
 @safe unittest
 {
     import std.algorithm.internal : rndstuff;
-    import std.typetuple : TypeTuple;
+    import std.meta : AliasSeq;
     import std.uni : toUpper;
 
     debug(std_algorithm) scope(success)
@@ -1999,7 +1999,7 @@ if (Ranges.length > 1 && is(typeof(startsWith!pred(haystack, needles))))
     assert(find(a, 5).empty);
     assert(find(a, 2) == [2, 3]);
 
-    foreach (T; TypeTuple!(int, double))
+    foreach (T; AliasSeq!(int, double))
     {
         auto b = rndstuff!(T)();
         if (!b.length) continue;
@@ -2021,8 +2021,8 @@ if (Ranges.length > 1 && is(typeof(startsWith!pred(haystack, needles))))
 {
     import std.algorithm.internal : rndstuff;
     import std.algorithm.comparison : equal;
+    import std.meta : AliasSeq;
     import std.range : retro;
-    import std.typetuple : TypeTuple;
 
     debug(std_algorithm) scope(success)
         writeln("unittest @", __FILE__, ":", __LINE__, " done.");
@@ -2031,7 +2031,7 @@ if (Ranges.length > 1 && is(typeof(startsWith!pred(haystack, needles))))
     assert(find(retro(a), 5).empty);
     assert(equal(find(retro(a), 2), [ 2, 3, 2, 1 ][]));
 
-    foreach (T; TypeTuple!(int, double))
+    foreach (T; AliasSeq!(int, double))
     {
         auto b = rndstuff!(T)();
         if (!b.length) continue;
@@ -2120,7 +2120,7 @@ $(LREF among) for checking a value against multiple possibilities.
  +/
 template canFind(alias pred="a == b")
 {
-    import std.typetuple : allSatisfy;
+    import std.meta : allSatisfy;
 
     /++
     Returns $(D true) if and only if any value $(D v) found in the
@@ -2736,7 +2736,7 @@ unittest
 unittest
 {
     import std.conv : text;
-    import std.typetuple : TypeTuple;
+    import std.meta : AliasSeq;
 
     debug(std_algorithm) scope(success)
         writeln("unittest @", __FILE__, ":", __LINE__, " done.");
@@ -2786,7 +2786,7 @@ unittest
     }
     static assert(!isAssignable!S3);
 
-    foreach (Type; TypeTuple!(S1, IS1, S2, IS2, S3))
+    foreach (Type; AliasSeq!(S1, IS1, S2, IS2, S3))
     {
         static if (is(Type == immutable)) alias V = immutable int;
         else                              alias V = int;
@@ -3225,13 +3225,13 @@ if (isInputRange!R &&
 {
     import std.algorithm.iteration : filter;
     import std.conv : to;
+    import std.meta : AliasSeq;
     import std.range;
-    import std.typetuple : TypeTuple;
 
     debug(std_algorithm) scope(success)
         writeln("unittest @", __FILE__, ":", __LINE__, " done.");
 
-    foreach (S; TypeTuple!(char[], wchar[], dchar[], string, wstring, dstring))
+    foreach (S; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
     {
         assert(!startsWith(to!S("abc"), 'c'));
         assert(startsWith(to!S("abc"), 'a', 'c') == 1);
@@ -3239,7 +3239,7 @@ if (isInputRange!R &&
         assert(startsWith(to!S("abc"), 'x', 'n', 'a') == 3);
         assert(startsWith(to!S("\uFF28abc"), 'a', '\uFF28', 'c') == 2);
 
-        foreach (T; TypeTuple!(char[], wchar[], dchar[], string, wstring, dstring))
+        foreach (T; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             //Lots of strings
             assert(startsWith(to!S("abc"), to!T("")));
@@ -3281,7 +3281,7 @@ if (isInputRange!R &&
     assert(startsWith("abc".takeExactly(3), "abcd".takeExactly(3)));
     assert(startsWith("abc".takeExactly(3), "abcd".takeExactly(1)));
 
-    foreach (T; TypeTuple!(int, short))
+    foreach (T; AliasSeq!(int, short))
     {
         immutable arr = cast(T[])[0, 1, 2, 3, 4, 5];
 

--- a/std/algorithm/setops.d
+++ b/std/algorithm/setops.d
@@ -47,7 +47,7 @@ import std.range.primitives;
 import std.functional; // : unaryFun, binaryFun;
 import std.traits;
 // FIXME
-import std.typetuple; // : TypeTuple, staticMap, allSatisfy, anySatisfy;
+import std.meta; // : AliasSeq, staticMap, allSatisfy, anySatisfy;
 
 // cartesianProduct
 /**

--- a/std/array.d
+++ b/std/array.d
@@ -75,8 +75,8 @@ Source: $(PHOBOSSRC std/_array.d)
 */
 module std.array;
 
+import std.meta;
 import std.traits;
-import std.typetuple;
 import std.functional;
 static import std.algorithm; // FIXME, remove with alias of splitter
 
@@ -283,7 +283,7 @@ unittest
         int i;
     }
 
-    foreach(T; TypeTuple!(S, const S, immutable S))
+    foreach(T; AliasSeq!(S, const S, immutable S))
     {
         auto arr = [T(1), T(2), T(3), T(4)];
         assert(array(arr) == arr);
@@ -1056,10 +1056,10 @@ unittest
                 new AssertError("testStr failure 3", file, line));
     }
 
-    foreach (T; TypeTuple!(char, wchar, dchar,
+    foreach (T; AliasSeq!(char, wchar, dchar,
         immutable(char), immutable(wchar), immutable(dchar)))
     {
-        foreach (U; TypeTuple!(char, wchar, dchar,
+        foreach (U; AliasSeq!(char, wchar, dchar,
             immutable(char), immutable(wchar), immutable(dchar)))
         {
             testStr!(T[], U[])();
@@ -1215,7 +1215,7 @@ pure nothrow bool sameTail(T)(in T[] lhs, in T[] rhs)
 
 @safe pure nothrow unittest
 {
-    foreach(T; TypeTuple!(int[], const(int)[], immutable(int)[], const int[], immutable int[]))
+    foreach(T; AliasSeq!(int[], const(int)[], immutable(int)[], const int[], immutable int[]))
     {
         T a = [1, 2, 3, 4, 5];
         T b = a;
@@ -1302,7 +1302,7 @@ unittest
 
     debug(std_array) printf("array.replicate.unittest\n");
 
-    foreach (S; TypeTuple!(string, wstring, dstring, char[], wchar[], dchar[]))
+    foreach (S; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[]))
     {
         S s;
         immutable S t = "abc";
@@ -1371,7 +1371,7 @@ unittest
     static auto makeEntry(S)(string l, string[] r)
     {return tuple(l.to!S(), r.to!(S[])());}
 
-    foreach (S; TypeTuple!(string, wstring, dstring,))
+    foreach (S; AliasSeq!(string, wstring, dstring,))
     {
         auto entries =
         [
@@ -1475,7 +1475,7 @@ unittest
     import std.algorithm : cmp;
 
     debug(std_array) printf("array.split\n");
-    foreach (S; TypeTuple!(string, wstring, dstring,
+    foreach (S; AliasSeq!(string, wstring, dstring,
                     immutable(string), immutable(wstring), immutable(dstring),
                     char[], wchar[], dchar[],
                     const(char)[], const(wchar)[], const(dchar)[],
@@ -1763,18 +1763,18 @@ ElementEncodingType!(ElementType!RoR)[] join(RoR)(RoR ror)
 {
     import std.conv : to;
 
-    foreach (T; TypeTuple!(string,wstring,dstring))
+    foreach (T; AliasSeq!(string,wstring,dstring))
     {
         auto arr2 = "Здравствуй Мир Unicode".to!(T);
         auto arr = ["Здравствуй", "Мир", "Unicode"].to!(T[]);
         assert(join(arr) == "ЗдравствуйМирUnicode");
-        foreach (S; TypeTuple!(char,wchar,dchar))
+        foreach (S; AliasSeq!(char,wchar,dchar))
         {
             auto jarr = arr.join(to!S(' '));
             static assert(is(typeof(jarr) == T));
             assert(jarr == arr2);
         }
-        foreach (S; TypeTuple!(string,wstring,dstring))
+        foreach (S; AliasSeq!(string,wstring,dstring))
         {
             auto jarr = arr.join(to!S(" "));
             static assert(is(typeof(jarr) == T));
@@ -1782,11 +1782,11 @@ ElementEncodingType!(ElementType!RoR)[] join(RoR)(RoR ror)
         }
     }
 
-    foreach (T; TypeTuple!(string,wstring,dstring))
+    foreach (T; AliasSeq!(string,wstring,dstring))
     {
         auto arr2 = "Здравствуй\u047CМир\u047CUnicode".to!(T);
         auto arr = ["Здравствуй", "Мир", "Unicode"].to!(T[]);
-        foreach (S; TypeTuple!(wchar,dchar))
+        foreach (S; AliasSeq!(wchar,dchar))
         {
             auto jarr = arr.join(to!S('\u047C'));
             static assert(is(typeof(jarr) == T));
@@ -1806,7 +1806,7 @@ unittest
 
     debug(std_array) printf("array.join.unittest\n");
 
-    foreach(R; TypeTuple!(string, wstring, dstring))
+    foreach(R; AliasSeq!(string, wstring, dstring))
     {
         R word1 = "日本語";
         R word2 = "paul";
@@ -1823,7 +1823,7 @@ unittest
         auto filteredLenWordsArr = [filteredLenWord1, filteredLenWord2, filteredLenWord3];
         auto filteredWords    = filter!"true"(filteredWordsArr);
 
-        foreach(S; TypeTuple!(string, wstring, dstring))
+        foreach(S; AliasSeq!(string, wstring, dstring))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             assert(join(filteredWords, to!S(", ")) == "日本語, paul, jerry");
             assert(join(filteredWords, to!(ElementType!S)(',')) == "日本語,paul,jerry");
@@ -2014,9 +2014,9 @@ unittest
 
     debug(std_array) printf("array.replace.unittest\n");
 
-    foreach (S; TypeTuple!(string, wstring, dstring, char[], wchar[], dchar[]))
+    foreach (S; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[]))
     {
-        foreach (T; TypeTuple!(string, wstring, dstring, char[], wchar[], dchar[]))
+        foreach (T; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[]))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             auto s = to!S("This is a foo foo list");
             auto from = to!T("foo");
@@ -2051,7 +2051,7 @@ unittest
         this(C[] arr){ desired = arr; }
         void put(C[] part){ assert(skipOver(desired, part)); }
     }
-    foreach (S; TypeTuple!(string, wstring, dstring, char[], wchar[], dchar[]))
+    foreach (S; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[]))
     {
         alias Char = ElementEncodingType!S;
         S s = to!S("yet another dummy text, yet another ...");
@@ -2437,10 +2437,10 @@ unittest
 
     debug(std_array) printf("array.replaceFirst.unittest\n");
 
-    foreach (S; TypeTuple!(string, wstring, dstring, char[], wchar[], dchar[],
+    foreach (S; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[],
                           const(char[]), immutable(char[])))
     {
-        foreach (T; TypeTuple!(string, wstring, dstring, char[], wchar[], dchar[],
+        foreach (T; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[],
                               const(char[]), immutable(char[])))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             auto s = to!S("This is a foo foo list");
@@ -2545,10 +2545,10 @@ unittest
 
     debug(std_array) printf("array.replaceLast.unittest\n");
 
-    foreach (S; TypeTuple!(string, wstring, dstring, char[], wchar[], dchar[],
+    foreach (S; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[],
                           const(char[]), immutable(char[])))
     {
-        foreach (T; TypeTuple!(string, wstring, dstring, char[], wchar[], dchar[],
+        foreach (T; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[],
                               const(char[]), immutable(char[])))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             auto s = to!S("This is a foo foo list");
@@ -3173,7 +3173,7 @@ Appender!(E[]) appender(A : E[], E)(auto ref A array)
     catch (Exception) assert(0);
 
     // Issue 5663 & 9725 tests
-    foreach (S; TypeTuple!(char[], const(char)[], string))
+    foreach (S; AliasSeq!(char[], const(char)[], string))
     {
         {
             Appender!S app5663i;

--- a/std/ascii.d
+++ b/std/ascii.d
@@ -28,9 +28,9 @@ module std.ascii;
 version (unittest)
 {
     // FIXME: When dmd bug #314 is fixed, make these selective.
+    import std.meta; // : AliasSeq;
     import std.range; // : chain;
     import std.traits; // : functionAttributes, FunctionAttribute, isSafe;
-    import std.typetuple; // : TypeTuple;
 }
 
 
@@ -531,7 +531,7 @@ auto toLower(C)(C c)
 @safe pure nothrow unittest
 {
 
-    foreach(C; TypeTuple!(char, wchar, dchar, immutable char, ubyte))
+    foreach(C; AliasSeq!(char, wchar, dchar, immutable char, ubyte))
     {
         foreach(i, c; uppercase)
             assert(toLower(cast(C)c) == lowercase[i]);
@@ -592,7 +592,7 @@ auto toUpper(C)(C c)
 
 @safe pure nothrow unittest
 {
-    foreach(C; TypeTuple!(char, wchar, dchar, immutable char, ubyte))
+    foreach(C; AliasSeq!(char, wchar, dchar, immutable char, ubyte))
     {
         foreach(i, c; lowercase)
             assert(toUpper(cast(C)c) == uppercase[i]);
@@ -631,7 +631,7 @@ unittest //Test both toUpper and toLower with non-builtin
     enum UDDE : UDD {a = UDD('a'), A = UDD('A')}
 
     //User defined types with implicit cast to dchar test.
-    foreach (Char; TypeTuple!(UDC, UDW, UDD))
+    foreach (Char; AliasSeq!(UDC, UDW, UDD))
     {
         assert(toLower(Char('a')) == 'a');
         assert(toLower(Char('A')) == 'a');
@@ -642,7 +642,7 @@ unittest //Test both toUpper and toLower with non-builtin
     }
 
     //Various enum tests.
-    foreach (Enum; TypeTuple!(CE, WE, DE, UDCE, UDWE, UDDE))
+    foreach (Enum; AliasSeq!(CE, WE, DE, UDCE, UDWE, UDDE))
     {
         assert(toLower(Enum.a) == 'a');
         assert(toLower(Enum.A) == 'a');
@@ -655,7 +655,7 @@ unittest //Test both toUpper and toLower with non-builtin
     }
 
     //Return value type tests for enum of non-UDT. These should be the original type.
-    foreach (T; TypeTuple!(CE, WE, DE))
+    foreach (T; AliasSeq!(CE, WE, DE))
     {
         alias C = OriginalType!T;
         static assert(is(typeof(toLower(T.init)) == C));
@@ -663,7 +663,7 @@ unittest //Test both toUpper and toLower with non-builtin
     }
 
     //Return value tests for UDT and enum of UDT. These should be dchar
-    foreach (T; TypeTuple!(UDC, UDW, UDD, UDCE, UDWE, UDDE))
+    foreach (T; AliasSeq!(UDC, UDW, UDD, UDCE, UDWE, UDDE))
     {
         static assert(is(typeof(toLower(T.init)) == dchar));
         static assert(is(typeof(toUpper(T.init)) == dchar));

--- a/std/bigint.d
+++ b/std/bigint.d
@@ -1325,12 +1325,12 @@ unittest // 11148
     assert(__traits(compiles, foo(cbi)));
     assert(__traits(compiles, foo(ibi)));
 
-    import std.typetuple : TypeTuple;
+    import std.meta : AliasSeq;
     import std.conv : to;
 
-    foreach (T1; TypeTuple!(BigInt, const(BigInt), immutable(BigInt)))
+    foreach (T1; AliasSeq!(BigInt, const(BigInt), immutable(BigInt)))
     {
-        foreach (T2; TypeTuple!(BigInt, const(BigInt), immutable(BigInt)))
+        foreach (T2; AliasSeq!(BigInt, const(BigInt), immutable(BigInt)))
         {
             T1 t1 = 2;
             T2 t2 = t1;
@@ -1405,8 +1405,8 @@ unittest // 13391
     BigInt x2 = "123456789123456789";
     BigInt x3 = "123456789123456789123456789";
 
-    import std.typetuple : TypeTuple;
-    foreach (T; TypeTuple!(byte, ubyte, short, ushort, int, uint, long, ulong))
+    import std.meta : AliasSeq;
+    foreach (T; AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong))
     {
         assert((x1 * T.max) / T.max == x1);
         assert((x2 * T.max) / T.max == x2);
@@ -1433,8 +1433,8 @@ unittest // 13391
 unittest // 13963
 {
     BigInt x = 1;
-    import std.typetuple : TypeTuple;
-    foreach(Int; TypeTuple!(byte, ubyte, short, ushort, int, uint))
+    import std.meta : AliasSeq;
+    foreach(Int; AliasSeq!(byte, ubyte, short, ushort, int, uint))
     {
         assert(is(typeof(x % Int(1)) == int));
     }

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -2166,8 +2166,8 @@ private ulong swapEndianImpl(ulong val) @trusted pure nothrow @nogc
 
 unittest
 {
-    import std.typetuple;
-    foreach(T; TypeTuple!(bool, byte, ubyte, short, ushort, int, uint, long, ulong, char, wchar, dchar))
+    import std.meta;
+    foreach(T; AliasSeq!(bool, byte, ubyte, short, ushort, int, uint, long, ulong, char, wchar, dchar))
     {
         scope(failure) writefln("Failed type: %s", T.stringof);
         T val;
@@ -2282,9 +2282,9 @@ private auto nativeToBigEndianImpl(T)(T val) @safe pure nothrow @nogc
 
 unittest
 {
-    import std.typetuple;
-    foreach(T; TypeTuple!(bool, byte, ubyte, short, ushort, int, uint, long, ulong,
-                          char, wchar, dchar
+    import std.meta;
+    foreach(T; AliasSeq!(bool, byte, ubyte, short, ushort, int, uint, long, ulong,
+                         char, wchar, dchar
         /* The trouble here is with floats and doubles being compared against nan
          * using a bit compare. There are two kinds of nans, quiet and signaling.
          * When a nan passes through the x87, it converts signaling to quiet.
@@ -2456,10 +2456,10 @@ private auto nativeToLittleEndianImpl(T)(T val) @safe pure nothrow @nogc
 
 unittest
 {
-    import std.typetuple;
-    foreach(T; TypeTuple!(bool, byte, ubyte, short, ushort, int, uint, long, ulong,
-                          char, wchar, dchar/*,
-                          float, double*/))
+    import std.meta;
+    foreach(T; AliasSeq!(bool, byte, ubyte, short, ushort, int, uint, long, ulong,
+                         char, wchar, dchar/*,
+                         float, double*/))
     {
         scope(failure) writefln("Failed type: %s", T.stringof);
         T val;
@@ -2586,8 +2586,8 @@ private template isFloatOrDouble(T)
 
 unittest
 {
-    import std.typetuple;
-    foreach(T; TypeTuple!(float, double))
+    import std.meta;
+    foreach(T; AliasSeq!(float, double))
     {
         static assert(isFloatOrDouble!(T));
         static assert(isFloatOrDouble!(const T));
@@ -2615,9 +2615,9 @@ private template canSwapEndianness(T)
 
 unittest
 {
-    import std.typetuple;
-    foreach(T; TypeTuple!(bool, ubyte, byte, ushort, short, uint, int, ulong,
-                          long, char, wchar, dchar, float, double))
+    import std.meta;
+    foreach(T; AliasSeq!(bool, ubyte, byte, ushort, short, uint, int, ulong,
+                         long, char, wchar, dchar, float, double))
     {
         static assert(canSwapEndianness!(T));
         static assert(canSwapEndianness!(const T));
@@ -2628,7 +2628,7 @@ unittest
     }
 
     //!
-    foreach(T; TypeTuple!(real, string, wstring, dstring))
+    foreach(T; AliasSeq!(real, string, wstring, dstring))
     {
         static assert(!canSwapEndianness!(T));
         static assert(!canSwapEndianness!(const T));
@@ -3706,11 +3706,11 @@ unittest
 {
     import std.format : format;
     import std.array;
-    import std.typetuple;
-    foreach(endianness; TypeTuple!(Endian.bigEndian, Endian.littleEndian))
+    import std.meta;
+    foreach(endianness; AliasSeq!(Endian.bigEndian, Endian.littleEndian))
     {
         auto toWrite = appender!(ubyte[])();
-        alias Types = TypeTuple!(uint, int, long, ulong, short, ubyte, ushort, byte, uint);
+        alias Types = AliasSeq!(uint, int, long, ulong, short, ubyte, ushort, byte, uint);
         ulong[] values = [42, -11, long.max, 1098911981329L, 16, 255, 19012, 2, 17];
         assert(Types.length == values.length);
 
@@ -3781,8 +3781,8 @@ unittest
 
 unittest
 {
-    import std.typetuple;
-    foreach (T; TypeTuple!(byte, ubyte, short, ushort, int, uint, long, ulong))
+    import std.meta;
+    foreach (T; AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong))
     {
         assert(countTrailingZeros(cast(T)0) == 8 * T.sizeof);
         assert(countTrailingZeros(cast(T)1) == 0);
@@ -3862,8 +3862,8 @@ unittest
 
 unittest
 {
-    import std.typetuple;
-    foreach (T; TypeTuple!(byte, ubyte, short, ushort, int, uint, long, ulong))
+    import std.meta;
+    foreach (T; AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong))
     {
         assert(countBitsSet(cast(T)0) == 0);
         assert(countBitsSet(cast(T)1) == 1);
@@ -3963,8 +3963,8 @@ unittest
     import std.algorithm : equal;
     import std.range: iota;
 
-    import std.typetuple;
-    foreach (T; TypeTuple!(byte, ubyte, short, ushort, int, uint, long, ulong))
+    import std.meta;
+    foreach (T; AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong))
     {
         assert(bitsSet(cast(T)0).empty);
         assert(bitsSet(cast(T)1).equal([0]));

--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -76,11 +76,11 @@ private
     import core.sync.condition;
     import std.algorithm;
     import std.exception;
+    import std.meta;
     import std.range;
     import std.string;
     import std.traits;
     import std.typecons;
-    import std.typetuple;
     import std.concurrencybase;
 
     template hasLocalAliasing(T...)
@@ -150,7 +150,7 @@ private
 
         auto map(Op)( Op op )
         {
-            alias Args = ParameterTypeTuple!(Op);
+            alias Args = Parameters!(Op);
 
             static if( Args.length == 1 )
             {
@@ -171,7 +171,7 @@ private
         foreach( i, t1; T )
         {
             static assert( isFunctionPointer!t1 || isDelegate!t1 );
-            alias a1 = ParameterTypeTuple!(t1);
+            alias a1 = Parameters!(t1);
             alias r1 = ReturnType!(t1);
 
             static if( i < T.length - 1 && is( r1 == void ) )
@@ -183,7 +183,7 @@ private
                 foreach( t2; T[i+1 .. $] )
                 {
                     static assert( isFunctionPointer!t2 || isDelegate!t2 );
-                    alias a2 = ParameterTypeTuple!(t2);
+                    alias a2 = Parameters!(t2);
 
                     static assert( !is( a1 == a2 ),
                                    "function with arguments " ~ a1.stringof ~
@@ -397,8 +397,8 @@ private template isSpawnable(F, T...)
 {
     template isParamsImplicitlyConvertible(F1, F2, int i=0)
     {
-        alias param1 = ParameterTypeTuple!F1;
-        alias param2 = ParameterTypeTuple!F2;
+        alias param1 = Parameters!F1;
+        alias param2 = Parameters!F2;
         static if (param1.length != param2.length)
             enum isParamsImplicitlyConvertible = false;
         else static if (param1.length == i)
@@ -1905,7 +1905,7 @@ private
 
             static if( isImplicitlyConvertible!(T[0], Duration) )
             {
-                alias Ops = TypeTuple!(T[1 .. $]);
+                alias Ops = AliasSeq!(T[1 .. $]);
                 alias ops = vals[1 .. $];
                 assert( vals[0] >= msecs(0) );
                 enum timedWait = true;
@@ -1913,7 +1913,7 @@ private
             }
             else
             {
-                alias Ops = TypeTuple!(T);
+                alias Ops = AliasSeq!(T);
                 alias ops = vals[0 .. $];
                 enum timedWait = false;
             }
@@ -1922,7 +1922,7 @@ private
             {
                 foreach( i, t; Ops )
                 {
-                    alias Args = ParameterTypeTuple!(t);
+                    alias Args = Parameters!(t);
                     auto  op   = ops[i];
 
                     if( msg.convertsTo!(Args) )

--- a/std/container/package.d
+++ b/std/container/package.d
@@ -425,7 +425,7 @@ public import std.container.dlist;
 public import std.container.rbtree;
 public import std.container.slist;
 
-import std.typetuple;
+import std.meta;
 
 
 /* The following documentation and type $(D TotalContainer) are
@@ -470,7 +470,7 @@ the type of the $(D k)th key of the container.
 A container may define both $(D KeyType) and $(D KeyTypes), e.g. in
 the case it has the notion of primary/preferred key.
  */
-    alias KeyTypes = TypeTuple!T;
+    alias KeyTypes = AliasSeq!T;
 
 /**
 If the container has a notion of key-value mapping, $(D ValueType)

--- a/std/container/rbtree.d
+++ b/std/container/rbtree.d
@@ -701,9 +701,9 @@ private struct RBRange(N)
 final class RedBlackTree(T, alias less = "a < b", bool allowDuplicates = false)
     if(is(typeof(binaryFun!less(T.init, T.init))))
 {
+    import std.meta : allSatisfy;
     import std.range.primitives;
     import std.range : Take;
-    import std.typetuple : allSatisfy;
     import std.traits;
 
     alias _less = binaryFun!less;

--- a/std/conv.d
+++ b/std/conv.d
@@ -23,9 +23,9 @@ module std.conv;
 
 public import std.ascii : LetterCase;
 
+import std.meta;
 import std.range.primitives;
 import std.traits;
-import std.typetuple;
 
 // Same as std.string.format, but "self-importing".
 // Helps reduce code and imports, particularly in static asserts.
@@ -335,12 +335,12 @@ template to(T)
 @safe pure unittest
 {
     import std.exception;
-    foreach (T; TypeTuple!(byte, ubyte, short, ushort, int, uint, long, ulong))
+    foreach (T; AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong))
     {
         assertThrown!ConvException(to!T(" 0"));
         assertThrown!ConvException(to!T(" 0", 8));
     }
-    foreach (T; TypeTuple!(float, double, real))
+    foreach (T; AliasSeq!(float, double, real))
     {
         assertThrown!ConvException(to!T(" 0"));
     }
@@ -407,12 +407,12 @@ T toImpl(T, S)(S value)
 {
     import std.exception;
     // Conversion between same size
-    foreach (S; TypeTuple!(byte, short, int, long))
+    foreach (S; AliasSeq!(byte, short, int, long))
     (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
         alias U = Unsigned!S;
 
-        foreach (Sint; TypeTuple!(S, const S, immutable S))
-        foreach (Uint; TypeTuple!(U, const U, immutable U))
+        foreach (Sint; AliasSeq!(S, const S, immutable S))
+        foreach (Uint; AliasSeq!(U, const U, immutable U))
         {
             // positive overflow
             Uint un = Uint.max;
@@ -427,8 +427,8 @@ T toImpl(T, S)(S value)
     }();
 
     // Conversion between different size
-    foreach (i, S1; TypeTuple!(byte, short, int, long))
-    foreach (   S2; TypeTuple!(byte, short, int, long)[i+1..$])
+    foreach (i, S1; AliasSeq!(byte, short, int, long))
+    foreach (   S2; AliasSeq!(byte, short, int, long)[i+1..$])
     (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
         alias U1 = Unsigned!S1;
         alias U2 = Unsigned!S2;
@@ -436,8 +436,8 @@ T toImpl(T, S)(S value)
         static assert(U1.sizeof < S2.sizeof);
 
         // small unsigned to big signed
-        foreach (Uint; TypeTuple!(U1, const U1, immutable U1))
-        foreach (Sint; TypeTuple!(S2, const S2, immutable S2))
+        foreach (Uint; AliasSeq!(U1, const U1, immutable U1))
+        foreach (Sint; AliasSeq!(S2, const S2, immutable S2))
         {
             Uint un = Uint.max;
             assertNotThrown(to!Sint(un));
@@ -445,8 +445,8 @@ T toImpl(T, S)(S value)
         }
 
         // big unsigned to small signed
-        foreach (Uint; TypeTuple!(U2, const U2, immutable U2))
-        foreach (Sint; TypeTuple!(S1, const S1, immutable S1))
+        foreach (Uint; AliasSeq!(U2, const U2, immutable U2))
+        foreach (Sint; AliasSeq!(S1, const S1, immutable S1))
         {
             Uint un = Uint.max;
             assertThrown(to!Sint(un));
@@ -455,16 +455,16 @@ T toImpl(T, S)(S value)
         static assert(S1.sizeof < U2.sizeof);
 
         // small signed to big unsigned
-        foreach (Sint; TypeTuple!(S1, const S1, immutable S1))
-        foreach (Uint; TypeTuple!(U2, const U2, immutable U2))
+        foreach (Sint; AliasSeq!(S1, const S1, immutable S1))
+        foreach (Uint; AliasSeq!(U2, const U2, immutable U2))
         {
             Sint sn = -1;
             assertThrown!ConvOverflowException(to!Uint(sn));
         }
 
         // big signed to small unsigned
-        foreach (Sint; TypeTuple!(S2, const S2, immutable S2))
-        foreach (Uint; TypeTuple!(U1, const U1, immutable U1))
+        foreach (Sint; AliasSeq!(S2, const S2, immutable S2))
+        foreach (Uint; AliasSeq!(U1, const U1, immutable U1))
         {
             Sint sn = -1;
             assertThrown!ConvOverflowException(to!Uint(sn));
@@ -755,8 +755,8 @@ T toImpl(T, S)(S value)
     class C : B, I, J {}
     class D : I {}
 
-    foreach (m1; TypeTuple!(0,1,2,3,4)) // enumerate modifiers
-    foreach (m2; TypeTuple!(0,1,2,3,4)) // ditto
+    foreach (m1; AliasSeq!(0,1,2,3,4)) // enumerate modifiers
+    foreach (m2; AliasSeq!(0,1,2,3,4)) // ditto
     (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
         alias srcmod = AddModifier!m1;
         alias tgtmod = AddModifier!m2;
@@ -965,15 +965,15 @@ if (is (T == immutable) && isExactSomeString!T && is(S == enum))
     void dg()
     {
         // string to string conversion
-        alias Chars = TypeTuple!(char, wchar, dchar);
+        alias Chars = AliasSeq!(char, wchar, dchar);
         foreach (LhsC; Chars)
         {
-            alias LhStrings = TypeTuple!(LhsC[], const(LhsC)[], immutable(LhsC)[]);
+            alias LhStrings = AliasSeq!(LhsC[], const(LhsC)[], immutable(LhsC)[]);
             foreach (Lhs; LhStrings)
             {
                 foreach (RhsC; Chars)
                 {
-                    alias RhStrings = TypeTuple!(RhsC[], const(RhsC)[], immutable(RhsC)[]);
+                    alias RhStrings = AliasSeq!(RhsC[], const(RhsC)[], immutable(RhsC)[]);
                     foreach (Rhs; RhStrings)
                     {
                         Lhs s1 = to!Lhs("wyda");
@@ -1034,9 +1034,9 @@ if (is (T == immutable) && isExactSomeString!T && is(S == enum))
 {
     // Conversion representing character value with string
     alias AllChars =
-        TypeTuple!( char, const( char), immutable( char),
-                   wchar, const(wchar), immutable(wchar),
-                   dchar, const(dchar), immutable(dchar));
+        AliasSeq!( char, const( char), immutable( char),
+                  wchar, const(wchar), immutable(wchar),
+                  dchar, const(dchar), immutable(dchar));
     foreach (Char1; AllChars)
     {
         foreach (Char2; AllChars)
@@ -1063,14 +1063,14 @@ if (is (T == immutable) && isExactSomeString!T && is(S == enum))
     import std.exception;
     // Conversion representing integer values with string
 
-    foreach (Int; TypeTuple!(ubyte, ushort, uint, ulong))
+    foreach (Int; AliasSeq!(ubyte, ushort, uint, ulong))
     {
         assert(to!string(Int(0)) == "0");
         assert(to!string(Int(9)) == "9");
         assert(to!string(Int(123)) == "123");
     }
 
-    foreach (Int; TypeTuple!(byte, short, int, long))
+    foreach (Int; AliasSeq!(byte, short, int, long))
     {
         assert(to!string(Int(0)) == "0");
         assert(to!string(Int(9)) == "9");
@@ -1171,7 +1171,7 @@ unittest
     enum EC : char { a = 'x', b = 'y' }
     enum ES : string { a = "aaa", b = "bbb" }
 
-    foreach (E; TypeTuple!(EB, EU, EI, EF, EC, ES))
+    foreach (E; AliasSeq!(EB, EU, EI, EF, EC, ES))
     {
         assert(to! string(E.a) == "a"c);
         assert(to!wstring(E.a) == "a"w);
@@ -1199,7 +1199,7 @@ unittest
     assert(to!string(E.doo) == "foo");
     assert(to!string(E.bar) == "bar");
 
-    foreach (S; TypeTuple!(string, wstring, dstring, const(char[]), const(wchar[]), const(dchar[])))
+    foreach (S; AliasSeq!(string, wstring, dstring, const(char[]), const(wchar[]), const(dchar[])))
     {
         auto s1 = to!S(E.foo);
         auto s2 = to!S(E.foo);
@@ -1208,7 +1208,7 @@ unittest
         assert(s1 is s2);
     }
 
-    foreach (S; TypeTuple!(char[], wchar[], dchar[]))
+    foreach (S; AliasSeq!(char[], wchar[], dchar[]))
     {
         auto s1 = to!S(E.foo);
         auto s2 = to!S(E.foo);
@@ -1275,7 +1275,7 @@ body
 
 @safe pure nothrow unittest
 {
-    foreach (Int; TypeTuple!(uint, ulong))
+    foreach (Int; AliasSeq!(uint, ulong))
     {
         assert(to!string(Int(16), 16) == "10");
         assert(to!string(Int(15), 2u) == "1111");
@@ -1285,7 +1285,7 @@ body
         assert(to!string(Int(0x1234AF), 16u, LetterCase.lower) == "1234af");
     }
 
-    foreach (Int; TypeTuple!(int, long))
+    foreach (Int; AliasSeq!(int, long))
     {
         assert(to!string(Int(-10), 10u) == "-10");
     }
@@ -1594,9 +1594,9 @@ private void testFloatingToIntegral(Floating, Integral)()
 
 @safe pure unittest
 {
-    alias AllInts = TypeTuple!(byte, ubyte, short, ushort, int, uint, long, ulong);
-    alias AllFloats = TypeTuple!(float, double, real);
-    alias AllNumerics = TypeTuple!(AllInts, AllFloats);
+    alias AllInts = AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong);
+    alias AllFloats = AliasSeq!(float, double, real);
+    alias AllNumerics = AliasSeq!(AllInts, AllFloats);
     // test with same type
     {
         foreach (T; AllNumerics)
@@ -1670,9 +1670,9 @@ private void testFloatingToIntegral(Floating, Integral)()
 }
 /*@safe pure */unittest
 {
-    alias AllInts = TypeTuple!(byte, ubyte, short, ushort, int, uint, long, ulong);
-    alias AllFloats = TypeTuple!(float, double, real);
-    alias AllNumerics = TypeTuple!(AllInts, AllFloats);
+    alias AllInts = AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong);
+    alias AllFloats = AliasSeq!(float, double, real);
+    alias AllNumerics = AliasSeq!(AllInts, AllFloats);
     // test conversions to string
     {
         foreach (T; AllNumerics)
@@ -1747,7 +1747,7 @@ T toImpl(T, S)(S value, uint radix)
 
 @safe pure unittest
 {
-    foreach (Str; TypeTuple!(string, wstring, dstring))
+    foreach (Str; AliasSeq!(string, wstring, dstring))
     {
         Str a = "123";
         assert(to!int(a) == 123);
@@ -1828,7 +1828,7 @@ unittest
 {
     import std.exception;
     // boundary values
-    foreach (Int; TypeTuple!(byte, ubyte, short, ushort, int, uint))
+    foreach (Int; AliasSeq!(byte, ubyte, short, ushort, int, uint))
     {
         assert(roundTo!Int(Int.min - 0.4L) == Int.min);
         assert(roundTo!Int(Int.max + 0.4L) == Int.max);
@@ -2007,7 +2007,7 @@ Lerr:
 
 @safe pure unittest
 {
-    foreach (Int; TypeTuple!(byte, ubyte, short, ushort, int, uint, long, ulong))
+    foreach (Int; AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong))
     {
         {
             assert(to!Int("0") == 0);
@@ -2103,7 +2103,7 @@ Lerr:
 {
     import std.exception;
     // parsing error check
-    foreach (Int; TypeTuple!(byte, ubyte, short, ushort, int, uint, long, ulong))
+    foreach (Int; AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong))
     {
         {
             immutable string[] errors1 =
@@ -2142,7 +2142,7 @@ Lerr:
     }
 
     // positive overflow check
-    foreach (i, Int; TypeTuple!(byte, ubyte, short, ushort, int, uint, long, ulong))
+    foreach (i, Int; AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong))
     {
         immutable string[] errors =
         [
@@ -2160,7 +2160,7 @@ Lerr:
     }
 
     // negative overflow check
-    foreach (i, Int; TypeTuple!(byte, short, int, long))
+    foreach (i, Int; AliasSeq!(byte, short, int, long))
     {
         immutable string[] errors =
         [
@@ -2355,7 +2355,7 @@ unittest
     enum EC : char { a = 'a', b = 'b', c = 'c' }
     enum ES : string { a = "aaa", b = "bbb", c = "ccc" }
 
-    foreach (E; TypeTuple!(EB, EU, EI, EF, EC, ES))
+    foreach (E; AliasSeq!(EB, EU, EI, EF, EC, ES))
     {
         assert(to!E("a"c) == E.a);
         assert(to!E("b"w) == E.b);
@@ -2804,7 +2804,7 @@ unittest
         return f;
     }
 
-    foreach (Float; TypeTuple!(float, double, real))
+    foreach (Float; AliasSeq!(float, double, real))
     {
         assert(to!Float("123") == Literal!Float(123));
         assert(to!Float("+123") == Literal!Float(+123));
@@ -3060,9 +3060,9 @@ Target parse(Target, Source)(ref Source s)
 
 @safe pure unittest
 {
-    foreach (Str; TypeTuple!(string, wstring, dstring))
+    foreach (Str; AliasSeq!(string, wstring, dstring))
     {
-        foreach (Char; TypeTuple!(char, wchar, dchar))
+        foreach (Char; AliasSeq!(char, wchar, dchar))
         {
             static if (is(Unqual!Char == dchar) ||
                        Char.sizeof == ElementEncodingType!Str.sizeof)
@@ -5204,28 +5204,28 @@ unittest
 
 unittest
 {
-    foreach(T; TypeTuple!(byte, ubyte))
+    foreach(T; AliasSeq!(byte, ubyte))
     {
         static assert(is(typeof(unsigned(cast(T)1)) == ubyte));
         static assert(is(typeof(unsigned(cast(const T)1)) == ubyte));
         static assert(is(typeof(unsigned(cast(immutable T)1)) == ubyte));
     }
 
-    foreach(T; TypeTuple!(short, ushort))
+    foreach(T; AliasSeq!(short, ushort))
     {
         static assert(is(typeof(unsigned(cast(T)1)) == ushort));
         static assert(is(typeof(unsigned(cast(const T)1)) == ushort));
         static assert(is(typeof(unsigned(cast(immutable T)1)) == ushort));
     }
 
-    foreach(T; TypeTuple!(int, uint))
+    foreach(T; AliasSeq!(int, uint))
     {
         static assert(is(typeof(unsigned(cast(T)1)) == uint));
         static assert(is(typeof(unsigned(cast(const T)1)) == uint));
         static assert(is(typeof(unsigned(cast(immutable T)1)) == uint));
     }
 
-    foreach(T; TypeTuple!(long, ulong))
+    foreach(T; AliasSeq!(long, ulong))
     {
         static assert(is(typeof(unsigned(cast(T)1)) == ulong));
         static assert(is(typeof(unsigned(cast(const T)1)) == ulong));
@@ -5242,7 +5242,7 @@ auto unsigned(T)(T x) if (isSomeChar!T)
 
 unittest
 {
-    foreach(T; TypeTuple!(char, wchar, dchar))
+    foreach(T; AliasSeq!(char, wchar, dchar))
     {
         static assert(is(typeof(unsigned(cast(T)'A')) == T));
         static assert(is(typeof(unsigned(cast(const T)'A')) == T));
@@ -5278,28 +5278,28 @@ unittest
 
 unittest
 {
-    foreach(T; TypeTuple!(byte, ubyte))
+    foreach(T; AliasSeq!(byte, ubyte))
     {
         static assert(is(typeof(signed(cast(T)1)) == byte));
         static assert(is(typeof(signed(cast(const T)1)) == byte));
         static assert(is(typeof(signed(cast(immutable T)1)) == byte));
     }
 
-    foreach(T; TypeTuple!(short, ushort))
+    foreach(T; AliasSeq!(short, ushort))
     {
         static assert(is(typeof(signed(cast(T)1)) == short));
         static assert(is(typeof(signed(cast(const T)1)) == short));
         static assert(is(typeof(signed(cast(immutable T)1)) == short));
     }
 
-    foreach(T; TypeTuple!(int, uint))
+    foreach(T; AliasSeq!(int, uint))
     {
         static assert(is(typeof(signed(cast(T)1)) == int));
         static assert(is(typeof(signed(cast(const T)1)) == int));
         static assert(is(typeof(signed(cast(immutable T)1)) == int));
     }
 
-    foreach(T; TypeTuple!(long, ulong))
+    foreach(T; AliasSeq!(long, ulong))
     {
         static assert(is(typeof(signed(cast(T)1)) == long));
         static assert(is(typeof(signed(cast(const T)1)) == long));

--- a/std/csv.d
+++ b/std/csv.d
@@ -1080,7 +1080,7 @@ public:
                     scope(exit) colIndex++;
                     if (indices.length > 0)
                     {
-                        foreach(ti, ToType; FieldTypeTuple!(Contents))
+                        foreach(ti, ToType; Fields!(Contents))
                         {
                             if (indices[ti] == colIndex)
                             {
@@ -1091,7 +1091,7 @@ public:
                     }
                     else
                     {
-                        foreach(ti, ToType; FieldTypeTuple!(Contents))
+                        foreach(ti, ToType; Fields!(Contents))
                         {
                             if (ti == colIndex)
                             {

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -347,8 +347,8 @@ public:
         assert(norm1 <= norm2, format("%s %s", norm1, norm2));
         assert(abs(norm1 - norm2) <= seconds(2));
 
-        import std.typetuple;
-        foreach(ct; TypeTuple!(ClockType.coarse, ClockType.precise, ClockType.second))
+        import std.meta : AliasSeq;
+        foreach(ct; AliasSeq!(ClockType.coarse, ClockType.precise, ClockType.second))
         {
             scope(failure) writefln("ClockType.%s", ct);
             auto value1 = Clock.currTime!ct;
@@ -467,8 +467,8 @@ public:
         assert(norm1 <= norm2, format("%s %s", norm1, norm2));
         assert(abs(norm1 - norm2) <= limit);
 
-        import std.typetuple;
-        foreach(ct; TypeTuple!(ClockType.coarse, ClockType.precise, ClockType.second))
+        import std.meta : AliasSeq;
+        foreach(ct; AliasSeq!(ClockType.coarse, ClockType.precise, ClockType.second))
         {
             scope(failure) writefln("ClockType.%s", ct);
             auto value1 = Clock.currStdTime!ct;
@@ -2489,8 +2489,8 @@ public:
     unittest
     {
         assert(SysTime(DateTime(1970, 1, 1), UTC()).toUnixTime() == 0);
-        import std.typetuple : TypeTuple;
-        foreach(units; TypeTuple!("hnsecs", "usecs", "msecs"))
+        import std.meta : AliasSeq;
+        foreach(units; AliasSeq!("hnsecs", "usecs", "msecs"))
             assert(SysTime(DateTime(1970, 1, 1, 0, 0, 0), dur!units(1), UTC()).toUnixTime() == 0);
         assert(SysTime(DateTime(1970, 1, 1, 0, 0, 1), UTC()).toUnixTime() == 1);
         assert(SysTime(DateTime(1969, 12, 31, 23, 59, 59), hnsecs(9_999_999), UTC()).toUnixTime() == 0);
@@ -31276,10 +31276,10 @@ unittest
     import std.algorithm;
     import std.ascii;
     import std.format : format;
+    import std.meta;
     import std.range;
     import std.string;
     import std.typecons;
-    import std.typetuple;
 
     static struct Rand3Letters
     {
@@ -31294,10 +31294,10 @@ unittest
         static auto start() { Rand3Letters retval; retval.popFront(); return retval; }
     }
 
-    foreach(cr; TypeTuple!(function(string a){return cast(char[])a;},
-                           function(string a){return cast(ubyte[])a;},
-                           function(string a){return a;},
-                           function(string a){return map!(b => cast(char)b)(a.representation);}))
+    foreach(cr; AliasSeq!(function(string a){return cast(char[])a;},
+                          function(string a){return cast(ubyte[])a;},
+                          function(string a){return a;},
+                          function(string a){return map!(b => cast(char)b)(a.representation);}))
     (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
         scope(failure) writeln(typeof(cr).stringof);
         alias test = testParse822!cr;
@@ -31545,10 +31545,10 @@ unittest
     import std.algorithm;
     import std.ascii;
     import std.format : format;
+    import std.meta;
     import std.range;
     import std.string;
     import std.typecons;
-    import std.typetuple;
 
     auto std1 = SysTime(DateTime(2012, 12, 21, 13, 14, 15), UTC());
     auto std2 = SysTime(DateTime(2012, 12, 21, 13, 14, 0), UTC());
@@ -31559,10 +31559,10 @@ unittest
     auto tooLate1 = SysTime(Date(10_000, 1, 1), UTC());
     auto tooLate2 = SysTime(DateTime(12_007, 12, 31, 12, 22, 19), UTC());
 
-    foreach(cr; TypeTuple!(function(string a){return cast(char[])a;},
-                           function(string a){return cast(ubyte[])a;},
-                           function(string a){return a;},
-                           function(string a){return map!(b => cast(char)b)(a.representation);}))
+    foreach(cr; AliasSeq!(function(string a){return cast(char[])a;},
+                          function(string a){return cast(ubyte[])a;},
+                          function(string a){return a;},
+                          function(string a){return map!(b => cast(char)b)(a.representation);}))
     (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
         scope(failure) writeln(typeof(cr).stringof);
         alias test = testParse822!cr;
@@ -31872,9 +31872,9 @@ private int cmpTimeUnitsCTFE(string lhs, string rhs) @safe pure nothrow
 unittest
 {
     import std.format : format;
+    import std.meta;
     import std.string;
     import std.typecons;
-    import std.typetuple;
 
     static string genTest(size_t index)
     {
@@ -31891,7 +31891,7 @@ unittest
     }
 
     static assert(timeStrings.length == 10);
-    foreach(n; TypeTuple!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9))
+    foreach(n; AliasSeq!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9))
         mixin(genTest(n));
 }
 
@@ -33000,12 +33000,12 @@ R _stripCFWS(R)(R range)
 unittest
 {
     import std.algorithm;
+    import std.meta;
     import std.string;
     import std.typecons;
-    import std.typetuple;
 
-    foreach(cr; TypeTuple!(function(string a){return cast(ubyte[])a;},
-                           function(string a){return map!(b => cast(char)b)(a.representation);}))
+    foreach(cr; AliasSeq!(function(string a){return cast(ubyte[])a;},
+                          function(string a){return map!(b => cast(char)b)(a.representation);}))
     (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
         scope(failure) writeln(typeof(cr).stringof);
 

--- a/std/digest/digest.d
+++ b/std/digest/digest.d
@@ -63,8 +63,8 @@ $(TR $(TDNW Implementation helpers) $(TD $(MYREF digestLength) $(MYREF WrapperDi
  */
 module std.digest.digest;
 
+import std.meta : allSatisfy;
 import std.traits;
-import std.typetuple : allSatisfy;
 public import std.ascii : LetterCase;
 
 

--- a/std/digest/hmac.d
+++ b/std/digest/hmac.d
@@ -20,7 +20,7 @@ Source: $(PHOBOSSRC std/digest/_hmac.d)
 module std.digest.hmac;
 
 import std.digest.digest : isDigest, hasBlockSize, isDigestibleRange, DigestType;
-import std.typetuple : allSatisfy;
+import std.meta : allSatisfy;
 
 /**
  * Template API HMAC implementation.

--- a/std/encoding.d
+++ b/std/encoding.d
@@ -2285,14 +2285,14 @@ unittest
 
 unittest
 {
+    import std.meta;
     import std.range;
-    import std.typetuple;
     {
         import std.conv : to;
 
         string asciiCharString = to!string(iota(0, 128, 1));
 
-        alias Types = TypeTuple!(string, Latin1String, Latin2String, AsciiString, Windows1250String, Windows1252String, dstring, wstring);
+        alias Types = AliasSeq!(string, Latin1String, Latin2String, AsciiString, Windows1250String, Windows1252String, dstring, wstring);
         foreach(S; Types)
             foreach(D; Types)
             {
@@ -2307,7 +2307,7 @@ unittest
     }
     {
         string czechChars = "Příliš žluťoučký kůň úpěl ďábelské ódy.";
-        alias Types = TypeTuple!(string, dstring, wstring);
+        alias Types = AliasSeq!(string, dstring, wstring);
         foreach(S; Types)
             foreach(D; Types)
             {

--- a/std/exception.d
+++ b/std/exception.d
@@ -442,13 +442,13 @@ unittest
 // purity and safety inference test
 unittest
 {
-    import std.typetuple;
+    import std.meta : AliasSeq;
 
-    foreach (EncloseSafe; TypeTuple!(false, true))
-    foreach (EnclosePure; TypeTuple!(false, true))
+    foreach (EncloseSafe; AliasSeq!(false, true))
+    foreach (EnclosePure; AliasSeq!(false, true))
     {
-        foreach (BodySafe; TypeTuple!(false, true))
-        foreach (BodyPure; TypeTuple!(false, true))
+        foreach (BodySafe; AliasSeq!(false, true))
+        foreach (BodyPure; AliasSeq!(false, true))
         {
             enum code =
                 "delegate void() " ~
@@ -1226,7 +1226,7 @@ unittest
     //To check the class payload itself, iterate on its members:
     ()
     {
-        foreach (index, _; FieldTypeTuple!C)
+        foreach (index, _; Fields!C)
             if (doesPointTo(a.tupleof[index], i))
                 return;
         assert(0);

--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -162,7 +162,7 @@ template stateSize(T)
     static if (is(T == class) || is(T == interface))
         enum stateSize = __traits(classInstanceSize, T);
     else static if (is(T == struct) || is(T == union))
-        enum stateSize = FieldTypeTuple!T.length || isNested!T ? T.sizeof : 0;
+        enum stateSize = Fields!T.length || isNested!T ? T.sizeof : 0;
     else static if (is(T == void))
         enum size_t stateSize = 0;
     else
@@ -560,12 +560,12 @@ Forwards each of the methods in `funs` (if defined) to `member`.
 */
 /*package*/ string forwardToMember(string member, string[] funs...)
 {
-    string result = "    import std.traits : hasMember, ParameterTypeTuple;\n";
+    string result = "    import std.traits : hasMember, Parameters;\n";
     foreach (fun; funs)
     {
         result ~= "
     static if (hasMember!(typeof("~member~"), `"~fun~"`))
-    auto ref "~fun~"(ParameterTypeTuple!(typeof("~member~"."~fun~")) args)
+    auto ref "~fun~"(Parameters!(typeof("~member~"."~fun~")) args)
     {
         return "~member~"."~fun~"(args);
     }\n";

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -250,7 +250,7 @@ unittest
 }
 
 import std.algorithm, std.conv, std.exception, std.range, std.traits,
-    std.typecons, std.typetuple;
+    std.typecons;
 version(unittest) import std.random, std.stdio;
 
 /**

--- a/std/file.d
+++ b/std/file.d
@@ -23,11 +23,11 @@ import core.stdc.stdlib, core.stdc.string, core.stdc.errno;
 import std.conv;
 import std.datetime;
 import std.exception;
+import std.meta;
 import std.path;
 import std.range.primitives;
 import std.traits;
 import std.typecons;
-import std.typetuple;
 import std.internal.cstring;
 
 version (Windows)
@@ -339,7 +339,7 @@ version (Windows) private void[] readImpl(const(char)[] name, const(FSChar)* nam
     }
 
     alias defaults =
-        TypeTuple!(GENERIC_READ,
+        AliasSeq!(GENERIC_READ,
             FILE_SHARE_READ | FILE_SHARE_WRITE, (SECURITY_ATTRIBUTES*).init,
             OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN,
             HANDLE.init);
@@ -509,7 +509,7 @@ version(Windows) private void writeImpl(const(char)[] name, const(FSChar)* namez
     if (append)
     {
         alias defaults =
-            TypeTuple!(GENERIC_WRITE, 0, null, OPEN_ALWAYS,
+            AliasSeq!(GENERIC_WRITE, 0, null, OPEN_ALWAYS,
                 FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN,
                 HANDLE.init);
 
@@ -526,7 +526,7 @@ version(Windows) private void writeImpl(const(char)[] name, const(FSChar)* namez
     else // write
     {
         alias defaults =
-            TypeTuple!(GENERIC_WRITE, 0, null, CREATE_ALWAYS,
+            AliasSeq!(GENERIC_WRITE, 0, null, CREATE_ALWAYS,
                 FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN,
                 HANDLE.init);
 
@@ -982,14 +982,14 @@ void setTimes(R)(R name,
         const ta = SysTimeToFILETIME(accessTime);
         const tm = SysTimeToFILETIME(modificationTime);
         alias defaults =
-            TypeTuple!(GENERIC_WRITE,
-                         0,
-                         null,
-                         OPEN_EXISTING,
-                         FILE_ATTRIBUTE_NORMAL |
-                         FILE_ATTRIBUTE_DIRECTORY |
-                         FILE_FLAG_BACKUP_SEMANTICS,
-                         HANDLE.init);
+            AliasSeq!(GENERIC_WRITE,
+                      0,
+                      null,
+                      OPEN_EXISTING,
+                      FILE_ATTRIBUTE_NORMAL |
+                      FILE_ATTRIBUTE_DIRECTORY |
+                      FILE_FLAG_BACKUP_SEMANTICS,
+                      HANDLE.init);
         auto h = trustedCreateFileW(namez, defaults);
 
         static if (isNarrowString!R && is(Unqual!(ElementEncodingType!R) == char))

--- a/std/format.d
+++ b/std/format.d
@@ -62,9 +62,9 @@ module std.format;
 
 import core.vararg;
 import std.exception;
+import std.meta;
 import std.range.primitives;
 import std.traits;
-import std.typetuple;
 
 version(CRuntime_DigitalMars)
 {
@@ -1785,7 +1785,7 @@ unittest
 @safe /*pure*/ unittest     // formatting floating point values is now impure
 {
     import std.conv : to;
-    foreach (T; TypeTuple!(float, double, real))
+    foreach (T; AliasSeq!(float, double, real))
     {
         formatTest( to!(          T)(5.5), "5.5" );
         formatTest( to!(    const T)(5.5), "5.5" );
@@ -1839,13 +1839,13 @@ if (is(Unqual!T : creal) && !is(T == enum) && !hasToString!(T, Char))
 @safe /*pure*/ unittest     // formatting floating point values is now impure
 {
     import std.conv : to;
-    foreach (T; TypeTuple!(cfloat, cdouble, creal))
+    foreach (T; AliasSeq!(cfloat, cdouble, creal))
     {
         formatTest( to!(          T)(1 + 1i), "1+1i" );
         formatTest( to!(    const T)(1 + 1i), "1+1i" );
         formatTest( to!(immutable T)(1 + 1i), "1+1i" );
     }
-    foreach (T; TypeTuple!(cfloat, cdouble, creal))
+    foreach (T; AliasSeq!(cfloat, cdouble, creal))
     {
         formatTest( to!(          T)(0 - 3i), "0-3i" );
         formatTest( to!(    const T)(0 - 3i), "0-3i" );
@@ -1890,7 +1890,7 @@ if (is(Unqual!T : ireal) && !is(T == enum) && !hasToString!(T, Char))
 @safe /*pure*/ unittest     // formatting floating point values is now impure
 {
     import std.conv : to;
-    foreach (T; TypeTuple!(ifloat, idouble, ireal))
+    foreach (T; AliasSeq!(ifloat, idouble, ireal))
     {
         formatTest( to!(          T)(1i), "1i" );
         formatTest( to!(    const T)(1i), "1i" );
@@ -1936,7 +1936,7 @@ if (is(CharTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
     }
     else
     {
-        alias U = TypeTuple!(ubyte, ushort, uint)[CharTypeOf!T.sizeof/2];
+        alias U = AliasSeq!(ubyte, ushort, uint)[CharTypeOf!T.sizeof/2];
         formatValue(w, cast(U) val, f);
     }
 }
@@ -2262,7 +2262,7 @@ unittest
 unittest
 {
     // string literal from valid UTF sequence is encoding free.
-    foreach (StrType; TypeTuple!(string, wstring, dstring))
+    foreach (StrType; AliasSeq!(string, wstring, dstring))
     {
         // Valid and printable (ASCII)
         formatTest( [cast(StrType)"hello"],
@@ -4172,8 +4172,8 @@ unittest
 
     auto stream = appender!(char[])();
     alias AllNumerics =
-        TypeTuple!(byte, ubyte, short, ushort, int, uint, long, ulong,
-                   float, double, real);
+        AliasSeq!(byte, ubyte, short, ushort, int, uint, long, ulong,
+                  float, double, real);
     foreach (T; AllNumerics)
     {
         T value = 1;

--- a/std/internal/test/dummyrange.d
+++ b/std/internal/test/dummyrange.d
@@ -4,8 +4,8 @@ Used with the dummy ranges for testing higher order ranges.
 */
 module std.internal.test.dummyrange;
 
+import std.meta;
 import std.typecons;
-import std.typetuple;
 import std.range.primitives;
 
 enum RangeType
@@ -157,7 +157,7 @@ struct DummyRange(ReturnBy _r, Length _l, RangeType _rt)
 
 enum dummyLength = 10;
 
-alias AllDummyRanges = TypeTuple!(
+alias AllDummyRanges = AliasSeq!(
     DummyRange!(ReturnBy.Reference, Length.Yes, RangeType.Forward),
     DummyRange!(ReturnBy.Reference, Length.Yes, RangeType.Bidirectional),
     DummyRange!(ReturnBy.Reference, Length.Yes, RangeType.Random),

--- a/std/math.d
+++ b/std/math.d
@@ -549,14 +549,14 @@ auto abs(Num)(Num y) @safe pure nothrow @nogc
 
 @safe pure nothrow @nogc unittest
 {
-    import std.typetuple;
-    foreach (T; TypeTuple!(float, double, real))
+    import std.meta : AliasSeq;
+    foreach (T; AliasSeq!(float, double, real))
     {
         T f = 3;
         assert(abs(f) == f);
         assert(abs(-f) == f);
     }
-    foreach (T; TypeTuple!(cfloat, cdouble, creal))
+    foreach (T; AliasSeq!(cfloat, cdouble, creal))
     {
         T f = -12+3i;
         assert(abs(f) == hypot(f.re, f.im));
@@ -2556,9 +2556,9 @@ unittest
 
 unittest
 {
-    import std.typetuple, std.typecons;
+    import std.meta, std.typecons;
 
-    foreach (T; TypeTuple!(real, double, float))
+    foreach (T; AliasSeq!(real, double, float))
     {
         Tuple!(T, T, int)[] vals =     // x,frexp,exp
             [
@@ -2611,9 +2611,9 @@ unittest
 
 unittest
 {
-    import std.typetuple: TypeTuple;
+    import std.meta: AliasSeq;
     void foo() {
-        foreach (T; TypeTuple!(real, double, float))
+        foreach (T; AliasSeq!(real, double, float))
         {
             int exp;
             const T a = 1;
@@ -2836,8 +2836,8 @@ alias FP_ILOGBNAN = core.stdc.math.FP_ILOGBNAN;
 
 @trusted nothrow @nogc unittest
 {
-    import std.typetuple, std.typecons;
-    foreach (F; TypeTuple!(float, double, real))
+    import std.meta, std.typecons;
+    foreach (F; AliasSeq!(float, double, real))
     {
         alias T = Tuple!(F, int);
         T[13] vals =   // x, ilogb(x)
@@ -2909,8 +2909,8 @@ float ldexp(float n, int exp) @safe pure nothrow @nogc { return ldexp(cast(real)
 ///
 @nogc @safe pure nothrow unittest
 {
-    import std.typetuple;
-    foreach(T; TypeTuple!(float, double, real))
+    import std.meta;
+    foreach(T; AliasSeq!(float, double, real))
     {
         T r;
 
@@ -4924,9 +4924,9 @@ bool isNaN(X)(X x) @nogc @trusted pure nothrow
 
 @safe pure nothrow @nogc unittest
 {
-    import std.typetuple;
+    import std.meta;
 
-    foreach(T; TypeTuple!(float, double, real))
+    foreach(T; AliasSeq!(float, double, real))
     {
         // CTFE-able tests
         assert(isNaN(T.init));
@@ -5107,9 +5107,9 @@ bool isSubnormal(X)(X x) @trusted pure nothrow @nogc
 ///
 @safe pure nothrow @nogc unittest
 {
-    import std.typetuple;
+    import std.meta;
 
-    foreach (T; TypeTuple!(float, double, real))
+    foreach (T; AliasSeq!(float, double, real))
     {
         T f;
         for (f = 1.0; !isSubnormal(f); f /= 2)
@@ -5345,11 +5345,11 @@ R copysign(R, X)(X to, R from) @trusted pure nothrow @nogc
 
 @safe pure nothrow @nogc unittest
 {
-    import std.typetuple;
+    import std.meta;
 
-    foreach (X; TypeTuple!(float, double, real, int, long))
+    foreach (X; AliasSeq!(float, double, real, int, long))
     {
-        foreach (Y; TypeTuple!(float, double, real))
+        foreach (Y; AliasSeq!(float, double, real))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             X x = 21;
             Y y = 23.8;
@@ -7263,8 +7263,8 @@ unittest
 
 unittest
 {
-    import std.typetuple;
-    foreach (T; TypeTuple!(float, double, real))
+    import std.meta;
+    foreach (T; AliasSeq!(float, double, real))
     {
         T[] values = [-cast(T)NaN(20), -cast(T)NaN(10), -T.nan, -T.infinity,
                       -T.max, -T.max / 2, T(-16.0), T(-1.0).nextDown,

--- a/std/meta.d
+++ b/std/meta.d
@@ -18,14 +18,14 @@
  *      Modern C++ Design),
  *   Andrei Alexandrescu (Addison-Wesley Professional, 2001)
  * Macros:
- *  WIKI = Phobos/StdTypeTuple
+ *  WIKI = Phobos/StdMeta
  *
  * Copyright: Copyright Digital Mars 2005 - 2015.
  * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:
  *     $(WEB digitalmars.com, Walter Bright),
  *     $(WEB klickverbot.at, David Nadlinger)
- * Source:    $(PHOBOSSRC std/_typetuple.d)
+ * Source:    $(PHOBOSSRC std/_meta.d)
  */
 
 module std.meta;

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -165,12 +165,12 @@ import std.conv;
 import std.datetime;
 import std.encoding;
 import std.exception;
+import std.meta;
 import std.regex;
 import std.socket : InternetAddress;
 import std.string;
 import std.traits;
 import std.typecons;
-import std.typetuple;
 
 import std.internal.cstring;
 
@@ -3982,7 +3982,7 @@ struct Curl
         copy.stopped = false;
 
         with (CurlOption) {
-            auto tt = TypeTuple!(file, writefunction, writeheader,
+            auto tt = AliasSeq!(file, writefunction, writeheader,
                 headerfunction, infile, readfunction, ioctldata, ioctlfunction,
                 seekdata, seekfunction, sockoptdata, sockoptfunction,
                 opensocketdata, opensocketfunction, progressdata,

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -114,9 +114,9 @@ private template CustomFloatParams(uint bits)
 
 private template CustomFloatParams(uint precision, uint exponentWidth, CustomFloatFlags flags)
 {
-    import std.typetuple : TypeTuple;
+    import std.meta : AliasSeq;
     alias CustomFloatParams =
-        TypeTuple!(
+        AliasSeq!(
             precision,
             exponentWidth,
             flags,
@@ -175,7 +175,7 @@ struct CustomFloat(uint             precision,  // fraction bits (23 for float)
         precision + exponentWidth > 0)
 {
     import std.bitmanip;
-    import std.typetuple;
+    import std.meta;
 private:
     // get the correct unsigned bitfield type to support > 32 bits
     template uType(uint bits)
@@ -631,9 +631,9 @@ public:
 
 unittest
 {
-    import std.typetuple;
+    import std.meta;
     alias FPTypes =
-        TypeTuple!(
+        AliasSeq!(
             CustomFloat!(5, 10),
             CustomFloat!(5, 11, CustomFloatFlags.ieee ^ CustomFloatFlags.signed),
             CustomFloat!(1, 15, CustomFloatFlags.ieee ^ CustomFloatFlags.signed),
@@ -1448,8 +1448,8 @@ euclideanDistance(Range1, Range2, F)(Range1 a, Range2 b, F limit)
 
 unittest
 {
-    import std.typetuple;
-    foreach(T; TypeTuple!(double, const double, immutable double))
+    import std.meta : AliasSeq;
+    foreach(T; AliasSeq!(double, const double, immutable double))
     {
         T[] a = [ 1.0, 2.0, ];
         T[] b = [ 4.0, 6.0, ];
@@ -1538,8 +1538,8 @@ dotProduct(F1, F2)(in F1[] avector, in F2[] bvector)
 
 unittest
 {
-    import std.typetuple;
-    foreach(T; TypeTuple!(double, const double, immutable double))
+    import std.meta : AliasSeq;
+    foreach(T; AliasSeq!(double, const double, immutable double))
     {
         T[] a = [ 1.0, 2.0, ];
         T[] b = [ 4.0, 6.0, ];
@@ -1582,8 +1582,8 @@ cosineSimilarity(Range1, Range2)(Range1 a, Range2 b)
 
 unittest
 {
-    import std.typetuple;
-    foreach(T; TypeTuple!(double, const double, immutable double))
+    import std.meta : AliasSeq;
+    foreach(T; AliasSeq!(double, const double, immutable double))
     {
         T[] a = [ 1.0, 2.0, ];
         T[] b = [ 4.0, 3.0, ];
@@ -1732,8 +1732,8 @@ if (isInputRange!Range &&
 
 unittest
 {
-    import std.typetuple;
-    foreach(T; TypeTuple!(double, const double, immutable double))
+    import std.meta : AliasSeq;
+    foreach(T; AliasSeq!(double, const double, immutable double))
     {
         T[] p = [ 0.0, 0, 0, 1 ];
         assert(entropy(p) == 0);

--- a/std/path.d
+++ b/std/path.d
@@ -3288,8 +3288,8 @@ unittest
     else version (Posix) valid ~= pfdep;
     else static assert (0);
 
-    import std.typetuple;
-    foreach (T; TypeTuple!(char[], const(char)[], string, wchar[],
+    import std.meta : AliasSeq;
+    foreach (T; AliasSeq!(char[], const(char)[], string, wchar[],
         const(wchar)[], wstring, dchar[], const(dchar)[], dstring))
     {
         foreach (fn; valid)

--- a/std/random.d
+++ b/std/random.d
@@ -66,9 +66,9 @@ import std.traits;
 
 version(unittest)
 {
-    static import std.typetuple;
-    package alias PseudoRngTypes = std.typetuple.TypeTuple!(MinstdRand0, MinstdRand, Mt19937, Xorshift32, Xorshift64,
-                                              Xorshift96, Xorshift128, Xorshift160, Xorshift192);
+    static import std.meta;
+    package alias PseudoRngTypes = std.meta.AliasSeq!(MinstdRand0, MinstdRand, Mt19937, Xorshift32, Xorshift64,
+                                                      Xorshift96, Xorshift128, Xorshift160, Xorshift192);
 }
 
 // Segments of the code in this file Copyright (c) 1997 by Rick Booth
@@ -515,7 +515,7 @@ unittest
     assert(rnd.front == 399268537);
 
     // Check .save works
-    foreach (Type; std.typetuple.TypeTuple!(MinstdRand0, MinstdRand))
+    foreach (Type; std.meta.AliasSeq!(MinstdRand0, MinstdRand))
     {
         auto rnd1 = Type(unpredictableSeed);
         auto rnd2 = rnd1.save;
@@ -795,7 +795,7 @@ unittest
 {
     import std.range;
     // Check .save works
-    foreach(Type; std.typetuple.TypeTuple!(Mt19937))
+    foreach(Type; std.meta.AliasSeq!(Mt19937))
     {
         auto gen1 = Type(unpredictableSeed);
         auto gen2 = gen1.save;
@@ -813,7 +813,7 @@ unittest
                                                         0x9d2c5680, 15,
                                                         0xefc60000, 18);
 
-    foreach (R; std.typetuple.TypeTuple!(MT!(uint, 32), MT!(ulong, 32), MT!(ulong, 48), MT!(ulong, 64)))
+    foreach (R; std.meta.AliasSeq!(MT!(uint, 32), MT!(ulong, 32), MT!(ulong, 48), MT!(ulong, 64)))
         auto a = R();
 }
 
@@ -1068,7 +1068,7 @@ unittest
         [0UL, 246875399, 3690007200, 1264581005, 3906711041, 1866187943, 2481925219, 2464530826, 1604040631, 3653403911]
     ];
 
-    alias XorshiftTypes = std.typetuple.TypeTuple!(Xorshift32, Xorshift64, Xorshift96, Xorshift128, Xorshift160, Xorshift192);
+    alias XorshiftTypes = std.meta.AliasSeq!(Xorshift32, Xorshift64, Xorshift96, Xorshift128, Xorshift160, Xorshift192);
 
     foreach (I, Type; XorshiftTypes)
     {
@@ -1424,7 +1424,7 @@ if ((isIntegral!(CommonType!(T1, T2)) || isSomeChar!(CommonType!(T1, T2))) &&
     auto c = uniform(0.0, 1.0);
     assert(0 <= c && c < 1);
 
-    foreach (T; std.typetuple.TypeTuple!(char, wchar, dchar, byte, ubyte, short, ushort,
+    foreach (T; std.meta.AliasSeq!(char, wchar, dchar, byte, ubyte, short, ushort,
                           int, uint, long, ulong, float, double, real))
     {
         T lo = 0, hi = 100;
@@ -1478,7 +1478,7 @@ if ((isIntegral!(CommonType!(T1, T2)) || isSomeChar!(CommonType!(T1, T2))) &&
 
     auto reproRng = Xorshift(239842);
 
-    foreach (T; std.typetuple.TypeTuple!(char, wchar, dchar, byte, ubyte, short,
+    foreach (T; std.meta.AliasSeq!(char, wchar, dchar, byte, ubyte, short,
                           ushort, int, uint, long, ulong))
     {
         T lo = T.min + 10, hi = T.max - 10;
@@ -1597,7 +1597,7 @@ if (!is(T == enum) && (isIntegral!T || isSomeChar!T))
 
 @safe unittest
 {
-    foreach(T; std.typetuple.TypeTuple!(char, wchar, dchar, byte, ubyte, short, ushort,
+    foreach(T; std.meta.AliasSeq!(char, wchar, dchar, byte, ubyte, short, ushort,
                           int, uint, long, ulong))
     {
         T init = uniform!T();
@@ -1744,11 +1744,11 @@ body
 
 @safe unittest
 {
-    import std.typetuple;
+    import std.meta;
     foreach (UniformRNG; PseudoRngTypes)
     {
 
-        foreach (T; std.typetuple.TypeTuple!(float, double, real))
+        foreach (T; std.meta.AliasSeq!(float, double, real))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             UniformRNG rng = UniformRNG(unpredictableSeed);
 
@@ -2208,7 +2208,7 @@ unittest
     import std.algorithm;
     import std.conv;
     int[] a = [ 0, 1, 2, 3, 4, 5, 6, 7, 8 ];
-    foreach (UniformRNG; std.typetuple.TypeTuple!(void, PseudoRngTypes))
+    foreach (UniformRNG; std.meta.AliasSeq!(void, PseudoRngTypes))
     {
         static if (is(UniformRNG == void))
         {

--- a/std/range/interfaces.d
+++ b/std/range/interfaces.d
@@ -68,9 +68,9 @@ to $(WEB fantascienza.net/leonardo/so/, Leonardo Maffi).
 */
 module std.range.interfaces;
 
+import std.meta;
 import std.range.primitives;
 import std.traits;
-import std.typetuple;
 
 /**These interfaces are intended to provide virtual function-based wrappers
  * around input ranges with element type E.  This is useful where a well-defined

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -176,8 +176,8 @@ public import std.range.interfaces;
 public import std.array;
 public import std.typecons : Flag, Yes, No;
 
+import std.meta;
 import std.traits;
-import std.typetuple;
 
 
 /**
@@ -855,7 +855,7 @@ if (Ranges.length > 0 &&
                 }
             }
 
-            import std.typetuple : anySatisfy;
+            import std.meta : anySatisfy;
 
             static if (anySatisfy!(isInfinite, R))
             {
@@ -2507,22 +2507,22 @@ auto takeNone(R)(R range)
 
     import std.format : format;
 
-    foreach(range; TypeTuple!([1, 2, 3, 4, 5],
-                              "hello world",
-                              "hello world"w,
-                              "hello world"d,
-                              SliceStruct([1, 2, 3]),
-                              //@@@BUG@@@ 8339 forces this to be takeExactly
-                              //`InitStruct([1, 2, 3]),
-                              TakeNoneStruct([1, 2, 3])))
+    foreach(range; AliasSeq!([1, 2, 3, 4, 5],
+                             "hello world",
+                             "hello world"w,
+                             "hello world"d,
+                             SliceStruct([1, 2, 3]),
+                             //@@@BUG@@@ 8339 forces this to be takeExactly
+                             //`InitStruct([1, 2, 3]),
+                             TakeNoneStruct([1, 2, 3])))
     {
         static assert(takeNone(range).empty, typeof(range).stringof);
         assert(takeNone(range).empty);
         static assert(is(typeof(range) == typeof(takeNone(range))), typeof(range).stringof);
     }
 
-    foreach(range; TypeTuple!(NormalStruct([1, 2, 3]),
-                              InitStruct([1, 2, 3])))
+    foreach(range; AliasSeq!(NormalStruct([1, 2, 3]),
+                             InitStruct([1, 2, 3])))
     {
         static assert(takeNone(range).empty, typeof(range).stringof);
         assert(takeNone(range).empty);
@@ -4971,7 +4971,7 @@ unittest
     assert(iota(uint.max, 0u, -1).length == uint.max);
 
     // Issue 8920
-    foreach (Type; TypeTuple!(byte, ubyte, short, ushort,
+    foreach (Type; AliasSeq!(byte, ubyte, short, ushort,
         int, uint, long, ulong))
     {
         Type val;
@@ -4989,10 +4989,10 @@ unittest
 
 @safe unittest
 {
-    foreach(range; TypeTuple!(iota(2, 27, 4),
-                              iota(3, 9),
-                              iota(2.7, 12.3, .1),
-                              iota(3.2, 9.7)))
+    foreach(range; AliasSeq!(iota(2, 27, 4),
+                             iota(3, 9),
+                             iota(2.7, 12.3, .1),
+                             iota(3.2, 9.7)))
     {
         const cRange = range;
         const e = cRange.empty;
@@ -6719,12 +6719,12 @@ unittest
     assert(saved[0 .. 0].empty);
     assert(saved[3 .. 3].empty);
 
-    alias data = TypeTuple!("one", "two", "three", "four");
+    alias data = AliasSeq!("one", "two", "three", "four");
     static joined =
         ["one two", "one two three", "one two three four"];
     string[] joinedRange = joined;
 
-    foreach(argCount; TypeTuple!(2, 3, 4))
+    foreach(argCount; AliasSeq!(2, 3, 4))
     {
         auto values = only(data[0 .. argCount]);
         alias Values = typeof(values);
@@ -6976,7 +6976,7 @@ pure @safe nothrow unittest
         }
     }
 
-    foreach (DummyType; TypeTuple!(AllDummyRanges, HasSlicing))
+    foreach (DummyType; AliasSeq!(AllDummyRanges, HasSlicing))
     {
         alias R = typeof(enumerate(DummyType.init));
         static assert(isInputRange!R);
@@ -7042,7 +7042,7 @@ pure @safe nothrow unittest
         assert(shifted.empty);
     }
 
-    foreach(T; TypeTuple!(ubyte, byte, uint, int))
+    foreach(T; AliasSeq!(ubyte, byte, uint, int))
     {
         auto inf = 42.repeat().enumerate(T.max);
         alias Inf = typeof(inf);
@@ -7069,7 +7069,7 @@ pure @safe unittest
 {
     import std.algorithm : equal;
     static immutable int[] values = [0, 1, 2, 3, 4];
-    foreach(T; TypeTuple!(ubyte, ushort, uint, ulong))
+    foreach(T; AliasSeq!(ubyte, ushort, uint, ulong))
     {
         auto enumerated = values.enumerate!T();
         static assert(is(typeof(enumerated.front.index) == T));
@@ -7110,7 +7110,7 @@ version(none) // @@@BUG@@@ 10939
         }
 
         SignedLengthRange svalues;
-        foreach(Enumerator; TypeTuple!(ubyte, byte, ushort, short, uint, int, ulong, long))
+        foreach(Enumerator; AliasSeq!(ubyte, byte, ushort, short, uint, int, ulong, long))
         {
             assertThrown!RangeError(values[].enumerate!Enumerator(Enumerator.max));
             assertNotThrown!RangeError(values[].enumerate!Enumerator(Enumerator.max - values.length));
@@ -7121,7 +7121,7 @@ version(none) // @@@BUG@@@ 10939
             assertThrown!RangeError(svalues.enumerate!Enumerator(Enumerator.max - values.length + 1));
         }
 
-        foreach(Enumerator; TypeTuple!(byte, short, int))
+        foreach(Enumerator; AliasSeq!(byte, short, int))
         {
             assertThrown!RangeError(repeat(0, uint.max).enumerate!Enumerator());
         }
@@ -8991,14 +8991,14 @@ if (is(typeof(fun) == void) || isSomeFunction!fun)
     auto result3 = txt.tee(asink3).array;
     assert(equal(txt, result3) && equal(result3, asink3));
 
-    foreach (CharType; TypeTuple!(char, wchar, dchar))
+    foreach (CharType; AliasSeq!(char, wchar, dchar))
     {
         auto appSink = appender!(CharType[])();
         auto appResult = txt.tee(appSink).array;
         assert(equal(txt, appResult) && equal(appResult, appSink.data));
     }
 
-    foreach (StringType; TypeTuple!(string, wstring, dstring))
+    foreach (StringType; AliasSeq!(string, wstring, dstring))
     {
         auto appSink = appender!StringType();
         auto appResult = txt.tee(appSink).array;

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -511,8 +511,8 @@ unittest
 unittest
 {
     import std.conv : to;
+    import std.meta : AliasSeq;
     import std.typecons : tuple;
-    import std.typetuple;
 
     static struct PutC(C)
     {
@@ -538,7 +538,7 @@ unittest
     putChar(p, cast(dchar)'a');
 
     //Source Char
-    foreach (SC; TypeTuple!(char, wchar, dchar))
+    foreach (SC; AliasSeq!(char, wchar, dchar))
     {
         SC ch = 'I';
         dchar dh = '♥';
@@ -546,10 +546,10 @@ unittest
         immutable(SC)[][] ss = ["日本語", "が", "好き", "ですか", "？"];
 
         //Target Char
-        foreach (TC; TypeTuple!(char, wchar, dchar))
+        foreach (TC; AliasSeq!(char, wchar, dchar))
         {
             //Testing PutC and PutS
-            foreach (Type; TypeTuple!(PutC!TC, PutS!TC))
+            foreach (Type; AliasSeq!(PutC!TC, PutS!TC))
             (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
                 Type type;
                 auto sink = new Type();
@@ -609,7 +609,7 @@ unittest
 unittest
 {
     import std.format;
-    import std.typetuple;
+    import std.meta : AliasSeq;
     struct PutC(C)
     {
         void put(C){}
@@ -642,7 +642,7 @@ unittest
     }
     void foo()
     {
-        foreach(C; TypeTuple!(char, wchar, dchar))
+        foreach(C; AliasSeq!(char, wchar, dchar))
         {
             formattedWrite((C c){},        "", 1, 'a', cast(wchar)'a', cast(dchar)'a', "a"c, "a"w, "a"d);
             formattedWrite((const(C)[]){}, "", 1, 'a', cast(wchar)'a', cast(dchar)'a', "a"c, "a"w, "a"d);
@@ -2090,9 +2090,9 @@ if (isNarrowString!(C[]))
 
 @safe pure unittest
 {
-    import std.typetuple;
+    import std.meta : AliasSeq;
 
-    foreach(S; TypeTuple!(string, wstring, dstring))
+    foreach(S; AliasSeq!(string, wstring, dstring))
     {
         S s = "\xC2\xA9hello";
         s.popFront();
@@ -2163,9 +2163,9 @@ if (isNarrowString!(T[]))
 
 @safe pure unittest
 {
-    import std.typetuple;
+    import std.meta : AliasSeq;
 
-    foreach(S; TypeTuple!(string, wstring, dstring))
+    foreach(S; AliasSeq!(string, wstring, dstring))
     {
         S s = "hello\xE2\x89\xA0";
         s.popBack();

--- a/std/regex/internal/ir.d
+++ b/std/regex/internal/ir.d
@@ -9,7 +9,7 @@ module std.regex.internal.ir;
 
 package(std.regex):
 
-import std.exception, std.uni, std.typetuple, std.traits, std.range;
+import std.exception, std.uni, std.meta, std.traits, std.range;
 
 // just a common trait, may be moved elsewhere
 alias BasicElementOf(Range) = Unqual!(ElementEncodingType!Range);
@@ -88,7 +88,7 @@ enum RegexOption: uint {
     singleline = 0x20
 }
 //do not reorder this list
-alias RegexOptionNames = TypeTuple!('g', 'i', 'x', 'U', 'm', 's');
+alias RegexOptionNames = AliasSeq!('g', 'i', 'x', 'U', 'm', 's');
 static assert( RegexOption.max < 0x80);
 // flags that allow guide execution of engine
 enum RegexInfo : uint { oneShot = 0x80 }

--- a/std/regex/internal/kickstart.d
+++ b/std/regex/internal/kickstart.d
@@ -484,7 +484,7 @@ unittest
     import std.conv, std.regex;
     @trusted void test_fixed(alias Kick)()
     {
-        foreach(i, v; TypeTuple!(char, wchar, dchar))
+        foreach(i, v; AliasSeq!(char, wchar, dchar))
         {
             alias Char = v;
             alias String = immutable(v)[];
@@ -510,7 +510,7 @@ unittest
     }
     @trusted void test_flex(alias Kick)()
     {
-        foreach(i, v;TypeTuple!(char, wchar, dchar))
+        foreach(i, v; AliasSeq!(char, wchar, dchar))
         {
             alias Char = v;
             alias String = immutable(v)[];

--- a/std/regex/internal/parser.d
+++ b/std/regex/internal/parser.d
@@ -5,7 +5,7 @@
 module std.regex.internal.parser;
 
 import std.regex.internal.ir;
-import std.algorithm, std.range, std.uni, std.typetuple,
+import std.algorithm, std.range, std.uni, std.meta,
     std.traits, std.typecons, std.exception;
 
 // package relevant info from parser into a regex object
@@ -155,7 +155,7 @@ unittest
 }
 
 
-alias Escapables = TypeTuple!('[', ']', '\\', '^', '$', '.', '|', '?', ',', '-',
+alias Escapables = AliasSeq!('[', ']', '\\', '^', '$', '.', '|', '?', ',', '-',
     ';', ':', '#', '&', '%', '/', '<', '>', '`',  '*', '+', '(', ')', '{', '}',  '~');
 
 //test if a given string starts with hex number of maxDigit that's a valid codepoint

--- a/std/regex/internal/tests.d
+++ b/std/regex/internal/tests.d
@@ -5,8 +5,8 @@ module std.regex.internal.tests;
 
 package(std.regex):
 
-import std.algorithm, std.conv, std.exception, std.range, std.typecons,
-    std.typetuple, std.regex;
+import std.algorithm, std.conv, std.exception, std.meta, std.range,
+    std.typecons, std.regex;
 
 import std.regex.internal.parser : Escapables; // characters that need escaping
 
@@ -347,7 +347,7 @@ unittest
     void run_tests(alias matchFn)()
     {
         int i;
-        foreach(Char; TypeTuple!( char, wchar, dchar))
+        foreach(Char; AliasSeq!( char, wchar, dchar))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             alias String = immutable(Char)[];
             String produceExpected(M,Range)(auto ref M m, Range fmt)
@@ -417,7 +417,7 @@ unittest
             alias Tests = Sequence!(220, tv.length);
         }
         else
-            alias Tests = TypeTuple!(Sequence!(0, 30), Sequence!(235, tv.length-5));
+            alias Tests = AliasSeq!(Sequence!(0, 30), Sequence!(235, tv.length-5));
         foreach(a, v; Tests)
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             enum tvd = tv[v];
@@ -670,7 +670,7 @@ unittest
     {
         import std.uni : toUpper;
 
-        foreach(i, v; TypeTuple!(string, wstring, dstring))
+        foreach(i, v; AliasSeq!(string, wstring, dstring))
         {
             auto baz(Cap)(Cap m)
             if (is(Cap == Captures!(Cap.String)))
@@ -753,7 +753,7 @@ unittest
 }
 unittest
 {// bugzilla 7679
-    foreach(S; TypeTuple!(string, wstring, dstring))
+    foreach(S; AliasSeq!(string, wstring, dstring))
     (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
         enum re = ctRegex!(to!S(r"\."));
         auto str = to!S("a.b");

--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -884,7 +884,7 @@ public auto matchAll(R, RegEx)(R input, RegEx re)
     import std.conv : to;
     import std.algorithm : map, equal;
 
-    foreach(String; TypeTuple!(string, wstring, const(dchar)[]))
+    foreach(String; AliasSeq!(string, wstring, const(dchar)[]))
     {
         auto str1 = "blah-bleh".to!String();
         auto pat1 = "bl[ae]h".to!String();
@@ -1267,7 +1267,7 @@ public @trusted void replaceAllInto(alias fun, Sink, R, RegEx)
 {
     import std.conv;
     // try and check first/all simple substitution
-    foreach(S; TypeTuple!(string, wstring, dstring, char[], wchar[], dchar[]))
+    foreach(S; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[]))
     {
         S s1 = "curt trial".to!S();
         S s2 = "round dome".to!S();

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1413,12 +1413,12 @@ void main()
     {
         static import std.file;
         import std.algorithm : equal;
-        import std.typetuple : TypeTuple;
+        import std.meta : AliasSeq;
 
         auto deleteme = testFilename();
         std.file.write(deleteme, "hello\nworld\n");
         scope(exit) std.file.remove(deleteme);
-        foreach (String; TypeTuple!(string, char[], wstring, wchar[], dstring, dchar[]))
+        foreach (String; AliasSeq!(string, char[], wstring, wchar[], dstring, dchar[]))
         {
             auto witness = [ "hello\n", "world\n" ];
             auto f = File(deleteme);
@@ -1903,8 +1903,8 @@ the contents may well have changed).
         std.file.write(deleteme, "hi");
         scope(success) std.file.remove(deleteme);
 
-        import std.typetuple;
-        foreach (T; TypeTuple!(char, wchar, dchar))
+        import std.meta : AliasSeq;
+        foreach (T; AliasSeq!(char, wchar, dchar))
         {
             auto blc = File(deleteme).byLine!(T, T);
             assert(blc.front == "hi");
@@ -2503,12 +2503,12 @@ $(D Range) that locks the file and allows fast writing to it.
         /// ditto
         void put(C)(C c) @safe if (is(C : const(dchar)))
         {
-            import std.traits : ParameterTypeTuple;
+            import std.traits : Parameters;
             static auto trustedFPUTC(int ch, _iobuf* h) @trusted
             {
                 return FPUTC(ch, h);
             }
-            static auto trustedFPUTWC(ParameterTypeTuple!FPUTWC[0] ch, _iobuf* h) @trusted
+            static auto trustedFPUTWC(Parameters!FPUTWC[0] ch, _iobuf* h) @trusted
             {
                 return FPUTWC(ch, h);
             }
@@ -3292,7 +3292,7 @@ unittest
     // stdout.open(file, "w");
     // assert(stdout.isOpen);
     // writefln("Hello, %s world number %s!", "nice", 42);
-    // foreach (F ; TypeTuple!(ifloat, idouble, ireal))
+    // foreach (F ; AliasSeq!(ifloat, idouble, ireal))
     // {
     //     F a = 5i;
     //     F b = a % 2;
@@ -3406,7 +3406,7 @@ if (isSomeChar!C && is(Unqual!C == C) && !is(C == enum) &&
 
 unittest
 {
-    import std.typetuple : TypeTuple;
+    import std.meta : AliasSeq;
 
     //we can't actually test readln, so at the very least,
     //we test compilability
@@ -3414,12 +3414,12 @@ unittest
     {
         readln();
         readln('\t');
-        foreach (String; TypeTuple!(string, char[], wstring, wchar[], dstring, dchar[]))
+        foreach (String; AliasSeq!(string, char[], wstring, wchar[], dstring, dchar[]))
         {
             readln!String();
             readln!String('\t');
         }
-        foreach (String; TypeTuple!(char[], wchar[], dchar[]))
+        foreach (String; AliasSeq!(char[], wchar[], dchar[]))
         {
             String buf;
             readln(buf);
@@ -3588,8 +3588,8 @@ struct lines
 //             if (fileName.length && fclose(f))
 //                 StdioException("Could not close file `"~fileName~"'");
 //         }
-        import std.traits : ParameterTypeTuple;
-        alias Parms = ParameterTypeTuple!(dg);
+        import std.traits : Parameters;
+        alias Parms = Parameters!(dg);
         static if (isSomeString!(Parms[$ - 1]))
         {
             enum bool duplicate = is(Parms[$ - 1] == string)
@@ -3634,9 +3634,9 @@ struct lines
     {
         import std.exception : assumeUnique;
         import std.conv : to;
-        import std.traits : ParameterTypeTuple;
+        import std.traits : Parameters;
 
-        alias Parms = ParameterTypeTuple!(dg);
+        alias Parms = Parameters!(dg);
         enum duplicate = is(Parms[$ - 1] : immutable(ubyte)[]);
         int result = 1;
         int c = void;
@@ -3680,7 +3680,7 @@ struct lines
 unittest
 {
     static import std.file;
-    import std.typetuple : TypeTuple;
+    import std.meta : AliasSeq;
 
     //printf("Entering test at line %d\n", __LINE__);
     scope(failure) printf("Failed test at line %d\n", __LINE__);
@@ -3689,8 +3689,8 @@ unittest
     scope(exit) { std.file.remove(deleteme); }
 
     alias TestedWith =
-          TypeTuple!(string, wstring, dstring,
-                     char[], wchar[], dchar[]);
+          AliasSeq!(string, wstring, dstring,
+                    char[], wchar[], dchar[]);
     foreach (T; TestedWith) {
         // test looping with an empty file
         std.file.write(deleteme, "");
@@ -3732,8 +3732,8 @@ unittest
 
     // test with ubyte[] inputs
     //@@@BUG 2612@@@
-    //alias TestedWith2 = TypeTuple!(immutable(ubyte)[], ubyte[]);
-    alias TestedWith2 = TypeTuple!(immutable(ubyte)[], ubyte[]);
+    //alias TestedWith2 = AliasSeq!(immutable(ubyte)[], ubyte[]);
+    alias TestedWith2 = AliasSeq!(immutable(ubyte)[], ubyte[]);
     foreach (T; TestedWith2) {
         // test looping with an empty file
         std.file.write(deleteme, "");
@@ -3775,7 +3775,7 @@ unittest
 
     }
 
-    foreach (T; TypeTuple!(ubyte[]))
+    foreach (T; AliasSeq!(ubyte[]))
     {
         // test looping with a file with three lines, last without a newline
         // using a counter too this time

--- a/std/string.d
+++ b/std/string.d
@@ -162,9 +162,9 @@ public import std.uni : icmp, toLower, toLowerInPlace, toUpper, toUpperInPlace;
 public import std.format : format, sformat;
 import std.typecons : Flag;
 
+import std.meta;
 import std.range.primitives;
 import std.traits;
-import std.typetuple;
 
 //public imports for backward compatibility
 public import std.algorithm : startsWith, endsWith, cmp, count;
@@ -508,7 +508,7 @@ unittest
     import std.utf : byChar, byWchar, byDchar;
     assertCTFEable!(
     {
-    foreach (S; TypeTuple!(string, wstring, dstring))
+    foreach (S; AliasSeq!(string, wstring, dstring))
     {
         assert(indexOf(cast(S)null, cast(dchar)'a') == -1);
         assert(indexOf(to!S("def"), cast(dchar)'a') == -1);
@@ -624,7 +624,7 @@ unittest
     assert("hello".byWchar.indexOf(cast(dchar)'l', 1) == 2);
     assert("hello".byWchar.indexOf(cast(dchar)'l', 6) == -1);
 
-    foreach (S; TypeTuple!(string, wstring, dstring))
+    foreach (S; AliasSeq!(string, wstring, dstring))
     {
         assert(indexOf(cast(S)null, cast(dchar)'a', 1) == -1);
         assert(indexOf(to!S("def"), cast(dchar)'a', 1) == -1);
@@ -775,9 +775,9 @@ unittest
     import std.exception;
     assertCTFEable!(
     {
-    foreach (S; TypeTuple!(string, wstring, dstring))
+    foreach (S; AliasSeq!(string, wstring, dstring))
     {
-        foreach (T; TypeTuple!(string, wstring, dstring))
+        foreach (T; AliasSeq!(string, wstring, dstring))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             assert(indexOf(cast(S)null, to!T("a")) == -1);
             assert(indexOf(to!S("def"), to!T("a")) == -1);
@@ -873,9 +873,9 @@ ptrdiff_t indexOf(Char1, Char2)(const(Char1)[] s, const(Char2)[] sub,
     import std.conv : to;
     debug(string) trustedPrintf("string.indexOf(startIdx).unittest\n");
 
-    foreach(S; TypeTuple!(string, wstring, dstring))
+    foreach(S; AliasSeq!(string, wstring, dstring))
     {
-        foreach(T; TypeTuple!(string, wstring, dstring))
+        foreach(T; AliasSeq!(string, wstring, dstring))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             assert(indexOf(cast(S)null, to!T("a"), 1337) == -1);
             assert(indexOf(to!S("def"), to!T("a"), 0) == -1);
@@ -1008,7 +1008,7 @@ ptrdiff_t lastIndexOf(Char)(const(Char)[] s, in dchar c,
     import std.exception;
     assertCTFEable!(
     {
-    foreach (S; TypeTuple!(string, wstring, dstring))
+    foreach (S; AliasSeq!(string, wstring, dstring))
     {
         assert(lastIndexOf(cast(S) null, 'a') == -1);
         assert(lastIndexOf(to!S("def"), 'a') == -1);
@@ -1074,7 +1074,7 @@ ptrdiff_t lastIndexOf(Char)(const(Char)[] s, in dchar c, in size_t startIdx,
 
     debug(string) trustedPrintf("string.lastIndexOf.unittest\n");
 
-    foreach(S; TypeTuple!(string, wstring, dstring))
+    foreach(S; AliasSeq!(string, wstring, dstring))
     {
         assert(lastIndexOf(cast(S) null, 'a') == -1);
         assert(lastIndexOf(to!S("def"), 'a') == -1);
@@ -1199,9 +1199,9 @@ ptrdiff_t lastIndexOf(Char1, Char2)(const(Char1)[] s, const(Char2)[] sub,
     import std.exception;
     assertCTFEable!(
     {
-    foreach (S; TypeTuple!(string, wstring, dstring))
+    foreach (S; AliasSeq!(string, wstring, dstring))
     {
-        foreach (T; TypeTuple!(string, wstring, dstring))
+        foreach (T; AliasSeq!(string, wstring, dstring))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             enum typeStr = S.stringof ~ " " ~ T.stringof;
 
@@ -1254,9 +1254,9 @@ ptrdiff_t lastIndexOf(Char1, Char2)(const(Char1)[] s, const(Char2)[] sub,
 @safe pure unittest // issue13529
 {
     import std.conv : to;
-    foreach (S; TypeTuple!(string, wstring, dstring))
+    foreach (S; AliasSeq!(string, wstring, dstring))
     {
-        foreach (T; TypeTuple!(string, wstring, dstring))
+        foreach (T; AliasSeq!(string, wstring, dstring))
         {
             enum typeStr = S.stringof ~ " " ~ T.stringof;
             auto idx = lastIndexOf(to!T("Hällö Wörldö ö"),to!S("ö ö"));
@@ -1302,9 +1302,9 @@ ptrdiff_t lastIndexOf(Char1, Char2)(const(Char1)[] s, const(Char2)[] sub,
 
     debug(string) trustedPrintf("string.lastIndexOf.unittest\n");
 
-    foreach(S; TypeTuple!(string, wstring, dstring))
+    foreach(S; AliasSeq!(string, wstring, dstring))
     {
-        foreach(T; TypeTuple!(string, wstring, dstring))
+        foreach(T; AliasSeq!(string, wstring, dstring))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             enum typeStr = S.stringof ~ " " ~ T.stringof;
 
@@ -1499,9 +1499,9 @@ ptrdiff_t indexOfAny(Char,Char2)(const(Char)[] haystack, const(Char2)[] needles,
     import std.exception;
     assertCTFEable!(
     {
-    foreach (S; TypeTuple!(string, wstring, dstring))
+    foreach (S; AliasSeq!(string, wstring, dstring))
     {
-        foreach (T; TypeTuple!(string, wstring, dstring))
+        foreach (T; AliasSeq!(string, wstring, dstring))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             assert(indexOfAny(cast(S)null, to!T("a")) == -1);
             assert(indexOfAny(to!S("def"), to!T("rsa")) == -1);
@@ -1582,9 +1582,9 @@ ptrdiff_t indexOfAny(Char,Char2)(const(Char)[] haystack, const(Char2)[] needles,
 
     debug(string) trustedPrintf("string.indexOfAny(startIdx).unittest\n");
 
-    foreach(S; TypeTuple!(string, wstring, dstring))
+    foreach(S; AliasSeq!(string, wstring, dstring))
     {
-        foreach(T; TypeTuple!(string, wstring, dstring))
+        foreach(T; AliasSeq!(string, wstring, dstring))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             assert(indexOfAny(cast(S)null, to!T("a"), 1337) == -1);
             assert(indexOfAny(to!S("def"), to!T("AaF"), 0) == -1);
@@ -1660,9 +1660,9 @@ ptrdiff_t lastIndexOfAny(Char,Char2)(const(Char)[] haystack,
     import std.exception;
     assertCTFEable!(
     {
-    foreach (S; TypeTuple!(string, wstring, dstring))
+    foreach (S; AliasSeq!(string, wstring, dstring))
     {
-        foreach (T; TypeTuple!(string, wstring, dstring))
+        foreach (T; AliasSeq!(string, wstring, dstring))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             assert(lastIndexOfAny(cast(S)null, to!T("a")) == -1);
             assert(lastIndexOfAny(to!S("def"), to!T("rsa")) == -1);
@@ -1756,9 +1756,9 @@ ptrdiff_t lastIndexOfAny(Char,Char2)(const(Char)[] haystack,
     import std.exception;
     assertCTFEable!(
     {
-    foreach (S; TypeTuple!(string, wstring, dstring))
+    foreach (S; AliasSeq!(string, wstring, dstring))
     {
-        foreach (T; TypeTuple!(string, wstring, dstring))
+        foreach (T; AliasSeq!(string, wstring, dstring))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             enum typeStr = S.stringof ~ " " ~ T.stringof;
 
@@ -1836,9 +1836,9 @@ ptrdiff_t indexOfNeither(Char,Char2)(const(Char)[] haystack,
     import std.exception;
     assertCTFEable!(
     {
-    foreach (S; TypeTuple!(string, wstring, dstring))
+    foreach (S; AliasSeq!(string, wstring, dstring))
     {
-        foreach (T; TypeTuple!(string, wstring, dstring))
+        foreach (T; AliasSeq!(string, wstring, dstring))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             assert(indexOfNeither(cast(S)null, to!T("a")) == -1);
             assert(indexOfNeither("abba", "a") == 1);
@@ -1921,9 +1921,9 @@ ptrdiff_t indexOfNeither(Char,Char2)(const(Char)[] haystack,
     import std.exception;
     assertCTFEable!(
     {
-    foreach (S; TypeTuple!(string, wstring, dstring))
+    foreach (S; AliasSeq!(string, wstring, dstring))
     {
-        foreach (T; TypeTuple!(string, wstring, dstring))
+        foreach (T; AliasSeq!(string, wstring, dstring))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             assert(indexOfNeither(cast(S)null, to!T("a"), 1) == -1);
             assert(indexOfNeither(to!S("def"), to!T("a"), 1) == 1,
@@ -1991,9 +1991,9 @@ ptrdiff_t lastIndexOfNeither(Char,Char2)(const(Char)[] haystack,
     import std.exception;
     assertCTFEable!(
     {
-    foreach (S; TypeTuple!(string, wstring, dstring))
+    foreach (S; AliasSeq!(string, wstring, dstring))
     {
-        foreach (T; TypeTuple!(string, wstring, dstring))
+        foreach (T; AliasSeq!(string, wstring, dstring))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             assert(lastIndexOfNeither(cast(S)null, to!T("a")) == -1);
             assert(lastIndexOfNeither(to!S("def"), to!T("rsa")) == 2);
@@ -2072,9 +2072,9 @@ ptrdiff_t lastIndexOfNeither(Char,Char2)(const(Char)[] haystack,
     import std.exception;
     assertCTFEable!(
     {
-    foreach (S; TypeTuple!(string, wstring, dstring))
+    foreach (S; AliasSeq!(string, wstring, dstring))
     {
-        foreach (T; TypeTuple!(string, wstring, dstring))
+        foreach (T; AliasSeq!(string, wstring, dstring))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             assert(lastIndexOfNeither(cast(S)null, to!T("a"), 1337) == -1);
             assert(lastIndexOfNeither(to!S("def"), to!T("f")) == 1);
@@ -2124,7 +2124,7 @@ ptrdiff_t lastIndexOfNeither(Char,Char2)(const(Char)[] haystack,
 auto representation(Char)(Char[] s) @safe pure nothrow @nogc
     if (isSomeChar!Char)
 {
-    alias ToRepType(T) = TypeTuple!(ubyte, ushort, uint)[T.sizeof / 2];
+    alias ToRepType(T) = AliasSeq!(ubyte, ushort, uint)[T.sizeof / 2];
     return cast(ModifyTypePreservingTQ!(ToRepType, Char)[])s;
 }
 
@@ -2150,12 +2150,12 @@ auto representation(Char)(Char[] s) @safe pure nothrow @nogc
         assert(representation(str) is cast(T[]) str);
     }
 
-    foreach (Type; TypeTuple!(Tuple!(char , ubyte ),
-                              Tuple!(wchar, ushort),
-                              Tuple!(dchar, uint  )))
+    foreach (Type; AliasSeq!(Tuple!(char , ubyte ),
+                             Tuple!(wchar, ushort),
+                             Tuple!(dchar, uint  )))
     {
-        alias Char = FieldTypeTuple!Type[0];
-        alias Int  = FieldTypeTuple!Type[1];
+        alias Char = Fields!Type[0];
+        alias Int  = Fields!Type[1];
         enum immutable(Char)[] hello = "hello";
 
         test!(   immutable Char,    immutable Int)(hello);
@@ -2227,7 +2227,7 @@ S capitalize(S)(S s) @trusted pure
     import std.exception;
     assertCTFEable!(
     {
-    foreach (S; TypeTuple!(string, wstring, dstring, char[], wchar[], dchar[]))
+    foreach (S; AliasSeq!(string, wstring, dstring, char[], wchar[], dchar[]))
     {
         S s1 = to!S("FoL");
         S s2;
@@ -2376,7 +2376,7 @@ S[] splitLines(S)(S s, in KeepTerminator keepTerm = KeepTerminator.no) @safe pur
     import std.exception;
     assertCTFEable!(
     {
-    foreach (S; TypeTuple!(char[], wchar[], dchar[], string, wstring, dstring))
+    foreach (S; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
     {
         auto s = to!S(
             "\rpeter\n\rpaul\r\njerry\u2028ice\u2029cream\n\nsunday\n" ~
@@ -2607,7 +2607,7 @@ if ((hasSlicing!Range && hasLength!Range) ||
     import std.exception;
     assertCTFEable!(
     {
-    foreach (S; TypeTuple!(char[], wchar[], dchar[], string, wstring, dstring))
+    foreach (S; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
     {
         auto s = to!S(
             "\rpeter\n\rpaul\r\njerry\u2028ice\u2029cream\n\n" ~
@@ -2867,7 +2867,7 @@ unittest
     assert(stripRight("\u2028hello world\u2020\u2028".byChar).array == "\u2028hello world\u2020");
     assert(stripRight("hello world\U00010001"w.byWchar).array == "hello world\U00010001"w);
 
-    foreach (C; TypeTuple!(char, wchar, dchar))
+    foreach (C; AliasSeq!(char, wchar, dchar))
     {
         foreach (s; invalidUTFstrings!C())
         {
@@ -2925,9 +2925,9 @@ auto strip(Range)(Range str)
     import std.exception;
     assertCTFEable!(
     {
-    foreach (S; TypeTuple!( char[], const  char[],  string,
-                           wchar[], const wchar[], wstring,
-                           dchar[], const dchar[], dstring))
+    foreach (S; AliasSeq!( char[], const  char[],  string,
+                          wchar[], const wchar[], wstring,
+                          dchar[], const dchar[], dstring))
     {
         assert(equal(stripLeft(to!S("  foo\t ")), "foo\t "));
         assert(equal(stripLeft(to!S("\u2008  foo\t \u2007")), "foo\t \u2007"));
@@ -3111,7 +3111,7 @@ unittest
     import std.exception;
     assertCTFEable!(
     {
-    foreach (S; TypeTuple!(char[], wchar[], dchar[], string, wstring, dstring))
+    foreach (S; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
     {
         // @@@ BUG IN COMPILER, MUST INSERT CAST
         assert(chomp(cast(S)null) is null);
@@ -3131,7 +3131,7 @@ unittest
         assert(chomp(to!S("hello\u2029\u2129")) == "hello\u2029\u2129");
         assert(chomp(to!S("hello\u2029\u0185")) == "hello\u2029\u0185");
 
-        foreach (T; TypeTuple!(char[], wchar[], dchar[], string, wstring, dstring))
+        foreach (T; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             // @@@ BUG IN COMPILER, MUST INSERT CAST
             assert(chomp(cast(S)null, cast(T)null) is null);
@@ -3226,9 +3226,9 @@ unittest
     import std.exception;
     assertCTFEable!(
     {
-    foreach (S; TypeTuple!(char[], wchar[], dchar[], string, wstring, dstring))
+    foreach (S; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
     {
-        foreach (T; TypeTuple!(char[], wchar[], dchar[], string, wstring, dstring))
+        foreach (T; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             assert(equal(chompPrefix(to!S("abcdefgh"), to!T("abcde")), "fgh"));
             assert(equal(chompPrefix(to!S("abcde"), to!T("abcdefgh")), "abcde"));
@@ -3378,7 +3378,7 @@ unittest
     import std.exception;
     assertCTFEable!(
     {
-    foreach (S; TypeTuple!(char[], wchar[], dchar[], string, wstring, dstring))
+    foreach (S; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
     {
         assert(chop(cast(S) null) is null);
         assert(equal(chop(to!S("hello")), "hell"));
@@ -3721,7 +3721,7 @@ unittest
     import std.exception;
     assertCTFEable!(
     {
-    foreach (S; TypeTuple!(char[], wchar[], dchar[], string, wstring, dstring))
+    foreach (S; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
     {
         S s = to!S("hello");
 
@@ -4002,7 +4002,7 @@ auto detabber(Range)(Range r, size_t tabSize = 8)
     import std.exception;
     assertCTFEable!(
     {
-    foreach (S; TypeTuple!(char[], wchar[], dchar[], string, wstring, dstring))
+    foreach (S; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
     {
         S s = to!S("This \tis\t a fofof\tof list");
         assert(cmp(detab(s), "This    is       a fofof        of list") == 0);
@@ -4433,9 +4433,9 @@ C1[] translate(C1, C2 = immutable char)(C1[] str,
     import std.exception;
     assertCTFEable!(
     {
-    foreach (S; TypeTuple!( char[], const( char)[], immutable( char)[],
-                           wchar[], const(wchar)[], immutable(wchar)[],
-                           dchar[], const(dchar)[], immutable(dchar)[]))
+    foreach (S; AliasSeq!( char[], const( char)[], immutable( char)[],
+                          wchar[], const(wchar)[], immutable(wchar)[],
+                          dchar[], const(dchar)[], immutable(dchar)[]))
     {
         assert(translate(to!S("hello world"), cast(dchar[dchar])['h' : 'q', 'l' : '5']) ==
                to!S("qe55o wor5d"));
@@ -4447,11 +4447,11 @@ C1[] translate(C1, C2 = immutable char)(C1[] str,
                to!S("hell0 o w0rld"));
         assert(translate(to!S("hello world"), cast(dchar[dchar])null) == to!S("hello world"));
 
-        foreach (T; TypeTuple!( char[], const( char)[], immutable( char)[],
-                               wchar[], const(wchar)[], immutable(wchar)[],
-                               dchar[], const(dchar)[], immutable(dchar)[]))
+        foreach (T; AliasSeq!( char[], const( char)[], immutable( char)[],
+                              wchar[], const(wchar)[], immutable(wchar)[],
+                              dchar[], const(dchar)[], immutable(dchar)[]))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
-            foreach(R; TypeTuple!(dchar[dchar], const dchar[dchar],
+            foreach(R; AliasSeq!(dchar[dchar], const dchar[dchar],
                         immutable dchar[dchar]))
             {
                 R tt = ['h' : 'q', 'l' : '5'];
@@ -4490,9 +4490,9 @@ C1[] translate(C1, S, C2 = immutable char)(C1[] str,
     import std.exception;
     assertCTFEable!(
     {
-    foreach (S; TypeTuple!( char[], const( char)[], immutable( char)[],
-                           wchar[], const(wchar)[], immutable(wchar)[],
-                           dchar[], const(dchar)[], immutable(dchar)[]))
+    foreach (S; AliasSeq!( char[], const( char)[], immutable( char)[],
+                          wchar[], const(wchar)[], immutable(wchar)[],
+                          dchar[], const(dchar)[], immutable(dchar)[]))
     {
         assert(translate(to!S("hello world"), ['h' : "yellow", 'l' : "42"]) ==
                to!S("yellowe4242o wor42d"));
@@ -4508,12 +4508,12 @@ C1[] translate(C1, S, C2 = immutable char)(C1[] str,
                to!S("hello  world"));
         assert(translate(to!S("hello world"), cast(string[dchar])null) == to!S("hello world"));
 
-        foreach (T; TypeTuple!( char[], const( char)[], immutable( char)[],
-                               wchar[], const(wchar)[], immutable(wchar)[],
-                               dchar[], const(dchar)[], immutable(dchar)[]))
+        foreach (T; AliasSeq!( char[], const( char)[], immutable( char)[],
+                              wchar[], const(wchar)[], immutable(wchar)[],
+                              dchar[], const(dchar)[], immutable(dchar)[]))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
 
-            foreach(R; TypeTuple!(string[dchar], const string[dchar],
+            foreach(R; AliasSeq!(string[dchar], const string[dchar],
                         immutable string[dchar]))
             {
                 R tt = ['h' : "yellow", 'l' : "42"];
@@ -4753,7 +4753,7 @@ body
     import std.exception;
     assertCTFEable!(
     {
-    foreach (C; TypeTuple!(char, const char, immutable char))
+    foreach (C; AliasSeq!(char, const char, immutable char))
     {
         assert(translate!C("hello world", makeTransTable("hl", "q5")) == to!(C[])("qe55o wor5d"));
 
@@ -4762,7 +4762,7 @@ body
         static assert(is(typeof(s) == typeof(translate!C(s, transTable))));
     }
 
-    foreach (S; TypeTuple!(char[], const(char)[], immutable(char)[]))
+    foreach (S; AliasSeq!(char[], const(char)[], immutable(char)[]))
     {
         assert(translate(to!S("hello world"), makeTransTable("hl", "q5")) == to!S("qe55o wor5d"));
         assert(translate(to!S("hello \U00010143 world"), makeTransTable("hl", "q5")) ==
@@ -4773,7 +4773,7 @@ body
         assert(translate(to!S("hello \U00010143 world"), makeTransTable("12345", "67890")) ==
                to!S("hello \U00010143 world"));
 
-        foreach (T; TypeTuple!(char[], const(char)[], immutable(char)[]))
+        foreach (T; AliasSeq!(char[], const(char)[], immutable(char)[]))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             assert(translate(to!S("hello world"), makeTransTable("hl", "q5"), to!T("r")) ==
                    to!S("qe55o wo5d"));
@@ -5376,13 +5376,13 @@ unittest
     import std.algorithm : equal;
 
     // Complete list of test types; too slow to test'em all
-    // alias TestTypes = TypeTuple!(
+    // alias TestTypes = AliasSeq!(
     //          char[], const( char)[], immutable( char)[],
     //         wchar[], const(wchar)[], immutable(wchar)[],
     //         dchar[], const(dchar)[], immutable(dchar)[]);
 
     // Reduced list of test types
-    alias TestTypes = TypeTuple!(char[], const(wchar)[], immutable(dchar)[]);
+    alias TestTypes = AliasSeq!(char[], const(wchar)[], immutable(dchar)[]);
 
     import std.exception;
     assertCTFEable!(
@@ -6309,7 +6309,7 @@ S[] outdent(S)(S[] lines) @safe pure if(isSomeString!S)
     assertCTFEable!(
     {
 
-    foreach (S; TypeTuple!(string, wstring, dstring))
+    foreach (S; AliasSeq!(string, wstring, dstring))
     {
         enum S blank = "";
         assert(blank.outdent() == blank);
@@ -6388,7 +6388,7 @@ auto assumeUTF(T)(T[] arr) pure
     if(staticIndexOf!(Unqual!T, ubyte, ushort, uint) != -1)
 {
     import std.utf : validate;
-    alias ToUTFType(U) = TypeTuple!(char, wchar, dchar)[U.sizeof / 2];
+    alias ToUTFType(U) = AliasSeq!(char, wchar, dchar)[U.sizeof / 2];
     auto asUTF = cast(ModifyTypePreservingTQ!(ToUTFType, T)[])arr;
     debug validate(asUTF);
     return asUTF;
@@ -6407,7 +6407,7 @@ auto assumeUTF(T)(T[] arr) pure
 pure unittest
 {
     import std.algorithm : equal;
-    foreach(T; TypeTuple!(char[], wchar[], dchar[]))
+    foreach(T; AliasSeq!(char[], wchar[], dchar[]))
     {
         immutable T jti = "Hello World";
         T jt = jti.dup;

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -43,9 +43,9 @@ Authors:   $(WEB erdani.org, Andrei Alexandrescu),
            Kenji Hara
  */
 module std.typecons;
+
+import std.meta; // : AliasSeq, allSatisfy;
 import std.traits;
-// FIXME
-import std.typetuple; // : TypeTuple, allSatisfy;
 
 debug(Unique) import std.stdio;
 
@@ -302,7 +302,7 @@ for the second, and so on.
 
 The choice of zero-based indexing instead of one-base indexing was
 motivated by the ability to use value `Tuple`s with various compile-time
-loop constructs (e.g. $(XREF typetuple, TypeTuple) iteration), all of which use
+loop constructs (e.g. $(XREF meta, AliasSeq) iteration), all of which use
 zero-based indexing.
 
 Params:
@@ -310,7 +310,7 @@ Params:
 */
 template Tuple(Specs...)
 {
-    import std.typetuple : staticMap;
+    import std.meta : staticMap;
 
     // Parse (type,name) pairs (FieldSpecs) out of the specified
     // arguments. Some fields would have name, others not.
@@ -318,21 +318,21 @@ template Tuple(Specs...)
     {
         static if (Specs.length == 0)
         {
-            alias parseSpecs = TypeTuple!();
+            alias parseSpecs = AliasSeq!();
         }
         else static if (is(Specs[0]))
         {
             static if (is(typeof(Specs[1]) : string))
             {
                 alias parseSpecs =
-                    TypeTuple!(FieldSpec!(Specs[0 .. 2]),
-                               parseSpecs!(Specs[2 .. $]));
+                    AliasSeq!(FieldSpec!(Specs[0 .. 2]),
+                              parseSpecs!(Specs[2 .. $]));
             }
             else
             {
                 alias parseSpecs =
-                    TypeTuple!(FieldSpec!(Specs[0]),
-                               parseSpecs!(Specs[1 .. $]));
+                    AliasSeq!(FieldSpec!(Specs[0]),
+                              parseSpecs!(Specs[1 .. $]));
             }
         }
         else
@@ -385,11 +385,11 @@ template Tuple(Specs...)
     {
         static if (spec.name.length == 0)
         {
-            alias expandSpec = TypeTuple!(spec.Type);
+            alias expandSpec = AliasSeq!(spec.Type);
         }
         else
         {
-            alias expandSpec = TypeTuple!(spec.Type, spec.name);
+            alias expandSpec = AliasSeq!(spec.Type, spec.name);
         }
     }
 
@@ -438,7 +438,7 @@ template Tuple(Specs...)
         unittest
         {
             alias Fields = Tuple!(int, "id", string, float);
-            static assert(is(Fields.Types == TypeTuple!(int, string, float)));
+            static assert(is(Fields.Types == AliasSeq!(int, string, float)));
         }
 
         /**
@@ -450,7 +450,7 @@ template Tuple(Specs...)
         unittest
         {
             alias Fields = Tuple!(int, "id", string, float);
-            static assert(Fields.fieldNames == TypeTuple!("id", "", ""));
+            static assert(Fields.fieldNames == AliasSeq!("id", "", ""));
         }
 
         /**
@@ -851,7 +851,7 @@ unittest
 ReverseTupleType!T reverse(T)(T t)
     if (isTuple!T)
 {
-    import std.typetuple : Reverse;
+    import std.meta : Reverse;
     // @@@BUG@@@ Cannot be an internal function due to forward reference issues.
 
     // @@@BUG@@@ 9929 Need 'this' when calling template with expanded tuple
@@ -885,11 +885,11 @@ private template ReverseTupleSpecs(T...)
     {
         static if (is(typeof(T[$-1]) : string))
         {
-            alias ReverseTupleSpecs = TypeTuple!(T[$-2], T[$-1], ReverseTupleSpecs!(T[0 .. $-2]));
+            alias ReverseTupleSpecs = AliasSeq!(T[$-2], T[$-1], ReverseTupleSpecs!(T[0 .. $-2]));
         }
         else
         {
-            alias ReverseTupleSpecs = TypeTuple!(T[$-1], ReverseTupleSpecs!(T[0 .. $-1]));
+            alias ReverseTupleSpecs = AliasSeq!(T[$-1], ReverseTupleSpecs!(T[0 .. $-1]));
         }
     }
     else
@@ -1158,8 +1158,8 @@ unittest
               inout V wv;   // OK <- NG
         inout const V wcv;  // OK <- NG
 
-        foreach (v1; TypeTuple!(mv, cv, iv, wv, wcv))
-        foreach (v2; TypeTuple!(mv, cv, iv, wv, wcv))
+        foreach (v1; AliasSeq!(mv, cv, iv, wv, wcv))
+        foreach (v2; AliasSeq!(mv, cv, iv, wv, wcv))
         {
             static assert(__traits(compiles, v1 < v2),
                           typeof(v1).stringof ~ " < " ~ typeof(v2).stringof);
@@ -1243,7 +1243,7 @@ unittest
     static assert(T.fieldNames[1] == "foo");
 
     alias Fields = Tuple!(int, "id", string, float);
-    static assert(Fields.fieldNames == TypeTuple!("id", "", ""));
+    static assert(Fields.fieldNames == AliasSeq!("id", "", ""));
 }
 
 // Bugzilla 13837
@@ -1339,12 +1339,12 @@ template tuple(Names...)
             {
                 template and(B...) if (B.length == 1)
                 {
-                    alias TypeTuple!(A[0], B[0]) and;
+                    alias AliasSeq!(A[0], B[0]) and;
                 }
 
                 template and(B...) if (B.length != 1)
                 {
-                    alias TypeTuple!(A[0], B[0],
+                    alias AliasSeq!(A[0], B[0],
                         Interleave!(A[1..$]).and!(B[1..$])) and;
                 }
             }
@@ -1629,7 +1629,7 @@ unittest
     immutable(char[]) s7654;
     Rebindable!(typeof(s7654)) r7654 = s7654;
 
-    foreach (T; TypeTuple!(char, wchar, char, int))
+    foreach (T; AliasSeq!(char, wchar, char, int))
     {
         static assert(is(Rebindable!(immutable(T[])) == immutable(T)[]));
         static assert(is(Rebindable!(const(T[])) == const(T)[]));
@@ -2160,7 +2160,7 @@ unittest
             ni = other.ni;
         }
     }
-    foreach (S; TypeTuple!(S1, S2))
+    foreach (S; AliasSeq!(S1, S2))
     {
         S a;
         S b = a;
@@ -2531,7 +2531,7 @@ unittest
             ni = other.ni;
         }
     }
-    foreach (S; TypeTuple!(S1, S2))
+    foreach (S; AliasSeq!(S1, S2))
     {
         S a;
         S b = a;
@@ -2833,7 +2833,7 @@ unittest
             ni = other.ni;
         }
     }
-    foreach (S; TypeTuple!(S1, S2))
+    foreach (S; AliasSeq!(S1, S2))
     {
         S a;
         S b = a;
@@ -3137,19 +3137,19 @@ private static:
     {
         template Impl(names...)
         {
-            import std.typetuple : Filter;
+            import std.meta : Filter;
             static if (names.length > 0)
             {
                 alias methods = Filter!(pred, MemberFunctionsTuple!(C, names[0]));
                 alias next = Impl!(names[1 .. $]);
 
                 static if (methods.length > 0)
-                    alias Impl = TypeTuple!(OverloadSet!(names[0], methods), next);
+                    alias Impl = AliasSeq!(OverloadSet!(names[0], methods), next);
                 else
                     alias Impl = next;
             }
             else
-                alias Impl = TypeTuple!();
+                alias Impl = AliasSeq!();
         }
 
         alias enumerateOverloads = Impl!(__traits(allMembers, C));
@@ -3436,13 +3436,13 @@ Used by MemberFunctionGenerator.
  */
 package template FuncInfo(alias func, /+[BUG 4217 ?]+/ T = typeof(&func))
 {
-    alias RT =         ReturnType!T;
-    alias PT = ParameterTypeTuple!T;
+    alias RT = ReturnType!T;
+    alias PT = Parameters!T;
 }
 package template FuncInfo(Func)
 {
-    alias RT =         ReturnType!Func;
-    alias PT = ParameterTypeTuple!Func;
+    alias RT = ReturnType!Func;
+    alias PT = Parameters!Func;
 }
 
 /*
@@ -3502,9 +3502,9 @@ private static:
     template CountUp(size_t n)
     {
         static if (n > 0)
-            alias CountUp = TypeTuple!(CountUp!(n - 1), n - 1);
+            alias CountUp = AliasSeq!(CountUp!(n - 1), n - 1);
         else
-            alias CountUp = TypeTuple!();
+            alias CountUp = AliasSeq!();
     }
 
 
@@ -3638,12 +3638,12 @@ private static:
         /*** Function Body ***/
         code ~= "{\n";
         {
-            enum nparams = ParameterTypeTuple!(func).length;
+            enum nparams = Parameters!(func).length;
 
             /* Declare keywords: args, self and parent. */
             string preamble;
 
-            preamble ~= "alias args = TypeTuple!(" ~ enumerateParameters!(nparams) ~ ");\n";
+            preamble ~= "alias args = AliasSeq!(" ~ enumerateParameters!(nparams) ~ ");\n";
             if (!isCtor)
             {
                 preamble ~= "alias self = " ~ name ~ ";\n";
@@ -3822,7 +3822,7 @@ unittest
 template wrap(Targets...)
 if (Targets.length >= 1 && allSatisfy!(isMutable, Targets))
 {
-    import std.typetuple : staticMap;
+    import std.meta : staticMap;
 
     // strict upcast
     auto wrap(Source)(inout Source src) @trusted pure nothrow
@@ -3856,17 +3856,17 @@ if (Targets.length >= 1 && allSatisfy!(isMutable, Targets))
         template Concat(size_t i = 0)
         {
             static if (i >= Targets.length)
-                alias Concat = TypeTuple!();
+                alias Concat = AliasSeq!();
             else
             {
-                alias Concat = TypeTuple!(GetOverloadedMethods!(Targets[i]), Concat!(i + 1));
+                alias Concat = AliasSeq!(GetOverloadedMethods!(Targets[i]), Concat!(i + 1));
             }
         }
         // Remove duplicated functions based on the identifier name and function type covariance
         template Uniq(members...)
         {
             static if (members.length == 0)
-                alias Uniq = TypeTuple!();
+                alias Uniq = AliasSeq!();
             else
             {
                 alias func = members[0];
@@ -3894,14 +3894,14 @@ if (Targets.length >= 1 && allSatisfy!(isMutable, Targets))
                                !is(DerivedFunctionType!(typex, remain[0].type) == void))
                     {
                         alias F = DerivedFunctionType!(typex, remain[0].type);
-                        alias Uniq = TypeTuple!(FuncInfo!(name, F), remain[1 .. $]);
+                        alias Uniq = AliasSeq!(FuncInfo!(name, F), remain[1 .. $]);
                     }
                     else
-                        alias Uniq = TypeTuple!(FuncInfo!(name, typex), remain);
+                        alias Uniq = AliasSeq!(FuncInfo!(name, typex), remain);
                 }
                 else
                 {
-                    alias Uniq = TypeTuple!(FuncInfo!(name, type), Uniq!(members[1 .. $]));
+                    alias Uniq = AliasSeq!(FuncInfo!(name, type), Uniq!(members[1 .. $]));
                 }
             }
         }
@@ -3955,7 +3955,7 @@ if (Targets.length >= 1 && allSatisfy!(isMutable, Targets))
                 }
                 static @property mod()
                 {
-                    alias type = TypeTuple!(TargetMembers[i].type)[0];
+                    alias type = AliasSeq!(TargetMembers[i].type)[0];
                     string r;
                     static if (is(type == immutable))       r ~= " immutable";
                     else
@@ -3970,7 +3970,7 @@ if (Targets.length >= 1 && allSatisfy!(isMutable, Targets))
                 enum n = to!string(i);
                 static if (fa & FunctionAttribute.property)
                 {
-                    static if (ParameterTypeTuple!(TargetMembers[i].type).length == 0)
+                    static if (Parameters!(TargetMembers[i].type).length == 0)
                         enum fbody = "_wrap_source."~name;
                     else
                         enum fbody = "_wrap_source."~name~" = forward!args";
@@ -3981,7 +3981,7 @@ if (Targets.length >= 1 && allSatisfy!(isMutable, Targets))
                 }
                 enum generateFun =
                     "override "~stc~"ReturnType!(TargetMembers["~n~"].type) "
-                    ~ name~"(ParameterTypeTuple!(TargetMembers["~n~"].type) args) "~mod~
+                    ~ name~"(Parameters!(TargetMembers["~n~"].type) args) "~mod~
                     "{ return "~fbody~"; }";
             }
 
@@ -3995,7 +3995,7 @@ if (Targets.length >= 1 && allSatisfy!(isMutable, Targets))
 template wrap(Targets...)
 if (Targets.length >= 1 && !allSatisfy!(isMutable, Targets))
 {
-    import std.typetuple : staticMap;
+    import std.meta : staticMap;
 
     alias wrap = .wrap!(staticMap!(Unqual, Targets));
 }
@@ -4229,14 +4229,14 @@ unittest
 // Make a tuple of non-static function symbols
 private template GetOverloadedMethods(T)
 {
-    import std.typetuple : Filter;
+    import std.meta : Filter;
 
-    alias allMembers = TypeTuple!(__traits(allMembers, T));
+    alias allMembers = AliasSeq!(__traits(allMembers, T));
     template follows(size_t i = 0)
     {
         static if (i >= allMembers.length)
         {
-            alias follows = TypeTuple!();
+            alias follows = AliasSeq!();
         }
         else static if (!__traits(compiles, mixin("T."~allMembers[i])))
         {
@@ -4253,8 +4253,8 @@ private template GetOverloadedMethods(T)
                 else
                     enum isMethod = false;
             }
-            alias follows = TypeTuple!(
-                std.typetuple.Filter!(isMethod, __traits(getOverloads, T, name)),
+            alias follows = AliasSeq!(
+                std.meta.Filter!(isMethod, __traits(getOverloads, T, name)),
                 follows!(i + 1));
         }
     }
@@ -4278,7 +4278,7 @@ private template findCovariantFunction(alias finfo, Source, Fs...)
     enum x = check!();
     static if (x == -1 && is(typeof(Source.opDispatch)))
     {
-        alias Params = ParameterTypeTuple!(finfo.type);
+        alias Params = Parameters!(finfo.type);
         enum ptrdiff_t findCovariantFunction =
             is(typeof((             Source).init.opDispatch!(finfo.name)(Params.init))) ||
             is(typeof((       const Source).init.opDispatch!(finfo.name)(Params.init))) ||
@@ -4480,17 +4480,17 @@ package template staticIota(int beg, int end)
     {
         static if (beg >= end)
         {
-            alias staticIota = TypeTuple!();
+            alias staticIota = AliasSeq!();
         }
         else
         {
-            alias staticIota = TypeTuple!(+beg);
+            alias staticIota = AliasSeq!(+beg);
         }
     }
     else
     {
         enum mid = beg + (end - beg) / 2;
-        alias staticIota = TypeTuple!(staticIota!(beg, mid), staticIota!(mid, end));
+        alias staticIota = AliasSeq!(staticIota!(beg, mid), staticIota!(mid, end));
     }
 }
 
@@ -5250,7 +5250,7 @@ unittest
         static immutable arr = [1,2,3];
     }
 
-    foreach (T; TypeTuple!(MyInt, const MyInt, immutable MyInt))
+    foreach (T; AliasSeq!(MyInt, const MyInt, immutable MyInt))
     {
         T m = 10;
         static assert(!__traits(compiles, { int x = m; }));
@@ -5295,7 +5295,7 @@ unittest
         this(immutable int[] arr) immutable { value = arr; }
     }
 
-    foreach (T; TypeTuple!(MyArray, const MyArray, immutable MyArray))
+    foreach (T; AliasSeq!(MyArray, const MyArray, immutable MyArray))
     {
       static if (is(T == immutable) && !is(typeof({ T a = [1,2,3,4]; })))
         T a = [1,2,3,4].idup;   // workaround until qualified ctor is properly supported
@@ -6027,7 +6027,7 @@ unittest // Issue 6580 testcase
             byte[size] arr;
             alignmentTest();
         }
-        foreach(i; TypeTuple!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
+        foreach(i; AliasSeq!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
             test!i();
     }
 }
@@ -6692,12 +6692,12 @@ template ReplaceType(From, To, T...)
     }
     else static if (T.length > 1)
     {
-        alias ReplaceType = TypeTuple!(ReplaceType!(From, To, T[0]),
+        alias ReplaceType = AliasSeq!(ReplaceType!(From, To, T[0]),
             ReplaceType!(From, To, T[1 .. $]));
     }
     else
     {
-        alias ReplaceType = TypeTuple!();
+        alias ReplaceType = AliasSeq!();
     }
 }
 

--- a/std/uni.d
+++ b/std/uni.d
@@ -649,7 +649,7 @@ CLUSTER = $(S_LINK Grapheme cluster, grapheme cluster)
 module std.uni;
 
 import core.stdc.stdlib;
-import std.traits, std.typetuple;
+import std.meta, std.traits;
 import std.range.primitives;
 
 
@@ -796,7 +796,7 @@ size_t replicateBits(size_t times, size_t bits)(size_t val) @safe pure nothrow @
     import std.range : iota;
     size_t m = 0b111;
     size_t m2 = 0b01;
-    foreach(i; TypeTuple!(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
+    foreach(i; AliasSeq!(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
     {
         assert(replicateBits!(i, 3)(m)+1 == (1<<(3*i)));
         assert(replicateBits!(i, 2)(m2) == iota(0, i).map!"2^^(2*a)"().sum());
@@ -3330,7 +3330,7 @@ private:
         assert(u24 != u24_2);
     }
 
-    foreach(Policy; TypeTuple!(GcPolicy, ReallocPolicy))
+    foreach(Policy; AliasSeq!(GcPolicy, ReallocPolicy))
     {
         alias Range = typeof(CowArray!Policy.init[]);
         alias U24A = CowArray!Policy;
@@ -3368,7 +3368,7 @@ private:
 
 version(unittest)
 {
-    private alias AllSets = TypeTuple!(InversionList!GcPolicy, InversionList!ReallocPolicy);
+    private alias AllSets = AliasSeq!(InversionList!GcPolicy, InversionList!ReallocPolicy);
 }
 
 @safe unittest// core set primitives test
@@ -3607,7 +3607,7 @@ version(unittest)
 {
     import std.conv;
     import std.typecons;
-    foreach(CodeList; TypeTuple!(InversionList!(ReallocPolicy)))
+    foreach(CodeList; AliasSeq!(InversionList!(ReallocPolicy)))
     {
         auto arr = "ABCDEFGHIJKLMabcdefghijklm"d;
         auto a = CodeList('A','N','a', 'n');
@@ -4069,10 +4069,10 @@ template GetBitSlicing(size_t top, sizes...)
 {
     static if(sizes.length > 0)
         alias GetBitSlicing =
-            TypeTuple!(sliceBits!(top - sizes[0], top),
-                       GetBitSlicing!(top - sizes[0], sizes[1..$]));
+            AliasSeq!(sliceBits!(top - sizes[0], top),
+                      GetBitSlicing!(top - sizes[0], sizes[1..$]));
     else
-        alias GetBitSlicing = TypeTuple!();
+        alias GetBitSlicing = AliasSeq!();
 }
 
 template callableWith(T)
@@ -4313,9 +4313,9 @@ public template buildTrie(Value, Key, Args...)
     {
         static if(n > 0)
             alias GetComparators =
-                TypeTuple!(GetComparators!(n-1), cmpK0!(Prefix[n-1]));
+                AliasSeq!(GetComparators!(n-1), cmpK0!(Prefix[n-1]));
         else
-            alias GetComparators = TypeTuple!();
+            alias GetComparators = AliasSeq!();
     }
 
     /*
@@ -4590,22 +4590,22 @@ template Utf8Matcher()
     }
 
     //for 1-stage ASCII
-    alias AsciiSpec = TypeTuple!(bool, char, clamp!7);
+    alias AsciiSpec = AliasSeq!(bool, char, clamp!7);
     //for 2-stage lookup of 2 byte UTF-8 sequences
-    alias Utf8Spec2 = TypeTuple!(bool, char[2],
+    alias Utf8Spec2 = AliasSeq!(bool, char[2],
         clampIdx!(0, 5), clampIdx!(1, 6));
     //ditto for 3 byte
-    alias Utf8Spec3 = TypeTuple!(bool, char[3],
+    alias Utf8Spec3 = AliasSeq!(bool, char[3],
         clampIdx!(0, 4),
         clampIdx!(1, 6),
         clampIdx!(2, 6)
     );
     //ditto for 4 byte
-    alias Utf8Spec4 = TypeTuple!(bool, char[4],
+    alias Utf8Spec4 = AliasSeq!(bool, char[4],
         clampIdx!(0, 3), clampIdx!(1, 6),
         clampIdx!(2, 6), clampIdx!(3, 6)
     );
-    alias Tables = TypeTuple!(
+    alias Tables = AliasSeq!(
         typeof(TrieBuilder!(AsciiSpec)(false).build()),
         typeof(TrieBuilder!(Utf8Spec2)(false).build()),
         typeof(TrieBuilder!(Utf8Spec3)(false).build()),
@@ -4869,15 +4869,14 @@ template Utf16Matcher()
         throw new UTFException("Invalid UTF-16 sequence");
     }
 
-    alias Seq = TypeTuple;
     // 1-stage ASCII
-    alias AsciiSpec = Seq!(bool, wchar, clamp!7);
+    alias AsciiSpec = AliasSeq!(bool, wchar, clamp!7);
     //2-stage BMP
-    alias BmpSpec = Seq!(bool, wchar, sliceBits!(7, 16), sliceBits!(0, 7));
+    alias BmpSpec = AliasSeq!(bool, wchar, sliceBits!(7, 16), sliceBits!(0, 7));
     //4-stage - full Unicode
     //assume that 0xD800 & 0xDC00 bits are cleared
     //thus leaving 10 bit per wchar to worry about
-    alias UniSpec = Seq!(bool, wchar[2],
+    alias UniSpec = AliasSeq!(bool, wchar[2],
         assumeSize!(x=>x[0]>>4, 6), assumeSize!(x=>x[0]&0xf, 4),
         assumeSize!(x=>x[1]>>6, 4), assumeSize!(x=>x[1]&0x3f, 6),
     );
@@ -5304,7 +5303,7 @@ unittest
     auto utf16 = utfMatcher!wchar(unicode.L);
     auto utf8 = utfMatcher!char(unicode.L);
     //decode failure cases UTF-8
-    alias fails8 = TypeTuple!("\xC1", "\x80\x00","\xC0\x00", "\xCF\x79",
+    alias fails8 = AliasSeq!("\xC1", "\x80\x00","\xC0\x00", "\xCF\x79",
         "\xFF\x00\0x00\0x00\x00", "\xC0\0x80\0x80\x80", "\x80\0x00\0x00\x00",
         "\xCF\x00\0x00\0x00\x00");
     foreach(msg; fails8){
@@ -5317,7 +5316,7 @@ unittest
         }()), format("%( %2x %)", cast(ubyte[])msg));
     }
     //decode failure cases UTF-16
-    alias fails16 = TypeTuple!([0xD811], [0xDC02]);
+    alias fails16 = AliasSeq!([0xD811], [0xDC02]);
     foreach(msg; fails16){
         assert(collectException((){
             auto s = msg.map!(x => cast(wchar)x);
@@ -5499,9 +5498,9 @@ static assert(bitSizeOf!(BitPacked!(uint, 2)) == 2);
 template Sequence(size_t start, size_t end)
 {
     static if(start < end)
-        alias Sequence = TypeTuple!(start, Sequence!(start+1, end));
+        alias Sequence = AliasSeq!(start, Sequence!(start+1, end));
     else
-        alias Sequence = TypeTuple!();
+        alias Sequence = AliasSeq!();
 }
 
 //---- TRIE TESTS ----
@@ -5631,7 +5630,7 @@ template idxTypes(Key, size_t fullBits, Prefix...)
 {
     static if(Prefix.length == 1)
     {// the last level is value level, so no index once reduced to 1-level
-        alias idxTypes = TypeTuple!();
+        alias idxTypes = AliasSeq!();
     }
     else
     {
@@ -5641,7 +5640,7 @@ template idxTypes(Key, size_t fullBits, Prefix...)
         // thus it's size in pages is full_bit_width - size_of_last_prefix
         // Recourse on this notion
         alias idxTypes =
-            TypeTuple!(
+            AliasSeq!(
                 idxTypes!(Key, fullBits - bitSizeOf!(Prefix[$-1]), Prefix[0..$-1]),
                 BitPacked!(typeof(Prefix[$-2](Key.init)), fullBits - bitSizeOf!(Prefix[$-1]))
             );
@@ -6454,7 +6453,7 @@ unittest
     auto gReverse = reverse.byGrapheme;
     assert(gReverse.walkLength == 4);
 
-    foreach(text; TypeTuple!("noe\u0308l"c, "noe\u0308l"w, "noe\u0308l"d))
+    foreach(text; AliasSeq!("noe\u0308l"c, "noe\u0308l"w, "noe\u0308l"d))
     {
         assert(text.walkLength == 5);
         static assert(isForwardRange!(typeof(text)));
@@ -7091,10 +7090,10 @@ unittest
     import std.algorithm;
     assertCTFEable!(
     {
-    foreach(cfunc; TypeTuple!(icmp, sicmp))
+    foreach(cfunc; AliasSeq!(icmp, sicmp))
     {
-        foreach(S1; TypeTuple!(string, wstring, dstring))
-        foreach(S2; TypeTuple!(string, wstring, dstring))
+        foreach(S1; AliasSeq!(string, wstring, dstring))
+        foreach(S2; AliasSeq!(string, wstring, dstring))
         (){ // avoid slow optimizations for large functions @@@BUG@@@ 2396
             assert(cfunc("".to!S1(), "".to!S2()) == 0);
             assert(cfunc("A".to!S1(), "".to!S2()) > 0);
@@ -8011,8 +8010,8 @@ private dchar toTitlecase(dchar c)
     return c;
 }
 
-private alias UpperTriple = TypeTuple!(toUpperIndex, MAX_SIMPLE_UPPER, toUpperTab);
-private alias LowerTriple = TypeTuple!(toLowerIndex, MAX_SIMPLE_LOWER, toLowerTab);
+private alias UpperTriple = AliasSeq!(toUpperIndex, MAX_SIMPLE_UPPER, toUpperTab);
+private alias LowerTriple = AliasSeq!(toLowerIndex, MAX_SIMPLE_LOWER, toLowerTab);
 
 // generic toUpper/toLower on whole string, creates new or returns as is
 private S toCase(alias indexFn, uint maxIdx, alias tableFn, S)(S s) @trusted pure
@@ -8945,7 +8944,7 @@ unittest
         assert(upInp == trueUp,
             format(diff, cast(ubyte[])s, cast(ubyte[])upInp, cast(ubyte[])trueUp));
     }
-    foreach(S; TypeTuple!(dstring, wstring, string))
+    foreach(S; AliasSeq!(dstring, wstring, string))
     {
 
         S easy = "123";
@@ -8956,7 +8955,7 @@ unittest
         S[] lower = ["123", "abcфеж", "\u0131\u023f\u03c9", "i\u0307\u1Fe2"];
         S[] upper = ["123", "ABCФЕЖ", "I\u2c7e\u2126", "\u0130\u03A5\u0308\u0300"];
 
-        foreach(val; TypeTuple!(easy, good))
+        foreach(val; AliasSeq!(easy, good))
         {
             auto e = val.dup;
             auto g = e;

--- a/std/uri.d
+++ b/std/uri.d
@@ -541,8 +541,8 @@ unittest
     result = decode("%41%42%43");
     debug(uri) writeln(result);
 
-    import std.typetuple : TypeTuple;
-    foreach (StringType; TypeTuple!(char[], wchar[], dchar[], string, wstring, dstring))
+    import std.meta : AliasSeq;
+    foreach (StringType; AliasSeq!(char[], wchar[], dchar[], string, wstring, dstring))
     {
         import std.conv : to;
         StringType decoded1 = source.to!StringType;

--- a/std/utf.d
+++ b/std/utf.d
@@ -20,9 +20,9 @@
    +/
 module std.utf;
 
+import std.meta;    // AliasSeq
 import std.range.primitives;
-import std.traits;     // isSomeChar, isSomeString
-import std.typetuple;  // TypeTuple
+import std.traits;  // isSomeChar, isSomeString
 import std.typecons : Flag;
 
 //debug=utf;           // uncomment to turn on debugging printf's
@@ -352,7 +352,7 @@ unittest
     test("hello\U00010143\u0100\U00010143", '\u0100', 9);
     test("hello\U00010143\u0100\U00010143", '\U00010143', 11);
 
-    foreach (S; TypeTuple!(char[], const char[], string))
+    foreach (S; AliasSeq!(char[], const char[], string))
     {
         enum str = to!S("hello world");
         static assert(isSafe!({ stride(str, 0); }));
@@ -413,7 +413,7 @@ uint strideBack(S)(auto ref S str, size_t index)
 
     if (index >= 4) //single verification for most common case
     {
-        foreach (i; TypeTuple!(2, 3, 4))
+        foreach (i; AliasSeq!(2, 3, 4))
         {
             if ((str[index-i] & 0b1100_0000) != 0b1000_0000)
                 return i;
@@ -421,7 +421,7 @@ uint strideBack(S)(auto ref S str, size_t index)
     }
     else
     {
-        foreach (i; TypeTuple!(2, 3))
+        foreach (i; AliasSeq!(2, 3))
         {
             if (index >= i && (str[index-i] & 0b1100_0000) != 0b1000_0000)
                 return i;
@@ -443,7 +443,7 @@ uint strideBack(S)(auto ref S str)
 {
     assert(!str.empty, "Past the end of the UTF-8 sequence");
     auto temp = str.save;
-    foreach (i; TypeTuple!(1, 2, 3, 4))
+    foreach (i; AliasSeq!(1, 2, 3, 4))
     {
         if ((temp.back & 0b1100_0000) != 0b1000_0000)
             return i;
@@ -510,7 +510,7 @@ unittest
     test("\U00010143\u0100\U00010143hello", '\u0100', 6);
     test("\U00010143\u0100\U00010143hello", '\U00010143', 4);
 
-    foreach (S; TypeTuple!(char[], const char[], string))
+    foreach (S; AliasSeq!(char[], const char[], string))
     {
         enum str = to!S("hello world");
         static assert(isSafe!({ strideBack(str, 0); }));
@@ -626,7 +626,7 @@ uint stride(S)(auto ref S str)
     test("hello\U00010143\u0100\U00010143", '\u0100', 7);
     test("hello\U00010143\u0100\U00010143", '\U00010143', 8);
 
-    foreach (S; TypeTuple!(wchar[], const wchar[], wstring))
+    foreach (S; AliasSeq!(wchar[], const wchar[], wstring))
     {
         enum str = to!S("hello world");
         static assert(isSafe!(() => stride(str, 0)));
@@ -746,7 +746,7 @@ unittest
     test("\U00010143\u0100\U00010143hello", '\u0100', 3);
     test("\U00010143\u0100\U00010143hello", '\U00010143', 2);
 
-    foreach (S; TypeTuple!(wchar[], const wchar[], wstring))
+    foreach (S; AliasSeq!(wchar[], const wchar[], wstring))
     {
         enum str = to!S("hello world");
         static assert(isSafe!(() => strideBack(str, 0)));
@@ -837,7 +837,7 @@ unittest
     test("hello\U00010143\u0100\U00010143", '\u0100', 6);
     test("hello\U00010143\u0100\U00010143", '\U00010143', 7);
 
-    foreach (S; TypeTuple!(dchar[], const dchar[], dstring))
+    foreach (S; AliasSeq!(dchar[], const dchar[], dstring))
     {
         enum str = to!S("hello world");
         static assert(isSafe!(() => stride(str, 0)));
@@ -938,7 +938,7 @@ unittest
     test("\U00010143\u0100\U00010143hello", '\u0100', 2);
     test("\U00010143\u0100\U00010143hello", '\U00010143', 1);
 
-    foreach (S; TypeTuple!(dchar[], const dchar[], dstring))
+    foreach (S; AliasSeq!(dchar[], const dchar[], dstring))
     {
         enum str = to!S("hello world");
         static assert(isSafe!(() => strideBack(str, 0)));
@@ -1241,7 +1241,7 @@ private dchar decodeImpl(bool canIndex, UseReplacementDchar useReplacementDchar 
 
     /* Dchar bitmask for different numbers of UTF-8 code units.
      */
-    alias bitMask = TypeTuple!((1 << 7) - 1, (1 << 11) - 1, (1 << 16) - 1, (1 << 21) - 1);
+    alias bitMask = AliasSeq!((1 << 7) - 1, (1 << 11) - 1, (1 << 16) - 1, (1 << 21) - 1);
 
     static if (is(S : const char[]))
         auto pstr = str.ptr + index;
@@ -1322,7 +1322,7 @@ private dchar decodeImpl(bool canIndex, UseReplacementDchar useReplacementDchar 
     dchar d = fst; // upper control bits are masked out later
     fst <<= 1;
 
-    foreach (i; TypeTuple!(1, 2, 3))
+    foreach (i; AliasSeq!(1, 2, 3))
     {
 
         static if (canIndex)
@@ -1737,9 +1737,9 @@ unittest
 
     assertCTFEable!(
     {
-    foreach (S; TypeTuple!(to!string, InputCU!char, RandomCU!char,
-                           (string s) => new RefBidirCU!char(s),
-                           (string s) => new RefRandomCU!char(s)))
+    foreach (S; AliasSeq!(to!string, InputCU!char, RandomCU!char,
+                          (string s) => new RefBidirCU!char(s),
+                          (string s) => new RefRandomCU!char(s)))
     {
         enum sHasLength = hasLength!(typeof(S("abcd")));
 
@@ -1799,9 +1799,9 @@ unittest
     import std.exception;
     assertCTFEable!(
     {
-    foreach (S; TypeTuple!(to!wstring, InputCU!wchar, RandomCU!wchar,
-                           (wstring s) => new RefBidirCU!wchar(s),
-                           (wstring s) => new RefRandomCU!wchar(s)))
+    foreach (S; AliasSeq!(to!wstring, InputCU!wchar, RandomCU!wchar,
+                          (wstring s) => new RefBidirCU!wchar(s),
+                          (wstring s) => new RefRandomCU!wchar(s)))
     {
         testBothDecode(S([cast(wchar)0x1111]), cast(dchar)0x1111, 1);
         testBothDecode(S([cast(wchar)0xD800, cast(wchar)0xDC00]), cast(dchar)0x10000, 2);
@@ -1823,7 +1823,7 @@ unittest
         }
     }
 
-    foreach (S; TypeTuple!(to!wstring, RandomCU!wchar, (wstring s) => new RefRandomCU!wchar(s)))
+    foreach (S; AliasSeq!(to!wstring, RandomCU!wchar, (wstring s) => new RefRandomCU!wchar(s)))
     {
         auto str = S([cast(wchar)0xD800, cast(wchar)0xDC00,
                       cast(wchar)0x1400,
@@ -1841,9 +1841,9 @@ unittest
     import std.exception;
     assertCTFEable!(
     {
-    foreach (S; TypeTuple!(to!dstring, RandomCU!dchar, InputCU!dchar,
-                           (dstring s) => new RefBidirCU!dchar(s),
-                           (dstring s) => new RefRandomCU!dchar(s)))
+    foreach (S; AliasSeq!(to!dstring, RandomCU!dchar, InputCU!dchar,
+                          (dstring s) => new RefBidirCU!dchar(s),
+                          (dstring s) => new RefRandomCU!dchar(s)))
     {
         testBothDecode(S([cast(dchar)0x1111]), cast(dchar)0x1111, 1);
         testBothDecode(S([cast(dchar)0x10000]), cast(dchar)0x10000, 1);
@@ -1866,7 +1866,7 @@ unittest
         }
     }
 
-    foreach (S; TypeTuple!(to!dstring, RandomCU!dchar, (dstring s) => new RefRandomCU!dchar(s)))
+    foreach (S; AliasSeq!(to!dstring, RandomCU!dchar, (dstring s) => new RefRandomCU!dchar(s)))
     {
         auto str = S([cast(dchar)0x10000, cast(dchar)0x1400, cast(dchar)0xB9DDE]);
         testDecode(str, 0, 0x10000, 1);
@@ -1881,9 +1881,9 @@ unittest
     import std.exception;
     assertCTFEable!(
     {
-    foreach (S; TypeTuple!( char[], const( char)[],  string,
-                           wchar[], const(wchar)[], wstring,
-                           dchar[], const(dchar)[], dstring))
+    foreach (S; AliasSeq!( char[], const( char)[],  string,
+                          wchar[], const(wchar)[], wstring,
+                          dchar[], const(dchar)[], dstring))
     {
         static assert(isSafe!({ S str; size_t i = 0; decode(str, i);      }));
         static assert(isSafe!({ S str; size_t i = 0; decodeFront(str, i); }));
@@ -2397,11 +2397,11 @@ unittest
 
     assertCTFEable!(
     {
-    foreach (S; TypeTuple!( char[], const  char[],  string,
-                           wchar[], const wchar[], wstring,
-                           dchar[], const dchar[], dstring))
+    foreach (S; AliasSeq!( char[], const  char[],  string,
+                          wchar[], const wchar[], wstring,
+                          dchar[], const dchar[], dstring))
     {
-        foreach (C; TypeTuple!(char, wchar, dchar))
+        foreach (C; AliasSeq!(char, wchar, dchar))
         {
             assert(codeLength!C(to!S("Walter Bright")) == to!(C[])("Walter Bright").length);
             assert(codeLength!C(to!S(`言語`)) == to!(C[])(`言語`).length);
@@ -2886,7 +2886,7 @@ private P toUTFzImpl(P, S)(S str) @safe pure
 
     assertCTFEable!(
     {
-    foreach (S; TypeTuple!(string, wstring, dstring))
+    foreach (S; AliasSeq!(string, wstring, dstring))
     {
         alias C = Unqual!(ElementEncodingType!S);
 
@@ -2906,7 +2906,7 @@ private P toUTFzImpl(P, S)(S str) @safe pure
             assert(p[s.length] == '\0');
         }
 
-        foreach (P; TypeTuple!(C*, const(C)*, immutable(C)*))
+        foreach (P; AliasSeq!(C*, const(C)*, immutable(C)*))
         {
             trustedCStringAssert!P(s1);
             trustedCStringAssert!P(s2);
@@ -2932,30 +2932,30 @@ private P toUTFzImpl(P, S)(S str) @safe pure
 
     assertCTFEable!(
     {
-    foreach (P; TypeTuple!(wchar*, const(wchar)*, immutable(wchar)*,
-                           dchar*, const(dchar)*, immutable(dchar)*))
+    foreach (P; AliasSeq!(wchar*, const(wchar)*, immutable(wchar)*,
+                          dchar*, const(dchar)*, immutable(dchar)*))
     {
         test!P("hello\U00010143\u0100\U00010143");
     }
-    foreach (P; TypeTuple!( char*, const( char)*, immutable( char)*,
-                           dchar*, const(dchar)*, immutable(dchar)*))
+    foreach (P; AliasSeq!( char*, const( char)*, immutable( char)*,
+                          dchar*, const(dchar)*, immutable(dchar)*))
     {
         test!P("hello\U00010143\u0100\U00010143"w);
     }
-    foreach (P; TypeTuple!( char*, const( char)*, immutable( char)*,
-                           wchar*, const(wchar)*, immutable(wchar)*))
+    foreach (P; AliasSeq!( char*, const( char)*, immutable( char)*,
+                          wchar*, const(wchar)*, immutable(wchar)*))
     {
         test!P("hello\U00010143\u0100\U00010143"d);
     }
-    foreach (S; TypeTuple!( char[], const( char)[],
-                           wchar[], const(wchar)[],
-                           dchar[], const(dchar)[]))
+    foreach (S; AliasSeq!( char[], const( char)[],
+                          wchar[], const(wchar)[],
+                          dchar[], const(dchar)[]))
     {
         auto s = to!S("hello\U00010143\u0100\U00010143");
 
-        foreach (P; TypeTuple!( char*, const( char)*, immutable( char)*,
-                               wchar*, const(wchar)*, immutable(wchar)*,
-                               dchar*, const(dchar)*, immutable(dchar)*))
+        foreach (P; AliasSeq!( char*, const( char)*, immutable( char)*,
+                              wchar*, const(wchar)*, immutable(wchar)*,
+                              dchar*, const(dchar)*, immutable(dchar)*))
         {
             test!P(s);
         }
@@ -2982,7 +2982,7 @@ const(wchar)* toUTF16z(C)(const(C)[] str) @safe pure
     import std.conv : to;
     //toUTFz is already thoroughly tested, so this will just verify that
     //toUTF16z compiles properly for the various string types.
-    foreach (S; TypeTuple!(string, wstring, dstring))
+    foreach (S; AliasSeq!(string, wstring, dstring))
         static assert(__traits(compiles, toUTF16z(to!S("hello world"))));
 }
 
@@ -3538,7 +3538,7 @@ int impureVariable;
         }
     }
 
-    foreach (Char; TypeTuple!(char, wchar, dchar))
+    foreach (Char; AliasSeq!(char, wchar, dchar))
     {
         ImpureThrowingSystemRange!Char range;
         foreach (c; range.byChar())  { }

--- a/std/uuid.d
+++ b/std/uuid.d
@@ -126,8 +126,7 @@ import std.traits;
  */
 public struct UUID
 {
-    import std.typetuple : allSatisfy;
-    import std.meta : AliasSeq;
+    import std.meta : AliasSeq, allSatisfy;
 
     private:
         alias skipSeq = AliasSeq!(8, 13, 18, 23);


### PR DESCRIPTION
Replace following names:
std.typetuple      -> std.meta
TypeTuple          -> AliasSeq
ParameterTypeTuple -> Parameters
FieldTypeTuple     -> Fields

std.traits requires more work than search/replace and is left unchanged.