### PR TITLE
Remove `static assert(__traits(compiles, xyz))` from `std.conv`

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -3876,14 +3876,18 @@ unittest
     long b;
 
     // biggest value that should fit in an it
-    static assert(__traits(compiles, a = octal!"17777777777"));
+    a = octal!"17777777777";
+    assert(a == int.max);
     // should not fit in the int
     static assert(!__traits(compiles, a = octal!"20000000000"));
     // ... but should fit in a long
-    static assert(__traits(compiles, b = octal!"20000000000"));
+    b = octal!"20000000000";
+    assert(b == 1L + int.max);
 
-    static assert(__traits(compiles, b = octal!"1L"));
-    static assert(__traits(compiles, b = octal!1L));
+    b = octal!"1L";
+    assert(b == 1);
+    b = octal!1L;
+    assert(b == 1);
 }
 
 /+
@@ -4129,7 +4133,7 @@ unittest
     struct S { @disable this(); }
     S s = void;
     static assert(!__traits(compiles, emplace(&s)));
-    static assert( __traits(compiles, emplace(&s, S.init)));
+    emplace(&s, S.init);
 }
 
 unittest
@@ -4186,12 +4190,12 @@ unittest
     }
     S1[2] ss1 = void;
     S2[2] ss2 = void;
-    static assert( __traits(compiles, emplace(&ss1)));
+    emplace(&ss1);
     static assert(!__traits(compiles, emplace(&ss2)));
     S1 s1 = S1.init;
     S2 s2 = S2.init;
     static assert(!__traits(compiles, emplace(&ss1, s1)));
-    static assert( __traits(compiles, emplace(&ss2, s2)));
+    emplace(&ss2, s2);
 }
 
 unittest
@@ -4398,7 +4402,7 @@ unittest
         @disable this(this);
     }
     S1 s1 = void;
-    static assert( __traits(compiles, emplace(&s1, 1)));
+    emplace(&s1, 1);
     static assert(!__traits(compiles, emplace(&s1, S1.init)));
 
     static struct S2
@@ -4409,14 +4413,14 @@ unittest
     }
     S2 s2 = void;
     static assert(!__traits(compiles, emplace(&s2, 1)));
-    static assert( __traits(compiles, emplace(&s2, S2.init)));
+    emplace(&s2, S2.init);
 
     static struct SS1
     {
         S1 s;
     }
     SS1 ss1 = void;
-    static assert( __traits(compiles, emplace(&ss1)));
+    emplace(&ss1);
     static assert(!__traits(compiles, emplace(&ss1, SS1.init)));
 
     static struct SS2
@@ -4424,7 +4428,7 @@ unittest
         S2 s;
     }
     SS2 ss2 = void;
-    static assert( __traits(compiles, emplace(&ss2)));
+    emplace(&ss2);
     static assert(!__traits(compiles, emplace(&ss2, SS2.init)));
 
 
@@ -4694,7 +4698,7 @@ unittest
         }
         S1 s = void;
         static assert(!__traits(compiles, emplace(&s,  1)));
-        static assert( __traits(compiles, emplace(&s, &i))); //(works, but deprected)
+        static assert( __traits(compiles, emplace(&s, &i))); //(works, but deprecated)
     }
     //With constructor
     {
@@ -4706,8 +4710,8 @@ unittest
             this(int i){this.i = i;}
         }
         S2 s = void;
-        static assert( __traits(compiles, emplace(&s, 1)));  //(works, but deprected)
-        static assert( __traits(compiles, emplace(&s, &i))); //(works, but deprected)
+        static assert( __traits(compiles, emplace(&s, 1)));  //(works, but deprecated)
+        static assert( __traits(compiles, emplace(&s, &i))); //(works, but deprecated)
         emplace(&s,  1);
         assert(s.i == 1);
     }
@@ -4719,7 +4723,7 @@ unittest
             static S3 opCall(ref S3){assert(0);}
         }
         S3 s = void;
-        static assert( __traits(compiles, emplace(&s, S3.init)));
+        emplace(&s, S3.init);
     }
 }
 

--- a/std/conv.d
+++ b/std/conv.d
@@ -4403,6 +4403,7 @@ unittest
     }
     S1 s1 = void;
     emplace(&s1, 1);
+    assert(s1.i == 1);
     static assert(!__traits(compiles, emplace(&s1, S1.init)));
 
     static struct S2


### PR DESCRIPTION
The pattern `static assert(__traits(compiles, xyz))` arised probably as a converse to its negation, e.g.:

```d
static assert( __traits(compiles, emplace(&ss2)));
static assert(!__traits(compiles, emplace(&ss2, SS2.init)));
```

However, the pattern should be avoided for two reasons:

1. Often it's best to also execute the code and make sure it works as expected (as this PR shows for the octal examples)
2. When working on the module, a failure of `static assert(__compiles)` does not show the reason in the error messages. This makes code more difficult to work with gratuitously.

This is just the beginning - could someone please eliminate this pattern from all of Phobos? Thanks!