### PR TITLE
Trivial fixes to enable Phobos to compile properly with DMD PR #5229.

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -538,13 +538,18 @@ uint formattedWrite(Writer, Char, A...)(Writer w, in Char[] fmt, A args)
         if (spec.indexStart > 0)
         {
             // using positional parameters!
-            foreach (i; spec.indexStart - 1 .. spec.indexEnd)
+
+            // Make the conditional compilation of this loop explicit, to avoid "statement not reachable" warnings.
+            static if(A.length > 0)
             {
-                if (funs.length <= i) break;
-                if (__ctfe)
-                    formatNth(w, spec, i, args);
-                else
-                    funs[i](w, argsAddresses[i], spec);
+                foreach (i; spec.indexStart - 1 .. spec.indexEnd)
+                {
+                    if (funs.length <= i) break;
+                    if (__ctfe)
+                        formatNth(w, spec, i, args);
+                    else
+                        funs[i](w, argsAddresses[i], spec);
+                }
             }
             if (currentArg < spec.indexEnd) currentArg = spec.indexEnd;
         }

--- a/std/uni.d
+++ b/std/uni.d
@@ -4890,7 +4890,7 @@ template Utf16Matcher()
         assert(ch <= 0xF_FFFF);
         wchar[2] ret;
         //do not put surrogate bits, they are sliced off
-        ret[0] = (ch>>10);
+        ret[0] = cast(wchar)(ch>>10);
         ret[1] = (ch & 0xFFF);
         return ret;
     }


### PR DESCRIPTION
This PR enables Phobos to compile properly without error with [DMD PR #5229](https://github.com/D-Programming-Language/dmd/pull/5229). This PR must be merged first, so that the DMD PR can pass the auto-tester.

The change to `std.uni` simply makes an implicit cast into an explicit one. This is necessary because the basis on which the old version of the compiler "proved" the cast to be safe included the faulty assumption that `dchar` values can never be greater than `dchar.max`. (Hopefully in the future VRP can be improved to take the assertion on line 4890 into account, instead. But that's probably a big project.)

The change to `std.format` is to prevent a "statement not reachable" warning on the original line 544, caused by the upgraded compiler correctly detecting that when `A.length == 0`, the `foreach` loop always `break`s on the first iteration without doing anything.

**Edit:** The problem in `std.format` is caused by [DMD issue #14835](https://issues.dlang.org/show_bug.cgi?id=14835#add_comment), which is exacerbated by the improved constant folding implemented by my DMD PR.