### PR TITLE
fix Issue 15027 - rangified function isDir no longer works with alias this'ed strings

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -1405,6 +1405,14 @@ assert("/usr/share/include".isDir);
     }
 }
 
+/// ditto
+@property bool isDir(R)(auto ref R name)
+if (!(isInputRange!R && isSomeChar!(ElementEncodingType!R))
+    && is(StringTypeOf!R))
+{
+    return isDir(cast(StringTypeOf!R)name);
+}
+
 @safe unittest
 {
     version(Windows)
@@ -1425,6 +1433,21 @@ assert("/usr/share/include".isDir);
     }
 }
 
+unittest
+{
+    version(Windows)
+        enum dir = "C:\\Program Files\\";
+    else version(Posix)
+        enum dir = system_directory;
+
+    if (dir.exists)
+    {
+        DirEntry de = DirEntry(dir);
+        assert(isDir(de));
+        assert(de.isDir);
+        assert(isDir(DirEntry(dir)));
+    }
+}
 
 /++
     Returns whether the given file attributes are for a directory.

--- a/std/file.d
+++ b/std/file.d
@@ -1405,7 +1405,6 @@ assert("/usr/share/include".isDir);
     }
 }
 
-/// ditto
 @property bool isDir(R)(auto ref R name)
 if (!(isInputRange!R && isSomeChar!(ElementEncodingType!R))
     && is(StringTypeOf!R))


### PR DESCRIPTION
https://github.com/D-Programming-Language/phobos/pull/3753 now on stable.

This adds the usual overload taking the struct by auto ref, avoiding issues with expensive or disabled posblit.

https://issues.dlang.org/show_bug.cgi?id=15027

Other functions in std.file have been rangified in previous releases, these should get the same fix.
