### PR TITLE
Add Unary Overload of startsWith() and endsWith()

### DIFF
--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -3154,12 +3154,13 @@ bool skipOver(alias pred, R, E)(ref R r, E e)
 /**
 Checks whether the given
 $(XREF_PACK_NAMED range,primitives,isInputRange,input range) starts with (one
-of) the given needle(s).
+of) the given needle(s) or, if no needles are given,
+if its front element fulfils predicate $(D pred).
 
 Params:
 
     pred = Predicate to use in comparing the elements of the haystack and the
-        needle(s).
+        needle(s). Mandatory if no needles are given.
 
     doesThisStart = The input range to check.
 

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -968,7 +968,10 @@ Returns:
 otherwise the position of the matching needle, that is, 1 if the range ends
 with $(D withOneOfThese[0]), 2 if it ends with $(D withOneOfThese[1]), and so
 on.
- */
+
+In the case when no needle parameters are given, return $(D true) iff back of
+$(D doesThisStart) fulfils predicate $(D pred).
+*/
 uint endsWith(alias pred = "a == b", Range, Needles...)(Range doesThisEnd, Needles withOneOfThese)
 if (isBidirectionalRange!Range && Needles.length > 1 &&
     is(typeof(.endsWith!pred(doesThisEnd, withOneOfThese[0])) : bool) &&
@@ -1063,29 +1066,6 @@ if (isBidirectionalRange!R1 &&
     }
 }
 
-/**
-   Checks whether the given
-   $(XREF_PACK_NAMED range,primitives,isInputRange,input range) ends with an
-   element that fulfils predicate $(D pred).
-
-   Params:
-
-   pred = Unary mandatory predicate.
-
-   doesThisEnd = The input range to check.
-
-   Returns:
-
-   $(D bool) if the first element in range $(D doesThisEnd) fulfils predicate
-   $(D pred), $(D false) otherwise.
-*/
-bool endsWith(alias pred = "a", R)(R doesThisEnd)
-    if (isInputRange!R &&
-        is(typeof(unaryFun!pred(doesThisEnd.front)) : bool))
-{
-    return !doesThisEnd.empty && unaryFun!pred(doesThisEnd.back);
-}
-
 /// Ditto
 bool endsWith(alias pred = "a == b", R, E)(R doesThisEnd, E withThis)
 if (isBidirectionalRange!R &&
@@ -1096,13 +1076,30 @@ if (isBidirectionalRange!R &&
         : binaryFun!pred(doesThisEnd.back, withThis);
 }
 
+/// Ditto
+bool endsWith(alias pred, R)(R doesThisEnd)
+    if (isInputRange!R &&
+        ifTestable!(typeof(doesThisEnd.front), unaryFun!pred))
+{
+    return !doesThisEnd.empty && unaryFun!pred(doesThisEnd.back);
+}
+
 ///
 @safe unittest
 {
     import std.ascii : isAlpha;
     assert("abc".endsWith!(a => a.isAlpha));
+    assert("abc".endsWith!isAlpha);
+
     assert(!"ab1".endsWith!(a => a.isAlpha));
+
+    assert(!"ab1".endsWith!isAlpha);
     assert(!"".endsWith!(a => a.isAlpha));
+
+    import std.algorithm.comparison : among;
+    assert("abc".endsWith!(a => a.among('c', 'd') != 0));
+    assert(!"abc".endsWith!(a => a.among('a', 'b') != 0));
+
     assert(endsWith("abc", ""));
     assert(!endsWith("abc", "b"));
     assert(endsWith("abc", "a", 'c') == 2);
@@ -3182,6 +3179,9 @@ elements in $(D withOneOfThese), then the shortest one matches (if there are
 two which match which are of the same length (e.g. $(D "a") and $(D 'a')), then
 the left-most of them in the argument
 list matches).
+
+In the case when no needle parameters are given, return $(D true) iff front of
+$(D doesThisStart) fulfils predicate $(D pred).
  */
 uint startsWith(alias pred = "a == b", Range, Needles...)(Range doesThisStart, Needles withOneOfThese)
 if (isInputRange!Range && Needles.length > 1 &&
@@ -3324,46 +3324,38 @@ if (isInputRange!R1 &&
     }
 }
 
-/**
-   Checks whether the given
-   $(XREF_PACK_NAMED range,primitives,isInputRange,input range) starts with an
-   element that fulfils predicate $(D pred).
-
-   Params:
-
-   pred = Unary mandatory predicate.
-
-   doesThisStart = The input range to check.
-
-   Returns:
-
-   $(D bool) if the first element in range $(D doesThisStart) fulfils predicate
-   $(D pred), $(D false) otherwise.
-*/
-bool startsWith(alias pred = "a", R)(R doesThisStart)
-    if (isInputRange!R &&
-        is(typeof(unaryFun!pred(doesThisStart.front)) : bool))
-{
-    return !doesThisStart.empty && unaryFun!pred(doesThisStart.front);
-}
-
 /// Ditto
 bool startsWith(alias pred = "a == b", R, E)(R doesThisStart, E withThis)
-if (isInputRange!R &&
-    is(typeof(binaryFun!pred(doesThisStart.front, withThis)) : bool))
+    if (isInputRange!R &&
+        is(typeof(binaryFun!pred(doesThisStart.front, withThis)) : bool))
 {
     return doesThisStart.empty
         ? false
         : binaryFun!pred(doesThisStart.front, withThis);
 }
 
+/// Ditto
+bool startsWith(alias pred, R)(R doesThisStart)
+    if (isInputRange!R &&
+        ifTestable!(typeof(doesThisStart.front), unaryFun!pred))
+{
+    return !doesThisStart.empty && unaryFun!pred(doesThisStart.front);
+}
+
 ///
 @safe unittest
 {
     import std.ascii : isAlpha;
+
     assert("abc".startsWith!(a => a.isAlpha));
+    assert("abc".startsWith!isAlpha);
     assert(!"1ab".startsWith!(a => a.isAlpha));
     assert(!"".startsWith!(a => a.isAlpha));
+
+    import std.algorithm.comparison : among;
+    assert("abc".startsWith!(a => a.among('a', 'b') != 0));
+    assert(!"abc".startsWith!(a => a.among('b', 'c') != 0));
+
     assert(startsWith("abc", ""));
     assert(startsWith("abc", "a"));
     assert(!startsWith("abc", "b"));

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -1063,6 +1063,29 @@ if (isBidirectionalRange!R1 &&
     }
 }
 
+/**
+   Checks whether the given
+   $(XREF_PACK_NAMED range,primitives,isInputRange,input range) ends with an
+   element that fulfils predicate $(D pred).
+
+   Params:
+
+   pred = Unary mandatory predicate.
+
+   doesThisEnd = The input range to check.
+
+   Returns:
+
+   $(D bool) if the first element in range $(D doesThisEnd) fulfils predicate
+   $(D pred), $(D false) otherwise.
+*/
+bool endsWith(alias pred = "a", R)(R doesThisEnd)
+    if (isInputRange!R &&
+        is(typeof(unaryFun!pred(doesThisEnd.front)) : bool))
+{
+    return !doesThisEnd.empty && unaryFun!pred(doesThisEnd.back);
+}
+
 /// Ditto
 bool endsWith(alias pred = "a == b", R, E)(R doesThisEnd, E withThis)
 if (isBidirectionalRange!R &&
@@ -1076,6 +1099,10 @@ if (isBidirectionalRange!R &&
 ///
 @safe unittest
 {
+    import std.ascii : isAlpha;
+    assert("abc".endsWith!(a => a.isAlpha));
+    assert(!"ab1".endsWith!(a => a.isAlpha));
+    assert(!"".endsWith!(a => a.isAlpha));
     assert(endsWith("abc", ""));
     assert(!endsWith("abc", "b"));
     assert(endsWith("abc", "a", 'c') == 2);
@@ -3296,6 +3323,29 @@ if (isInputRange!R1 &&
     }
 }
 
+/**
+   Checks whether the given
+   $(XREF_PACK_NAMED range,primitives,isInputRange,input range) starts with an
+   element that fulfils predicate $(D pred).
+
+   Params:
+
+   pred = Unary mandatory predicate.
+
+   doesThisStart = The input range to check.
+
+   Returns:
+
+   $(D bool) if the first element in range $(D doesThisStart) fulfils predicate
+   $(D pred), $(D false) otherwise.
+*/
+bool startsWith(alias pred = "a", R)(R doesThisStart)
+    if (isInputRange!R &&
+        is(typeof(unaryFun!pred(doesThisStart.front)) : bool))
+{
+    return !doesThisStart.empty && unaryFun!pred(doesThisStart.front);
+}
+
 /// Ditto
 bool startsWith(alias pred = "a == b", R, E)(R doesThisStart, E withThis)
 if (isInputRange!R &&
@@ -3309,6 +3359,10 @@ if (isInputRange!R &&
 ///
 @safe unittest
 {
+    import std.ascii : isAlpha;
+    assert("abc".startsWith!(a => a.isAlpha));
+    assert(!"1ab".startsWith!(a => a.isAlpha));
+    assert(!"".startsWith!(a => a.isAlpha));
     assert(startsWith("abc", ""));
     assert(startsWith("abc", "a"));
     assert(!startsWith("abc", "b"));


### PR DESCRIPTION
Adds overload that enables calling `startsWith` and `endsWith` with only a `haystack` and predicate `pred`.

See discussion at: http://forum.dlang.org/post/zobvqdmxnjnilqibtcph@forum.dlang.org

Should `RandomAccess` have special treatment via `.length` and `opIndex` or should we just use `.empty` and `.front` for every case?

If not I guess we could just do

```D
{
    return !haystack.empty && haystack.front.unaryFun!pred
}
```

right?