### PR TITLE
Add isInputRangeOf template constraint

### DIFF
--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -176,6 +176,18 @@ template isInputRange(R)
     static assert( isInputRange!(inout(int)[]));
 }
 
+/**
+ Returns $(D true) if $(D R) is an input range with elements of type $(D E);
+ */
+enum isInputRangeOf(R, E) = isInputRange!R && is(ElementType!R == E);
+
+///
+@safe unittest {
+    static assert(isInputRangeOf!(int[], int));
+    static assert(isInputRangeOf!(const(int)[], const(int)));
+    static assert(!isInputRangeOf!(int, int));
+}
+
 /+
 puts the whole raw element $(D e) into $(D r). doPut will not attempt to
 iterate, slice or transcode $(D e) in any way shape or form. It will $(B only)

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -179,12 +179,13 @@ template isInputRange(R)
 /**
  Returns $(D true) if $(D R) is an input range with elements of type $(D E);
  */
-enum isInputRangeOf(R, E) = isInputRange!R && is(ElementType!R == E);
+enum isInputRangeOf(R, E) = isInputRange!R && is(ElementType!R: E);
 
 ///
 @safe unittest {
     static assert(isInputRangeOf!(int[], int));
     static assert(isInputRangeOf!(const(int)[], const(int)));
+    static assert(isInputRangeOf!(int[], long));
     static assert(!isInputRangeOf!(int, int));
 }
 


### PR DESCRIPTION
Idiomatic D uses input ranges where possible. Right now however, transiotining a function from taking `T[]` to a range is more cumbersome than necessary. This PR introduces a new template contraint so that:

    void func(int[] numbers) { /*...*/ }

Can easily be converted to 
    
    void func(R)(R range) if(isInputRangeOf!(R, int)) { /*...*/ }

Instead of manually typing out

    void func(R)(R range) if(isInputRange!R && is(ElementType!R == int)) { /*...*/ }