### PR TITLE
std.format: give a proper message when a floating point value is not given a compatible format character

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -1698,7 +1698,7 @@ if (is(FloatingPointTypeOf!T) && !is(T == enum) && !hasToString!(T, Char))
         return;
     }
     enforceFmt(find("fgFGaAeEs", fs.spec).length,
-        "floating");
+        "incompatible format character for floating point type");
 
     version (CRuntime_Microsoft)
     {
@@ -5459,7 +5459,7 @@ void doFormat()(scope void delegate(dchar) putc, TypeInfo[] arguments, va_list a
                 default:
                     //printf("fc = '%c'\n", fc);
                 Lerror:
-                    throw new FormatException("floating");
+                    throw new FormatException("incompatible format character for floating point type");
             }
             version (DigitalMarsC)
             {


### PR DESCRIPTION
Currently when a floating point argument to format is not provided a compatible format character i.e. one of `fgFGaAeEs`, then it throws an exception whose message is just "floating", which is vague, to say the least. I have made it now give a meaningful message.

I'm not sure why this can't be detected at compile time, though, since I seem to remember Clang warning me of incompatible specifiers in case of C `fprintf`... Even `dmd -wi` doesn't give any warning.
