### PR TITLE
Simpler emplace

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -3925,8 +3925,8 @@ if (is(UT == Unqual!T))
                 static if (Args.length == 1)
                     static if (is(typeof(payload = x[0])))
                         payload = x[0];
-                else
-                    payload = T(x[0]);
+                    else
+                        payload = T(x[0]);
                 else
                     payload = T(x);
             }
@@ -3949,7 +3949,7 @@ if (is(UT == Unqual!T))
     }
     else static if (is(typeof(chunk.__ctor(args))))
     {
-        // This catches the rate case of local types that keep a frame pointer
+        // This catches the rare case of local types that keep a frame pointer
         emplaceInitializer(chunk);
         chunk.__ctor(args);
     }
@@ -4151,6 +4151,26 @@ unittest
     s.b = 43;
     auto s1 = emplace!S(p, s);
     assert(s1.a == 42 && s1.b == 43);
+}
+
+// Bulk of emplace unittests starts here
+
+unittest /* unions */
+{
+    static union U
+    {
+        string a;
+        int b;
+        struct
+        {
+            long c;
+            int[] d;
+        }
+    }
+    U u1 = void;
+    U u2 = { "hello" };
+    emplace(&u1, u2);
+    assert(u1.a == "hello");
 }
 
 version(unittest) private struct __conv_EmplaceTest
@@ -5037,6 +5057,7 @@ unittest
     // need ctor args
     static assert(!is(typeof(emplace!A(buf))));
 }
+// Bulk of emplace unittests ends here
 
 unittest
 {

--- a/std/conv.d
+++ b/std/conv.d
@@ -4693,6 +4693,7 @@ unittest
         emplace(ps2, 5);
         emplace(ps2, S2.init);
     }
+    foo();
 
     T bar(T)() @property
     {
@@ -4700,12 +4701,20 @@ unittest
         emplace(&t, 5);
         return t;
     }
+    // CTFE
     enum a = bar!int;
     static assert(a == 5);
     enum b = bar!S1;
     static assert(b.i == 5);
     enum c = bar!S2;
     static assert(c.i == 5);
+    // runtime
+    auto aa = bar!int;
+    assert(aa == 5);
+    auto bb = bar!S1;
+    assert(bb.i == 5);
+    auto cc = bar!S2;
+    assert(cc.i == 5);
 }
 
 

--- a/std/conv.d
+++ b/std/conv.d
@@ -3937,7 +3937,7 @@ if (is(UT == Unqual!T))
                 chunk = T(args);
             else static if (args.length == 1 && is(typeof(chunk = args[0])))
                 chunk = args[0];
-            else assert(0, "CTFE emplace doesn't support " 
+            else assert(0, "CTFE emplace doesn't support "
                 ~ T.stringof ~ " from " ~ Args.stringof);
         }
         else
@@ -3949,7 +3949,7 @@ if (is(UT == Unqual!T))
     }
     else static if (is(typeof(chunk.__ctor(args))))
     {
-        // This catches the rate case of local types that keep a frame pointer 
+        // This catches the rate case of local types that keep a frame pointer
         emplaceInitializer(chunk);
         chunk.__ctor(args);
     }
@@ -3963,7 +3963,7 @@ if (is(UT == Unqual!T))
         //We can't emplace. Try to diagnose a disabled postblit.
         static assert(!(Args.length == 1 && is(Args[0] : T)),
             convFormat("Cannot emplace a %1$s because %1$s.this(this) is annotated with @disable.", T.stringof));
-        
+
         //We can't emplace.
         static assert(false,
             convFormat("%s cannot be emplaced from %s.", T.stringof, Args[].stringof));
@@ -4014,7 +4014,7 @@ T* emplace(T)(T* chunk) @safe pure nothrow
 ///
 unittest
 {
-    static struct S 
+    static struct S
     {
         int i = 42;
     }
@@ -4074,10 +4074,10 @@ T emplace(T, Args...)(void[] chunk, auto ref Args args)
     enum classSize = __traits(classInstanceSize, T);
     testEmplaceChunk(chunk, classSize, classInstanceAlignment!T, T.stringof);
     auto result = cast(T) chunk.ptr;
-    
+
     // Initialize the object in its pre-ctor state
     chunk[0 .. classSize] = typeid(T).init[];
-    
+
     // Call the ctor if any
     static if (is(typeof(result.__ctor(args))))
     {
@@ -4099,11 +4099,11 @@ unittest
 {
     interface I {}
     class K : I {}
-    
+
     K k = void;
     emplace(&k);
     assert(k is null);
-    
+
     I i = void;
     emplace(&i);
     assert(i is null);


### PR DESCRIPTION
The logic in `emplace` copies the logic used by the compiler itself in generating constructors. After sleeping on it for a night I figured I could get most of that logic just work for us by defining a `struct` with only one member and one constructor. Then the rest is taken care of.