### PR TITLE
Fix DList.insertFront(range) regression - #15263.

### DIFF
--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -163,7 +163,7 @@ struct DList(T)
   private
   {
     //Construct as new PayNode, and returns it as a BaseNode.
-    static BaseNode* createNode(Stuff)(ref Stuff arg, BaseNode* prev = null, BaseNode* next = null)
+    static BaseNode* createNode(Stuff)(auto ref Stuff arg, BaseNode* prev = null, BaseNode* next = null)
     {
         return (new PayNode(BaseNode(prev, next), arg)).asBaseNode();
     }
@@ -935,4 +935,12 @@ private:
     static class Test : ITest {}
 
     DList!ITest().insertBack(new Test());
+}
+
+@safe unittest //15263
+{
+    import std.range : iota;
+    auto a = DList!int();
+    a.insertFront(iota(0, 5)); // can insert range with non-ref front
+    assert(a.front == 0 && a.back == 4);
 }


### PR DESCRIPTION
As createNode was taking a value by ref, Dlist.insertFront could not be
called with a range with a non-ref front.

Fix by providing a createNode overload to use for non-ref values.
Resolves #15263.