### PR TITLE
Slightly relax std.internal.math.gammafunction unittest for 64-bit reals

### DIFF
--- a/std/internal/math/gammafunction.d
+++ b/std/internal/math/gammafunction.d
@@ -1662,7 +1662,7 @@ unittest {
         tuple(1017.644138623741168814449776695062817947092468536L, 1.0L/1024),
     ];
     foreach (test; testData)
-        assert(approxEqual(logmdigammaInverse(test[0]), test[1], 1e-15, 0));
+        assert(approxEqual(logmdigammaInverse(test[0]), test[1], 2e-15, 0));
 
     assert(approxEqual(logmdigamma(logmdigammaInverse(1)), 1, 1e-15, 0));
     assert(approxEqual(logmdigamma(logmdigammaInverse(real.min_normal)), real.min_normal, 1e-15, 0));


### PR DESCRIPTION
Using LDC master on Win64, I get a relative diff of 1.068e-15 for the second tuple (input = 1/8), exceeding the allowed upper bound by not even 7%. I chose to be generous and doubled the limit. ;)

More details for the 2nd tuple:
```
actual:   0x1.0a333fd8b6880p+2
expected: 0x1.0a333fd8b687bp+2
rel diff: 1.067682e-15
```

The other 4 tuples are perfect matches.