### PR TITLE
[Issue 3764] Remove Phobos workarounds for fixed bugs

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -3731,8 +3731,6 @@ unittest
     }
 
     // test with ubyte[] inputs
-    //@@@BUG 2612@@@
-    //alias TestedWith2 = AliasSeq!(immutable(ubyte)[], ubyte[]);
     alias TestedWith2 = AliasSeq!(immutable(ubyte)[], ubyte[]);
     foreach (T; TestedWith2) {
         // test looping with an empty file


### PR DESCRIPTION
2612 was the only bug that still had a workaround.