### PR TITLE
fix Issue 15027 - rangified functions no longer work with alias this'ed strings (e.g. DirEntry) 

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -1387,6 +1387,14 @@ assert("/usr/share/include".isDir);
     }
 }
 
+/// ditto
+@property bool isDir(R)(auto ref R name)
+if (!(isInputRange!R && isSomeChar!(ElementEncodingType!R))
+    && is(StringTypeOf!R))
+{
+    return isDir(cast(StringTypeOf!R)name);
+}
+
 @safe unittest
 {
     version(Windows)
@@ -1407,6 +1415,21 @@ assert("/usr/share/include".isDir);
     }
 }
 
+unittest
+{
+    version(Windows)
+        enum dir = "C:\\Program Files\\";
+    else version(Posix)
+        enum dir = system_directory;
+
+    if (dir.exists)
+    {
+        DirEntry de = DirEntry(dir);
+        bool rc = isDir(de);
+        rc = de.isDir;
+        rc = isDir(DirEntry(dir));
+    }
+}
 
 /++
     Returns whether the given file attributes are for a directory.


### PR DESCRIPTION
This adds the usual overload taking the struct by auto ref, avoiding issues with expensive or disabled posblit.

https://issues.dlang.org/show_bug.cgi?id=15027

Other functions in std.file have been rangified in previous releases, these should get the same fix.