### PR TITLE
[Issue 15320] eliminate 'static assert(__traits(compiles,..'

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -765,14 +765,14 @@ unittest
 
     // Issue #10130 - map of iota with const step.
     const step = 2;
-    map!(i => i)(iota(0, 10, step));
+    assert(map!(i => i)(iota(0, 10, step)).walkLength == 5);
 
     // Need these to all by const to repro the float case, due to the
     // CommonType template used in the float specialization of iota.
     const floatBegin = 0.0;
     const floatEnd = 1.0;
     const floatStep = 0.02;
-    map!(i => i)(iota(floatBegin, floatEnd, floatStep));
+    assert(map!(i => i)(iota(floatBegin, floatEnd, floatStep)).walkLength == 50);
 }
 
 @safe unittest

--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -765,14 +765,14 @@ unittest
 
     // Issue #10130 - map of iota with const step.
     const step = 2;
-    static assert(__traits(compiles, map!(i => i)(iota(0, 10, step))));
+    map!(i => i)(iota(0, 10, step));
 
     // Need these to all by const to repro the float case, due to the
     // CommonType template used in the float specialization of iota.
     const floatBegin = 0.0;
     const floatEnd = 1.0;
     const floatStep = 0.02;
-    static assert(__traits(compiles, map!(i => i)(iota(floatBegin, floatEnd, floatStep))));
+    map!(i => i)(iota(floatBegin, floatEnd, floatStep));
 }
 
 @safe unittest

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -574,11 +574,13 @@ void fill(Range, Value)(Range range, Value value)
         int[] a = [1, 2, 3];
         immutable(int) b = 0;
         a.fill(b);
+        assert(a == [0, 0, 0]);
     }
     {
         double[] a = [1, 2, 3];
         immutable(int) b = 0;
         a.fill(b);
+        assert(a == [0, 0, 0]);
     }
 }
 
@@ -982,7 +984,10 @@ unittest
     class S5;
 
     S5 s51;
-    move(s51, s51);
+    S5 s52 = s51;
+    S5 s53;
+    move(s52, s53);
+    assert(s53 is s51);
 }
 
 /// Ditto
@@ -1092,17 +1097,24 @@ unittest
     class S5;
 
     S5 s51;
-    s51 = move(s51);
+    S5 s52 = s51;
+    S5 s53;
+    s53 = move(s52);
+    assert(s53 is s51);
 }
 
 unittest
 {
-    static struct S { ~this() @system { } }
+    static struct S { int n = 0; ~this() @system { n = 0; } }
     S a, b;
     static assert(!__traits(compiles, () @safe { move(a, b); }));
     static assert(!__traits(compiles, () @safe { move(a); }));
+    a.n = 1;
     () @trusted { move(a, b); }();
+    assert(a.n == 0);
+    a.n = 1;
     () @trusted { move(a); }();
+    assert(a.n == 0);
 }
 
 unittest//Issue 6217

--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -573,12 +573,12 @@ void fill(Range, Value)(Range range, Value value)
     {
         int[] a = [1, 2, 3];
         immutable(int) b = 0;
-        static assert(__traits(compiles, a.fill(b)));
+        a.fill(b);
     }
     {
         double[] a = [1, 2, 3];
         immutable(int) b = 0;
-        static assert(__traits(compiles, a.fill(b)));
+        a.fill(b);
     }
 }
 
@@ -982,8 +982,7 @@ unittest
     class S5;
 
     S5 s51;
-    static assert(__traits(compiles, move(s51, s51)),
-                  "issue 13990, cannot move opaque class reference");
+    move(s51, s51);
 }
 
 /// Ditto
@@ -1093,8 +1092,7 @@ unittest
     class S5;
 
     S5 s51;
-    static assert(__traits(compiles, s51 = move(s51)),
-                  "issue 13990, cannot move opaque class reference");
+    s51 = move(s51);
 }
 
 unittest
@@ -1103,8 +1101,8 @@ unittest
     S a, b;
     static assert(!__traits(compiles, () @safe { move(a, b); }));
     static assert(!__traits(compiles, () @safe { move(a); }));
-    static assert(__traits(compiles, () @trusted { move(a, b); }));
-    static assert(__traits(compiles, () @trusted { move(a); }));
+    () @trusted { move(a, b); }();
+    () @trusted { move(a); }();
 }
 
 unittest//Issue 6217
@@ -1166,8 +1164,8 @@ unittest// Issue 8057
         }
     }
     Array!int.Payload x = void;
-    static assert(__traits(compiles, move(x)    ));
-    static assert(__traits(compiles, move(x, x) ));
+    move(x);
+    move(x, x);
 }
 
 /**

--- a/std/array.d
+++ b/std/array.d
@@ -377,7 +377,7 @@ unittest
     import std.typecons;
     static assert(!__traits(compiles, [ tuple("foo", "bar", "baz") ].assocArray()));
     static assert(!__traits(compiles, [ tuple("foo") ].assocArray()));
-    static assert( __traits(compiles, [ tuple("foo", "bar") ].assocArray()));
+    [ tuple("foo", "bar") ].assocArray();
 }
 
 // Issue 13909
@@ -386,7 +386,7 @@ unittest
     import std.typecons;
     auto a = [tuple!(const string, string)("foo", "bar")];
     auto b = [tuple!(string, const string)("foo", "bar")];
-    static assert( __traits(compiles, assocArray(a)));
+    assocArray(a);
     static assert(!__traits(compiles, assocArray(b)));
 }
 

--- a/std/array.d
+++ b/std/array.d
@@ -377,7 +377,7 @@ unittest
     import std.typecons;
     static assert(!__traits(compiles, [ tuple("foo", "bar", "baz") ].assocArray()));
     static assert(!__traits(compiles, [ tuple("foo") ].assocArray()));
-    [ tuple("foo", "bar") ].assocArray();
+    assert([ tuple("foo", "bar") ].assocArray() == ["foo": "bar"]);
 }
 
 // Issue 13909
@@ -386,7 +386,7 @@ unittest
     import std.typecons;
     auto a = [tuple!(const string, string)("foo", "bar")];
     auto b = [tuple!(string, const string)("foo", "bar")];
-    assocArray(a);
+    assert(assocArray(a) == [cast(const(string)) "foo": "bar"]);
     static assert(!__traits(compiles, assocArray(b)));
 }
 

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -2290,8 +2290,8 @@ public:
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        assert(cst.stdTime == 630_668_538_330_000_000L);
-        //assert(ist.stdTime == 630_668_538_330_000_000L);
+        assert(cst.stdTime > 0);
+        //assert(ist.stdTime > 0);
     }
 
 

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -927,15 +927,15 @@ public:
         auto st = SysTime(DateTime(1999, 7, 6, 12, 33, 30));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 33, 30));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 33, 30));
-        static assert(__traits(compiles, st == st));
-        static assert(__traits(compiles, st == cst));
-        //static assert(__traits(compiles, st == ist));
-        static assert(__traits(compiles, cst == st));
-        static assert(__traits(compiles, cst == cst));
-        //static assert(__traits(compiles, cst == ist));
-        //static assert(__traits(compiles, ist == st));
-        //static assert(__traits(compiles, ist == cst));
-        //static assert(__traits(compiles, ist == ist));
+        assert(st == st);
+        assert(st == cst);
+        //assert(st == ist);
+        assert(cst == st);
+        assert(cst == cst);
+        //assert(cst == ist);
+        //assert(ist == st);
+        //assert(ist == cst);
+        //assert(ist == ist);
     }
 
     /++
@@ -1008,15 +1008,15 @@ public:
         auto st = SysTime(DateTime(1999, 7, 6, 12, 33, 30));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 33, 30));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 33, 30));
-        static assert(__traits(compiles, st.opCmp(st)));
-        static assert(__traits(compiles, st.opCmp(cst)));
-        //static assert(__traits(compiles, st.opCmp(ist)));
-        static assert(__traits(compiles, cst.opCmp(st)));
-        static assert(__traits(compiles, cst.opCmp(cst)));
-        //static assert(__traits(compiles, cst.opCmp(ist)));
-        //static assert(__traits(compiles, ist.opCmp(st)));
-        //static assert(__traits(compiles, ist.opCmp(cst)));
-        //static assert(__traits(compiles, ist.opCmp(ist)));
+        assert(st.opCmp(st) == 0);
+        assert(st.opCmp(cst) == 0);
+        //assert(st.opCmp(ist) == 0);
+        assert(cst.opCmp(st) == 0);
+        assert(cst.opCmp(cst) == 0);
+        //assert(cst.opCmp(ist) == 0);
+        //assert(ist.opCmp(st) == 0);
+        //assert(ist.opCmp(cst) == 0);
+        //assert(ist.opCmp(ist) == 0);
     }
 
     /++
@@ -1061,8 +1061,8 @@ public:
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, cst.year));
-        //static assert(__traits(compiles, ist.year));
+        assert(cst.year == 1999);
+        //assert(ist.year == 1999);
     }
 
     /++
@@ -1185,7 +1185,7 @@ public:
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, st.year = 12));
+        st.year = 12;
         static assert(!__traits(compiles, cst.year = 12));
         //static assert(!__traits(compiles, ist.year = 12));
     }
@@ -1281,7 +1281,7 @@ public:
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, st.yearBC = 12));
+        st.yearBC = 12;
         static assert(!__traits(compiles, cst.yearBC = 12));
         //static assert(!__traits(compiles, ist.yearBC = 12));
     }
@@ -1335,8 +1335,8 @@ public:
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, cst.month));
-        //static assert(__traits(compiles, ist.month));
+        assert(cst.month == 7);
+        //assert(ist.month == 7);
     }
 
 
@@ -1496,8 +1496,8 @@ public:
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, cst.day));
-        //static assert(__traits(compiles, ist.day));
+         assert(cst.day == 6);
+        //assert(ist.day == 6);
     }
 
 
@@ -1659,8 +1659,8 @@ public:
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, cst.hour));
-        //static assert(__traits(compiles, ist.hour));
+        assert(cst.hour == 12);
+        //assert(ist.hour == 12);
     }
 
 
@@ -1784,8 +1784,8 @@ public:
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, cst.minute));
-        //static assert(__traits(compiles, ist.minute));
+        assert(cst.minute == 30);
+        //assert(ist.minute == 30);
     }
 
 
@@ -1913,8 +1913,8 @@ public:
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, cst.second));
-        //static assert(__traits(compiles, ist.second));
+        assert(cst.second == 33);
+        //assert(ist.second == 33);
     }
 
 
@@ -2042,8 +2042,8 @@ public:
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, cst.fracSecs));
-        //static assert(__traits(compiles, ist.fracSecs));
+        assert(cst.fracSecs == Duration.zero);
+        //assert(ist.fracSecs == Duration.zero);
     }
 
 
@@ -2195,8 +2195,8 @@ public:
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, cst.fracSec));
-        //static assert(__traits(compiles, ist.fracSec));
+        assert(cst.fracSec == FracSec.zero);
+        //assert(ist.fracSec == FracSec.zero);
     }
 
 
@@ -2285,13 +2285,13 @@ public:
         assert(SysTime(0).stdTime == 0);
         assert(SysTime(1).stdTime == 1);
         assert(SysTime(-1).stdTime == -1);
-        assert(SysTime(DateTime(1, 1, 1, 0, 0, 33), hnsecs(502), UTC()).stdTime == 330000502L);
-        assert(SysTime(DateTime(1970, 1, 1, 0, 0, 0), UTC()).stdTime == 621355968000000000L);
+        assert(SysTime(DateTime(1, 1, 1, 0, 0, 33), hnsecs(502), UTC()).stdTime == 330_000_502L);
+        assert(SysTime(DateTime(1970, 1, 1, 0, 0, 0), UTC()).stdTime == 621_355_968_000_000_000L);
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, cst.stdTime));
-        //static assert(__traits(compiles, ist.stdTime));
+        assert(cst.stdTime == 630_668_538_330_000_000L);
+        //assert(ist.stdTime == 630_668_538_330_000_000L);
     }
 
 
@@ -3926,7 +3926,7 @@ public:
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, st.roll!"years"(4)));
+        st.roll!"years"(4);
         static assert(!__traits(compiles, cst.roll!"years"(4)));
         //static assert(!__traits(compiles, ist.roll!"years"(4)));
     }
@@ -6371,10 +6371,10 @@ public:
         auto duration = dur!"seconds"(12);
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, cst + duration));
-        //static assert(__traits(compiles, ist + duration));
-        static assert(__traits(compiles, cst - duration));
-        //static assert(__traits(compiles, ist - duration));
+        assert(cst + duration == SysTime(DateTime(1999, 7, 6, 12, 30, 45)));
+        //assert(ist + duration == SysTime(DateTime(1999, 7, 6, 12, 30, 45)));
+        assert(cst - duration == SysTime(DateTime(1999, 7, 6, 12, 30, 21)));
+        //assert(ist - duration == SysTime(DateTime(1999, 7, 6, 12, 30, 21)));
     }
 
 
@@ -6672,17 +6672,17 @@ public:
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, st - st));
-        static assert(__traits(compiles, cst - st));
-        //static assert(__traits(compiles, ist - st));
+        assert(st - st == Duration.zero);
+        assert(cst - st == Duration.zero);
+        //assert(ist - st == Duration.zero);
 
-        static assert(__traits(compiles, st - cst));
-        static assert(__traits(compiles, cst - cst));
-        //static assert(__traits(compiles, ist - cst));
+        assert(st - cst == Duration.zero);
+        assert(cst - cst == Duration.zero);
+        //assert(ist - cst == Duration.zero);
 
-        //static assert(__traits(compiles, st - ist));
-        //static assert(__traits(compiles, cst - ist));
-        //static assert(__traits(compiles, ist - ist));
+        //assert(st - ist == Duration.zero);
+        //assert(cst - ist == Duration.zero);
+        //assert(ist - ist == Duration.zero);
     }
 
 
@@ -6733,17 +6733,17 @@ public:
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, st.diffMonths(st)));
-        static assert(__traits(compiles, cst.diffMonths(st)));
-        //static assert(__traits(compiles, ist.diffMonths(st)));
+        assert(st.diffMonths(st) == 0);
+        assert(cst.diffMonths(st) == 0);
+        //assert(ist.diffMonths(st) == 0);
 
-        static assert(__traits(compiles, st.diffMonths(cst)));
-        static assert(__traits(compiles, cst.diffMonths(cst)));
-        //static assert(__traits(compiles, ist.diffMonths(cst)));
+        assert(st.diffMonths(cst) == 0);
+        assert(cst.diffMonths(cst) == 0);
+        //assert(ist.diffMonths(cst) == 0);
 
-        //static assert(__traits(compiles, st.diffMonths(ist)));
-        //static assert(__traits(compiles, cst.diffMonths(ist)));
-        //static assert(__traits(compiles, ist.diffMonths(ist)));
+        //assert(st.diffMonths(ist) == 0);
+        //assert(cst.diffMonths(ist) == 0);
+        //assert(ist.diffMonths(ist) == 0);
     }
 
 
@@ -6760,9 +6760,9 @@ public:
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, st.isLeapYear));
-        static assert(__traits(compiles, cst.isLeapYear));
-        //static assert(__traits(compiles, ist.isLeapYear));
+        assert(!st.isLeapYear);
+        assert(!cst.isLeapYear);
+        //assert(!ist.isLeapYear);
     }
 
 
@@ -6779,9 +6779,9 @@ public:
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, st.dayOfWeek));
-        static assert(__traits(compiles, cst.dayOfWeek));
-        //static assert(__traits(compiles, ist.dayOfWeek));
+        assert(st.dayOfWeek == DayOfWeek.tue);
+        assert(cst.dayOfWeek == DayOfWeek.tue);
+        //assert(ist.dayOfWeek == DayOfWeek.tue);
     }
 
 
@@ -6806,9 +6806,9 @@ public:
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, st.dayOfYear));
-        static assert(__traits(compiles, cst.dayOfYear));
-        //static assert(__traits(compiles, ist.dayOfYear));
+        assert(st.dayOfYear == 187);
+        assert(cst.dayOfYear == 187);
+        //assert(ist.dayOfYear == 187);
     }
 
 
@@ -6838,7 +6838,7 @@ public:
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, st.dayOfYear = 12));
+        st.dayOfYear = 12;
         static assert(!__traits(compiles, cst.dayOfYear = 12));
         //static assert(!__traits(compiles, ist.dayOfYear = 12));
     }
@@ -7042,8 +7042,8 @@ public:
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, cst.dayOfGregorianCal));
-        //static assert(__traits(compiles, ist.dayOfGregorianCal));
+        assert(cst.dayOfGregorianCal == 729_941);
+        //assert(ist.dayOfGregorianCal == 729_941);
     }
 
 
@@ -7486,9 +7486,9 @@ public:
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, st.isoWeek));
-        static assert(__traits(compiles, cst.isoWeek));
-        //static assert(__traits(compiles, ist.isoWeek));
+        assert(st.isoWeek == 27);
+        assert(cst.isoWeek == 27);
+        //assert(ist.isoWeek == 27);
     }
 
 
@@ -7581,8 +7581,8 @@ public:
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, cst.endOfMonth));
-        //static assert(__traits(compiles, ist.endOfMonth));
+        assert(cst.endOfMonth == SysTime(DateTime(1999, 7, 31, 23, 59, 59), hnsecs(9_999_999)));
+        //assert(ist.endOfMonth == SysTime(DateTime(1999, 7, 31, 23, 59, 59), hnsecs(9_999_999)));
     }
 
 
@@ -7637,8 +7637,8 @@ public:
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, cst.daysInMonth));
-        //static assert(__traits(compiles, ist.daysInMonth));
+        assert(cst.daysInMonth == 31);
+        //assert(ist.daysInMonth == 31);
     }
 
 
@@ -7670,8 +7670,8 @@ public:
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, cst.isAD));
-        //static assert(__traits(compiles, ist.isAD));
+        assert(cst.isAD);
+        //assert(ist.isAD);
     }
 
 
@@ -7717,8 +7717,8 @@ public:
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, cst.julianDay));
-        //static assert(__traits(compiles, ist.julianDay));
+        assert(cst.julianDay == 2_451_366);
+        //assert(ist.julianDay == 2_451_366);
     }
 
 
@@ -7741,8 +7741,8 @@ public:
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, cst.modJulianDay));
-        //static assert(__traits(compiles, ist.modJulianDay));
+        assert(cst.modJulianDay == 51_365);
+        //assert(ist.modJulianDay == 51_365);
     }
 
 
@@ -7775,8 +7775,8 @@ public:
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, cast(Date)cst));
-        //static assert(__traits(compiles, cast(Date)ist));
+        assert(cast(Date)cst != Date.init);
+        //assert(cast(Date)ist != Date.init);
     }
 
 
@@ -7834,8 +7834,8 @@ public:
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, cast(DateTime)cst));
-        //static assert(__traits(compiles, cast(DateTime)ist));
+        assert(cast(DateTime)cst != DateTime.init);
+        //assert(cast(DateTime)ist != DateTime.init);
     }
 
 
@@ -7883,8 +7883,8 @@ public:
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, cast(TimeOfDay)cst));
-        //static assert(__traits(compiles, cast(TimeOfDay)ist));
+        assert(cast(TimeOfDay)cst != TimeOfDay.init);
+        //assert(cast(TimeOfDay)ist != TimeOfDay.init);
     }
 
 
@@ -8024,8 +8024,8 @@ public:
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, cast(TimeOfDay)cst));
-        //static assert(__traits(compiles, cast(TimeOfDay)ist));
+        assert(cast(TimeOfDay)cst != TimeOfDay.init);
+        //assert(cast(TimeOfDay)ist != TimeOfDay.init);
     }
 
 
@@ -8160,8 +8160,8 @@ public:
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, cast(TimeOfDay)cst));
-        //static assert(__traits(compiles, cast(TimeOfDay)ist));
+        assert(cast(TimeOfDay)cst != TimeOfDay.init);
+        //assert(cast(TimeOfDay)ist != TimeOfDay.init);
     }
 
     /++
@@ -8295,8 +8295,8 @@ public:
 
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, cast(TimeOfDay)cst));
-        //static assert(__traits(compiles, cast(TimeOfDay)ist));
+        assert(cast(TimeOfDay)cst != TimeOfDay.init);
+        //assert(cast(TimeOfDay)ist != TimeOfDay.init);
     }
 
 
@@ -8313,9 +8313,9 @@ public:
         auto st = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
-        static assert(__traits(compiles, st.toString()));
-        static assert(__traits(compiles, cst.toString()));
-        //static assert(__traits(compiles, ist.toString()));
+        assert(st.toString());
+        assert(cst.toString());
+        //assert(ist.toString());
     }
 
 
@@ -9403,15 +9403,15 @@ public:
         auto date = Date(1999, 7, 6);
         const cdate = Date(1999, 7, 6);
         immutable idate = Date(1999, 7, 6);
-        static assert(__traits(compiles, date.opCmp(date)));
-        static assert(__traits(compiles, date.opCmp(cdate)));
-        static assert(__traits(compiles, date.opCmp(idate)));
-        static assert(__traits(compiles, cdate.opCmp(date)));
-        static assert(__traits(compiles, cdate.opCmp(cdate)));
-        static assert(__traits(compiles, cdate.opCmp(idate)));
-        static assert(__traits(compiles, idate.opCmp(date)));
-        static assert(__traits(compiles, idate.opCmp(cdate)));
-        static assert(__traits(compiles, idate.opCmp(idate)));
+        assert(date.opCmp(date) == 0);
+        assert(date.opCmp(cdate) == 0);
+        assert(date.opCmp(idate) == 0);
+        assert(cdate.opCmp(date) == 0);
+        assert(cdate.opCmp(cdate) == 0);
+        assert(cdate.opCmp(idate) == 0);
+        assert(idate.opCmp(date) == 0);
+        assert(idate.opCmp(cdate) == 0);
+        assert(idate.opCmp(idate) == 0);
     }
 
 
@@ -9440,8 +9440,8 @@ public:
 
         const cdate = Date(1999, 7, 6);
         immutable idate = Date(1999, 7, 6);
-        static assert(__traits(compiles, cdate.year == 1999));
-        static assert(__traits(compiles, idate.year == 1999));
+        assert(cdate.year == 1999);
+        assert(idate.year == 1999);
     }
 
     /++
@@ -9525,9 +9525,9 @@ public:
         auto date = Date(0, 7, 6);
         const cdate = Date(0, 7, 6);
         immutable idate = Date(0, 7, 6);
-        static assert(__traits(compiles, date.yearBC));
-        static assert(__traits(compiles, cdate.yearBC));
-        static assert(__traits(compiles, idate.yearBC));
+        assert(date.yearBC == 1);
+        assert(cdate.yearBC == 1);
+        assert(idate.yearBC == 1);
     }
 
 
@@ -9566,7 +9566,7 @@ public:
         auto date = Date(0, 7, 6);
         const cdate = Date(0, 7, 6);
         immutable idate = Date(0, 7, 6);
-        static assert(__traits(compiles, date.yearBC = 7));
+        date.yearBC = 7;
         static assert(!__traits(compiles, cdate.yearBC = 7));
         static assert(!__traits(compiles, idate.yearBC = 7));
     }
@@ -9596,8 +9596,8 @@ public:
 
         const cdate = Date(1999, 7, 6);
         immutable idate = Date(1999, 7, 6);
-        static assert(__traits(compiles, cdate.month == 7));
-        static assert(__traits(compiles, idate.month == 7));
+        assert(cdate.month == 7);
+        assert(idate.month == 7);
     }
 
     /++
@@ -9676,8 +9676,8 @@ public:
 
         const cdate = Date(1999, 7, 6);
         immutable idate = Date(1999, 7, 6);
-        static assert(__traits(compiles, cdate.day == 6));
-        static assert(__traits(compiles, idate.day == 6));
+        assert(cdate.day == 6);
+        assert(idate.day == 6);
     }
 
     /++
@@ -11534,13 +11534,13 @@ public:
         auto duration = dur!"days"(12);
         const cdate = Date(1999, 7, 6);
         immutable idate = Date(1999, 7, 6);
-        static assert(__traits(compiles, date + duration));
-        static assert(__traits(compiles, cdate + duration));
-        static assert(__traits(compiles, idate + duration));
+        assert(date + duration == Date(1999, 7, 18));
+        assert(cdate + duration == Date(1999, 7, 18));
+        assert(idate + duration == Date(1999, 7, 18));
 
-        static assert(__traits(compiles, date - duration));
-        static assert(__traits(compiles, cdate - duration));
-        static assert(__traits(compiles, idate - duration));
+        assert(date - duration == Date(1999, 6, 24));
+        assert(cdate - duration == Date(1999, 6, 24));
+        assert(idate - duration == Date(1999, 6, 24));
     }
 
 
@@ -11621,11 +11621,11 @@ public:
         auto date = Date(1999, 7, 6);
         const cdate = Date(1999, 7, 6);
         immutable idate = Date(1999, 7, 6);
-        static assert(__traits(compiles, date += duration));
+        date += duration;
         static assert(!__traits(compiles, cdate += duration));
         static assert(!__traits(compiles, idate += duration));
 
-        static assert(__traits(compiles, date -= duration));
+        date -= duration;
         static assert(!__traits(compiles, cdate -= duration));
         static assert(!__traits(compiles, idate -= duration));
     }
@@ -11659,17 +11659,17 @@ public:
 
         const cdate = Date(1999, 7, 6);
         immutable idate = Date(1999, 7, 6);
-        static assert(__traits(compiles, date - date));
-        static assert(__traits(compiles, cdate - date));
-        static assert(__traits(compiles, idate - date));
+        assert(date - date == Duration.zero);
+        assert(cdate - date == Duration.zero);
+        assert(idate - date == Duration.zero);
 
-        static assert(__traits(compiles, date - cdate));
-        static assert(__traits(compiles, cdate - cdate));
-        static assert(__traits(compiles, idate - cdate));
+        assert(date - cdate == Duration.zero);
+        assert(cdate - cdate == Duration.zero);
+        assert(idate - cdate == Duration.zero);
 
-        static assert(__traits(compiles, date - idate));
-        static assert(__traits(compiles, cdate - idate));
-        static assert(__traits(compiles, idate - idate));
+        assert(date - idate == Duration.zero);
+        assert(cdate - idate == Duration.zero);
+        assert(idate - idate == Duration.zero);
     }
 
 
@@ -11915,17 +11915,17 @@ public:
 
         const cdate = Date(1999, 7, 6);
         immutable idate = Date(1999, 7, 6);
-        static assert(__traits(compiles, date.diffMonths(date)));
-        static assert(__traits(compiles, cdate.diffMonths(date)));
-        static assert(__traits(compiles, idate.diffMonths(date)));
+        assert(date.diffMonths(date) == 0);
+        assert(cdate.diffMonths(date) == 0);
+        assert(idate.diffMonths(date) == 0);
 
-        static assert(__traits(compiles, date.diffMonths(cdate)));
-        static assert(__traits(compiles, cdate.diffMonths(cdate)));
-        static assert(__traits(compiles, idate.diffMonths(cdate)));
+        assert(date.diffMonths(cdate) == 0);
+        assert(cdate.diffMonths(cdate) == 0);
+        assert(idate.diffMonths(cdate) == 0);
 
-        static assert(__traits(compiles, date.diffMonths(idate)));
-        static assert(__traits(compiles, cdate.diffMonths(idate)));
-        static assert(__traits(compiles, idate.diffMonths(idate)));
+        assert(date.diffMonths(idate) == 0);
+        assert(cdate.diffMonths(idate) == 0);
+        assert(idate.diffMonths(idate) == 0);
     }
 
 
@@ -11960,9 +11960,9 @@ public:
     {
         const cdate = Date(1999, 7, 6);
         immutable idate = Date(1999, 7, 6);
-        static assert(__traits(compiles, cdate.dayOfWeek == DayOfWeek.sun));
+        assert(cdate.dayOfWeek == DayOfWeek.tue);
         static assert(!__traits(compiles, cdate.dayOfWeek = DayOfWeek.sun));
-        static assert(__traits(compiles, idate.dayOfWeek == DayOfWeek.sun));
+        assert(idate.dayOfWeek == DayOfWeek.tue);
         static assert(!__traits(compiles, idate.dayOfWeek = DayOfWeek.sun));
     }
 
@@ -12016,8 +12016,8 @@ public:
 
         const cdate = Date(1999, 7, 6);
         immutable idate = Date(1999, 7, 6);
-        static assert(__traits(compiles, cdate.dayOfYear == 187));
-        static assert(__traits(compiles, idate.dayOfYear == 187));
+        assert(cdate.dayOfYear == 187);
+        assert(idate.dayOfYear == 187);
     }
 
     /++
@@ -12159,9 +12159,9 @@ public:
         auto date = Date(1999, 7, 6);
         const cdate = Date(1999, 7, 6);
         immutable idate = Date(1999, 7, 6);
-        static assert(__traits(compiles, date.dayOfGregorianCal));
-        static assert(__traits(compiles, cdate.dayOfGregorianCal));
-        static assert(__traits(compiles, idate.dayOfGregorianCal));
+        assert(date.dayOfGregorianCal == 729_941);
+        assert(cdate.dayOfGregorianCal == 729_941);
+        assert(idate.dayOfGregorianCal == 729_941);
     }
 
     /++
@@ -12209,7 +12209,7 @@ public:
         auto date = Date(1999, 7, 6);
         const cdate = Date(1999, 7, 6);
         immutable idate = Date(1999, 7, 6);
-        static assert(__traits(compiles, date.dayOfGregorianCal = 187));
+        date.dayOfGregorianCal = 187;
         static assert(!__traits(compiles, cdate.dayOfGregorianCal = 187));
         static assert(!__traits(compiles, idate.dayOfGregorianCal = 187));
     }
@@ -12310,9 +12310,9 @@ public:
 
         const cdate = Date(1999, 7, 6);
         immutable idate = Date(1999, 7, 6);
-        static assert(__traits(compiles, cdate.isoWeek == 3));
+        assert(cdate.isoWeek == 27);
         static assert(!__traits(compiles, cdate.isoWeek = 3));
-        static assert(__traits(compiles, idate.isoWeek == 3));
+        assert(idate.isoWeek == 27);
         static assert(!__traits(compiles, idate.isoWeek = 3));
     }
 
@@ -12459,8 +12459,8 @@ public:
 
         const cdate = Date(1999, 7, 6);
         immutable idate = Date(1999, 7, 6);
-        static assert(__traits(compiles, cdate.isAD));
-        static assert(__traits(compiles, idate.isAD));
+        assert(cdate.isAD);
+        assert(idate.isAD);
     }
 
 
@@ -12486,8 +12486,8 @@ public:
 
         const cdate = Date(1999, 7, 6);
         immutable idate = Date(1999, 7, 6);
-        static assert(__traits(compiles, cdate.julianDay));
-        static assert(__traits(compiles, idate.julianDay));
+        assert(cdate.julianDay == 2_451_366);
+        assert(idate.julianDay == 2_451_366);
     }
 
 
@@ -12507,8 +12507,8 @@ public:
 
         const cdate = Date(1999, 7, 6);
         immutable idate = Date(1999, 7, 6);
-        static assert(__traits(compiles, cdate.modJulianDay));
-        static assert(__traits(compiles, idate.modJulianDay));
+        assert(cdate.modJulianDay == 51_365);
+        assert(idate.modJulianDay == 51_365);
     }
 
 
@@ -12564,8 +12564,8 @@ public:
 
         const cdate = Date(1999, 7, 6);
         immutable idate = Date(1999, 7, 6);
-        static assert(__traits(compiles, cdate.toISOString()));
-        static assert(__traits(compiles, idate.toISOString()));
+        assert(cdate.toISOString() == "19990706");
+        assert(idate.toISOString() == "19990706");
     }
 
     /++
@@ -12620,8 +12620,8 @@ public:
 
         const cdate = Date(1999, 7, 6);
         immutable idate = Date(1999, 7, 6);
-        static assert(__traits(compiles, cdate.toISOExtString()));
-        static assert(__traits(compiles, idate.toISOExtString()));
+        assert(cdate.toISOExtString() == "1999-07-06");
+        assert(idate.toISOExtString() == "1999-07-06");
     }
 
     /++
@@ -12676,8 +12676,8 @@ public:
 
         const cdate = Date(1999, 7, 6);
         immutable idate = Date(1999, 7, 6);
-        static assert(__traits(compiles, cdate.toSimpleString()));
-        static assert(__traits(compiles, idate.toSimpleString()));
+        assert(cdate.toSimpleString() == "1999-Jul-06");
+        assert(idate.toSimpleString() == "1999-Jul-06");
     }
 
 
@@ -12694,9 +12694,9 @@ public:
         auto date = Date(1999, 7, 6);
         const cdate = Date(1999, 7, 6);
         immutable idate = Date(1999, 7, 6);
-        static assert(__traits(compiles, date.toString()));
-        static assert(__traits(compiles, cdate.toString()));
-        static assert(__traits(compiles, idate.toString()));
+        assert(date.toString());
+        assert(cdate.toString());
+        assert(idate.toString());
     }
 
 
@@ -13452,8 +13452,8 @@ public:
 
         const ctod = TimeOfDay(12, 30, 33);
         immutable itod = TimeOfDay(12, 30, 33);
-        static assert(__traits(compiles, ctod.opCmp(itod)));
-        static assert(__traits(compiles, itod.opCmp(ctod)));
+        assert(ctod.opCmp(itod) == 0);
+        assert(itod.opCmp(ctod) == 0);
     }
 
 
@@ -13472,8 +13472,8 @@ public:
 
         const ctod = TimeOfDay(12, 0, 0);
         immutable itod = TimeOfDay(12, 0, 0);
-        static assert(__traits(compiles, ctod.hour == 12));
-        static assert(__traits(compiles, itod.hour == 12));
+        assert(ctod.hour == 12);
+        assert(itod.hour == 12);
     }
 
 
@@ -13523,8 +13523,8 @@ public:
 
         const ctod = TimeOfDay(0, 30, 0);
         immutable itod = TimeOfDay(0, 30, 0);
-        static assert(__traits(compiles, ctod.minute == 30));
-        static assert(__traits(compiles, itod.minute == 30));
+        assert(ctod.minute == 30);
+        assert(itod.minute == 30);
     }
 
 
@@ -13574,8 +13574,8 @@ public:
 
         const ctod = TimeOfDay(0, 0, 33);
         immutable itod = TimeOfDay(0, 0, 33);
-        static assert(__traits(compiles, ctod.second == 33));
-        static assert(__traits(compiles, itod.second == 33));
+        assert(ctod.second == 33);
+        assert(itod.second == 33);
     }
 
 
@@ -13935,15 +13935,15 @@ public:
         }
 
         auto duration = dur!"hours"(11);
-        const ctod = TimeOfDay(12, 33, 30);
-        immutable itod = TimeOfDay(12, 33, 30);
-        static assert(__traits(compiles, tod + duration));
-        static assert(__traits(compiles, ctod + duration));
-        static assert(__traits(compiles, itod + duration));
+        const ctod = TimeOfDay(12, 30, 33);
+        immutable itod = TimeOfDay(12, 30, 33);
+        assert(tod + duration == TimeOfDay(23, 30, 33));
+        assert(ctod + duration == TimeOfDay(23, 30, 33));
+        assert(itod + duration == TimeOfDay(23, 30, 33));
 
-        static assert(__traits(compiles, tod - duration));
-        static assert(__traits(compiles, ctod - duration));
-        static assert(__traits(compiles, itod - duration));
+        assert(tod - duration == TimeOfDay(1, 30, 33));
+        assert(ctod - duration == TimeOfDay(1, 30, 33));
+        assert(itod - duration == TimeOfDay(1, 30, 33));
     }
 
 
@@ -14058,17 +14058,17 @@ public:
 
         const ctod = TimeOfDay(12, 30, 33);
         immutable itod = TimeOfDay(12, 30, 33);
-        static assert(__traits(compiles, tod - tod));
-        static assert(__traits(compiles, ctod - tod));
-        static assert(__traits(compiles, itod - tod));
+        assert(tod - tod == Duration.zero);
+        assert(ctod - tod == Duration.zero);
+        assert(itod - tod == Duration.zero);
 
-        static assert(__traits(compiles, tod - ctod));
-        static assert(__traits(compiles, ctod - ctod));
-        static assert(__traits(compiles, itod - ctod));
+        assert(tod - ctod == Duration.zero);
+        assert(ctod - ctod == Duration.zero);
+        assert(itod - ctod == Duration.zero);
 
-        static assert(__traits(compiles, tod - itod));
-        static assert(__traits(compiles, ctod - itod));
-        static assert(__traits(compiles, itod - itod));
+        assert(tod - itod == Duration.zero);
+        assert(ctod - itod == Duration.zero);
+        assert(itod - itod == Duration.zero);
     }
 
 
@@ -14096,9 +14096,9 @@ public:
         auto tod = TimeOfDay(12, 30, 33);
         const ctod = TimeOfDay(12, 30, 33);
         immutable itod = TimeOfDay(12, 30, 33);
-        static assert(__traits(compiles, tod.toISOString()));
-        static assert(__traits(compiles, ctod.toISOString()));
-        static assert(__traits(compiles, itod.toISOString()));
+        assert(tod.toISOString() == "123033");
+        assert(ctod.toISOString() == "123033");
+        assert(itod.toISOString() == "123033");
     }
 
 
@@ -14126,9 +14126,9 @@ public:
         auto tod = TimeOfDay(12, 30, 33);
         const ctod = TimeOfDay(12, 30, 33);
         immutable itod = TimeOfDay(12, 30, 33);
-        static assert(__traits(compiles, tod.toISOExtString()));
-        static assert(__traits(compiles, ctod.toISOExtString()));
-        static assert(__traits(compiles, itod.toISOExtString()));
+        assert(tod.toISOExtString() == "12:30:33");
+        assert(ctod.toISOExtString() == "12:30:33");
+        assert(itod.toISOExtString() == "12:30:33");
     }
 
 
@@ -14145,9 +14145,9 @@ public:
         auto tod = TimeOfDay(12, 30, 33);
         const ctod = TimeOfDay(12, 30, 33);
         immutable itod = TimeOfDay(12, 30, 33);
-        static assert(__traits(compiles, tod.toString()));
-        static assert(__traits(compiles, ctod.toString()));
-        static assert(__traits(compiles, itod.toString()));
+        assert(tod.toString());
+        assert(ctod.toString());
+        assert(itod.toString());
     }
 
 
@@ -14830,15 +14830,15 @@ public:
         auto dt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 33, 30));
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 33, 30));
         immutable idt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 33, 30));
-        static assert(__traits(compiles, dt.opCmp(dt)));
-        static assert(__traits(compiles, dt.opCmp(cdt)));
-        static assert(__traits(compiles, dt.opCmp(idt)));
-        static assert(__traits(compiles, cdt.opCmp(dt)));
-        static assert(__traits(compiles, cdt.opCmp(cdt)));
-        static assert(__traits(compiles, cdt.opCmp(idt)));
-        static assert(__traits(compiles, idt.opCmp(dt)));
-        static assert(__traits(compiles, idt.opCmp(cdt)));
-        static assert(__traits(compiles, idt.opCmp(idt)));
+        assert(dt.opCmp(dt) == 0);
+        assert(dt.opCmp(cdt) == 0);
+        assert(dt.opCmp(idt) == 0);
+        assert(cdt.opCmp(dt) == 0);
+        assert(cdt.opCmp(cdt) == 0);
+        assert(cdt.opCmp(idt) == 0);
+        assert(idt.opCmp(dt) == 0);
+        assert(idt.opCmp(cdt) == 0);
+        assert(idt.opCmp(idt) == 0);
     }
 
 
@@ -14864,8 +14864,8 @@ public:
 
         const cdt = DateTime(1999, 7, 6);
         immutable idt = DateTime(1999, 7, 6);
-        static assert(__traits(compiles, cdt.date == Date(2010, 1, 1)));
-        static assert(__traits(compiles, idt.date == Date(2010, 1, 1)));
+        assert(cdt.date == Date(1999, 7, 6));
+        assert(idt.date == Date(1999, 7, 6));
     }
 
 
@@ -14916,8 +14916,8 @@ public:
 
         const cdt = DateTime(1999, 7, 6, 12, 30, 33);
         immutable idt = DateTime(1999, 7, 6, 12, 30, 33);
-        static assert(__traits(compiles, cdt.timeOfDay == TimeOfDay(12, 30, 33)));
-        static assert(__traits(compiles, idt.timeOfDay == TimeOfDay(12, 30, 33)));
+        assert(cdt.timeOfDay == TimeOfDay(12, 30, 33));
+        assert(idt.timeOfDay == TimeOfDay(12, 30, 33));
     }
 
 
@@ -14964,8 +14964,8 @@ public:
 
         const cdt = DateTime(1999, 7, 6, 12, 30, 33);
         immutable idt = DateTime(1999, 7, 6, 12, 30, 33);
-        static assert(__traits(compiles, idt.year));
-        static assert(__traits(compiles, idt.year));
+        assert(idt.year == 1999);
+        assert(idt.year == 1999);
     }
 
 
@@ -15038,7 +15038,7 @@ public:
         auto dt = DateTime(1999, 7, 6, 12, 30, 33);
         const cdt = DateTime(1999, 7, 6, 12, 30, 33);
         immutable idt = DateTime(1999, 7, 6, 12, 30, 33);
-        static assert(__traits(compiles, dt.yearBC = 12));
+        dt.yearBC = 12;
         static assert(!__traits(compiles, cdt.yearBC = 12));
         static assert(!__traits(compiles, idt.yearBC = 12));
     }
@@ -15076,7 +15076,7 @@ public:
         auto dt = DateTime(1999, 7, 6, 12, 30, 33);
         const cdt = DateTime(1999, 7, 6, 12, 30, 33);
         immutable idt = DateTime(1999, 7, 6, 12, 30, 33);
-        static assert(__traits(compiles, dt.yearBC = 12));
+        dt.yearBC = 12;
         static assert(!__traits(compiles, cdt.yearBC = 12));
         static assert(!__traits(compiles, idt.yearBC = 12));
     }
@@ -15106,8 +15106,8 @@ public:
 
         const cdt = DateTime(1999, 7, 6, 12, 30, 33);
         immutable idt = DateTime(1999, 7, 6, 12, 30, 33);
-        static assert(__traits(compiles, cdt.month));
-        static assert(__traits(compiles, idt.month));
+        assert(cdt.month == 7);
+        assert(idt.month == 7);
     }
 
 
@@ -15184,8 +15184,8 @@ public:
 
         const cdt = DateTime(1999, 7, 6, 12, 30, 33);
         immutable idt = DateTime(1999, 7, 6, 12, 30, 33);
-        static assert(__traits(compiles, cdt.day));
-        static assert(__traits(compiles, idt.day));
+        assert(cdt.day == 6);
+        assert(idt.day == 6);
     }
 
 
@@ -15303,8 +15303,8 @@ public:
 
         const cdt = DateTime(1999, 7, 6, 12, 30, 33);
         immutable idt = DateTime(1999, 7, 6, 12, 30, 33);
-        static assert(__traits(compiles, cdt.hour));
-        static assert(__traits(compiles, idt.hour));
+        assert(cdt.hour == 12);
+        assert(idt.hour == 12);
     }
 
 
@@ -15353,8 +15353,8 @@ public:
 
         const cdt = DateTime(1999, 7, 6, 12, 30, 33);
         immutable idt = DateTime(1999, 7, 6, 12, 30, 33);
-        static assert(__traits(compiles, cdt.minute));
-        static assert(__traits(compiles, idt.minute));
+        assert(cdt.minute == 30);
+        assert(idt.minute == 30);
     }
 
 
@@ -15403,8 +15403,8 @@ public:
 
         const cdt = DateTime(1999, 7, 6, 12, 30, 33);
         immutable idt = DateTime(1999, 7, 6, 12, 30, 33);
-        static assert(__traits(compiles, cdt.second));
-        static assert(__traits(compiles, idt.second));
+        assert(cdt.second == 33);
+        assert(idt.second == 33);
     }
 
 
@@ -16222,10 +16222,10 @@ public:
         auto duration = dur!"seconds"(12);
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         immutable idt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
-        static assert(__traits(compiles, cdt + duration));
-        static assert(__traits(compiles, idt + duration));
-        static assert(__traits(compiles, cdt - duration));
-        static assert(__traits(compiles, idt - duration));
+        assert(cdt + duration == DateTime(1999, 7, 6, 12, 30, 45));
+        assert(idt + duration == DateTime(1999, 7, 6, 12, 30, 45));
+        assert(cdt - duration == DateTime(1999, 7, 6, 12, 30, 21));
+        assert(idt - duration == DateTime(1999, 7, 6, 12, 30, 21));
     }
 
 
@@ -16384,17 +16384,17 @@ public:
 
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         immutable idt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
-        static assert(__traits(compiles, dt - dt));
-        static assert(__traits(compiles, cdt - dt));
-        static assert(__traits(compiles, idt - dt));
+        assert(dt - dt == Duration.zero);
+        assert(cdt - dt == Duration.zero);
+        assert(idt - dt == Duration.zero);
 
-        static assert(__traits(compiles, dt - cdt));
-        static assert(__traits(compiles, cdt - cdt));
-        static assert(__traits(compiles, idt - cdt));
+        assert(dt - cdt == Duration.zero);
+        assert(cdt - cdt == Duration.zero);
+        assert(idt - cdt == Duration.zero);
 
-        static assert(__traits(compiles, dt - idt));
-        static assert(__traits(compiles, cdt - idt));
-        static assert(__traits(compiles, idt - idt));
+        assert(dt - idt == Duration.zero);
+        assert(cdt - idt == Duration.zero);
+        assert(idt - idt == Duration.zero);
     }
 
 
@@ -16445,17 +16445,17 @@ public:
         auto dt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         immutable idt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
-        static assert(__traits(compiles, dt.diffMonths(dt)));
-        static assert(__traits(compiles, cdt.diffMonths(dt)));
-        static assert(__traits(compiles, idt.diffMonths(dt)));
+        assert(dt.diffMonths(dt) == 0);
+        assert(cdt.diffMonths(dt) == 0);
+        assert(idt.diffMonths(dt) == 0);
 
-        static assert(__traits(compiles, dt.diffMonths(cdt)));
-        static assert(__traits(compiles, cdt.diffMonths(cdt)));
-        static assert(__traits(compiles, idt.diffMonths(cdt)));
+        assert(dt.diffMonths(cdt) == 0);
+        assert(cdt.diffMonths(cdt) == 0);
+        assert(idt.diffMonths(cdt) == 0);
 
-        static assert(__traits(compiles, dt.diffMonths(idt)));
-        static assert(__traits(compiles, cdt.diffMonths(idt)));
-        static assert(__traits(compiles, idt.diffMonths(idt)));
+        assert(dt.diffMonths(idt) == 0);
+        assert(cdt.diffMonths(idt) == 0);
+        assert(idt.diffMonths(idt) == 0);
     }
 
 
@@ -16472,9 +16472,9 @@ public:
         auto dt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         immutable idt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
-        static assert(__traits(compiles, dt.isLeapYear));
-        static assert(__traits(compiles, cdt.isLeapYear));
-        static assert(__traits(compiles, idt.isLeapYear));
+        assert(!dt.isLeapYear);
+        assert(!cdt.isLeapYear);
+        assert(!idt.isLeapYear);
     }
 
 
@@ -16491,9 +16491,9 @@ public:
         auto dt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         immutable idt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
-        static assert(__traits(compiles, dt.dayOfWeek));
-        static assert(__traits(compiles, cdt.dayOfWeek));
-        static assert(__traits(compiles, idt.dayOfWeek));
+        assert(dt.dayOfWeek == DayOfWeek.tue);
+        assert(cdt.dayOfWeek == DayOfWeek.tue);
+        assert(idt.dayOfWeek == DayOfWeek.tue);
     }
 
 
@@ -16518,9 +16518,9 @@ public:
         auto dt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         immutable idt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
-        static assert(__traits(compiles, dt.dayOfYear));
-        static assert(__traits(compiles, cdt.dayOfYear));
-        static assert(__traits(compiles, idt.dayOfYear));
+        assert(dt.dayOfYear == 187);
+        assert(cdt.dayOfYear == 187);
+        assert(idt.dayOfYear == 187);
     }
 
 
@@ -16541,7 +16541,7 @@ public:
         auto dt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         immutable idt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
-        static assert(__traits(compiles, dt.dayOfYear = 12));
+        dt.dayOfYear = 12;
         static assert(!__traits(compiles, cdt.dayOfYear = 12));
         static assert(!__traits(compiles, idt.dayOfYear = 12));
     }
@@ -16574,8 +16574,8 @@ public:
     {
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         immutable idt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
-        static assert(__traits(compiles, cdt.dayOfGregorianCal));
-        static assert(__traits(compiles, idt.dayOfGregorianCal));
+        assert(cdt.dayOfGregorianCal == 729_941);
+        assert(idt.dayOfGregorianCal == 729_941);
     }
 
 
@@ -16647,9 +16647,9 @@ public:
         auto dt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         immutable idt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
-        static assert(__traits(compiles, dt.isoWeek));
-        static assert(__traits(compiles, cdt.isoWeek));
-        static assert(__traits(compiles, idt.isoWeek));
+        assert(dt.isoWeek == 27);
+        assert(cdt.isoWeek == 27);
+        assert(idt.isoWeek == 27);
     }
 
 
@@ -16715,8 +16715,8 @@ public:
 
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         immutable idt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
-        static assert(__traits(compiles, cdt.endOfMonth));
-        static assert(__traits(compiles, idt.endOfMonth));
+        assert(cdt.endOfMonth == DateTime(1999, 7, 31, 23, 59, 59));
+        assert(idt.endOfMonth == DateTime(1999, 7, 31, 23, 59, 59));
     }
 
 
@@ -16741,8 +16741,8 @@ public:
     {
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         immutable idt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
-        static assert(__traits(compiles, cdt.daysInMonth));
-        static assert(__traits(compiles, idt.daysInMonth));
+        assert(cdt.daysInMonth == 31);
+        assert(idt.daysInMonth == 31);
     }
 
 
@@ -16767,8 +16767,8 @@ public:
     {
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         immutable idt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
-        static assert(__traits(compiles, cdt.isAD));
-        static assert(__traits(compiles, idt.isAD));
+        assert(cdt.isAD);
+        assert(idt.isAD);
     }
 
 
@@ -16815,8 +16815,8 @@ public:
 
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         immutable idt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
-        static assert(__traits(compiles, cdt.julianDay));
-        static assert(__traits(compiles, idt.julianDay));
+        assert(cdt.julianDay == 2_451_366);
+        assert(idt.julianDay == 2_451_366);
     }
 
 
@@ -16839,8 +16839,8 @@ public:
 
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         immutable idt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
-        static assert(__traits(compiles, cdt.modJulianDay));
-        static assert(__traits(compiles, idt.modJulianDay));
+        assert(cdt.modJulianDay == 51_365);
+        assert(idt.modJulianDay == 51_365);
     }
 
 
@@ -16891,8 +16891,8 @@ public:
 
         const cdt = DateTime(1999, 7, 6, 12, 30, 33);
         immutable idt = DateTime(1999, 7, 6, 12, 30, 33);
-        static assert(__traits(compiles, cdt.toISOString()));
-        static assert(__traits(compiles, idt.toISOString()));
+        assert(cdt.toISOString() == "19990706T123033");
+        assert(idt.toISOString() == "19990706T123033");
     }
 
 
@@ -16944,8 +16944,8 @@ public:
 
         const cdt = DateTime(1999, 7, 6, 12, 30, 33);
         immutable idt = DateTime(1999, 7, 6, 12, 30, 33);
-        static assert(__traits(compiles, cdt.toISOExtString()));
-        static assert(__traits(compiles, idt.toISOExtString()));
+        assert(cdt.toISOExtString() == "1999-07-06T12:30:33");
+        assert(idt.toISOExtString() == "1999-07-06T12:30:33");
     }
 
     /++
@@ -16996,8 +16996,8 @@ public:
 
         const cdt = DateTime(1999, 7, 6, 12, 30, 33);
         immutable idt = DateTime(1999, 7, 6, 12, 30, 33);
-        static assert(__traits(compiles, cdt.toSimpleString()));
-        static assert(__traits(compiles, idt.toSimpleString()));
+        assert(cdt.toSimpleString() == "1999-Jul-06 12:30:33");
+        assert(idt.toSimpleString() == "1999-Jul-06 12:30:33");
     }
 
 
@@ -17014,9 +17014,9 @@ public:
         auto dt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         immutable idt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
-        static assert(__traits(compiles, dt.toString()));
-        static assert(__traits(compiles, cdt.toString()));
-        static assert(__traits(compiles, idt.toString()));
+        assert(dt.toString());
+        assert(cdt.toString());
+        assert(idt.toString());
     }
 
 
@@ -19087,8 +19087,8 @@ unittest
 
     const cInterval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
     immutable iInterval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
-    static assert(__traits(compiles, cInterval.begin));
-    static assert(__traits(compiles, iInterval.begin));
+    assert(cInterval.begin == Date(2010, 7, 4));
+    assert(iInterval.begin == Date(2010, 7, 4));
 
     //Verify Examples.
     assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).begin == Date(1996, 1, 2));
@@ -19103,8 +19103,8 @@ unittest
 
     const cInterval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
     immutable iInterval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
-    static assert(__traits(compiles, cInterval.end));
-    static assert(__traits(compiles, iInterval.end));
+    assert(cInterval.end == Date(2012, 1, 7));
+    assert(iInterval.end == Date(2012, 1, 7));
 
     //Verify Examples.
     assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).end == Date(2012, 3, 1));
@@ -19121,8 +19121,8 @@ unittest
 
     const cInterval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
     immutable iInterval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
-    static assert(__traits(compiles, cInterval.length));
-    static assert(__traits(compiles, iInterval.length));
+    assert(cInterval.length != Duration.zero);
+    assert(iInterval.length != Duration.zero);
 
     //Verify Examples.
     assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).length == dur!"days"(5903));
@@ -19139,8 +19139,8 @@ unittest
 
     const cInterval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
     immutable iInterval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
-    static assert(__traits(compiles, cInterval.empty));
-    static assert(__traits(compiles, iInterval.empty));
+    assert(!cInterval.empty);
+    assert(!iInterval.empty);
 
     //Verify Examples.
     assert(Interval!Date(Date(1996, 1, 2), Date(1996, 1, 2)).empty);
@@ -19167,9 +19167,9 @@ unittest
     const cdate = Date(2010, 7, 6);
     const cInterval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
     immutable iInterval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
-    static assert(__traits(compiles, interval.contains(cdate)));
-    static assert(__traits(compiles, cInterval.contains(cdate)));
-    static assert(__traits(compiles, iInterval.contains(cdate)));
+    assert(interval.contains(cdate));
+    assert(cInterval.contains(cdate));
+    assert(iInterval.contains(cdate));
 
     //Verify Examples.
     assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).contains(Date(1994, 12, 24)));
@@ -19235,33 +19235,33 @@ unittest
     auto negInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
-    static assert(__traits(compiles, interval.contains(interval)));
-    static assert(__traits(compiles, interval.contains(cInterval)));
-    static assert(__traits(compiles, interval.contains(iInterval)));
-    static assert(__traits(compiles, interval.contains(posInfInterval)));
-    static assert(__traits(compiles, interval.contains(cPosInfInterval)));
-    static assert(__traits(compiles, interval.contains(iPosInfInterval)));
-    static assert(__traits(compiles, interval.contains(negInfInterval)));
-    static assert(__traits(compiles, interval.contains(cNegInfInterval)));
-    static assert(__traits(compiles, interval.contains(iNegInfInterval)));
-    static assert(__traits(compiles, cInterval.contains(interval)));
-    static assert(__traits(compiles, cInterval.contains(cInterval)));
-    static assert(__traits(compiles, cInterval.contains(iInterval)));
-    static assert(__traits(compiles, cInterval.contains(posInfInterval)));
-    static assert(__traits(compiles, cInterval.contains(cPosInfInterval)));
-    static assert(__traits(compiles, cInterval.contains(iPosInfInterval)));
-    static assert(__traits(compiles, cInterval.contains(negInfInterval)));
-    static assert(__traits(compiles, cInterval.contains(cNegInfInterval)));
-    static assert(__traits(compiles, cInterval.contains(iNegInfInterval)));
-    static assert(__traits(compiles, iInterval.contains(interval)));
-    static assert(__traits(compiles, iInterval.contains(cInterval)));
-    static assert(__traits(compiles, iInterval.contains(iInterval)));
-    static assert(__traits(compiles, iInterval.contains(posInfInterval)));
-    static assert(__traits(compiles, iInterval.contains(cPosInfInterval)));
-    static assert(__traits(compiles, iInterval.contains(iPosInfInterval)));
-    static assert(__traits(compiles, iInterval.contains(negInfInterval)));
-    static assert(__traits(compiles, iInterval.contains(cNegInfInterval)));
-    static assert(__traits(compiles, iInterval.contains(iNegInfInterval)));
+    assert(interval.contains(interval));
+    assert(interval.contains(cInterval));
+    assert(interval.contains(iInterval));
+    assert(!interval.contains(posInfInterval));
+    assert(!interval.contains(cPosInfInterval));
+    assert(!interval.contains(iPosInfInterval));
+    assert(!interval.contains(negInfInterval));
+    assert(!interval.contains(cNegInfInterval));
+    assert(!interval.contains(iNegInfInterval));
+    assert(cInterval.contains(interval));
+    assert(cInterval.contains(cInterval));
+    assert(cInterval.contains(iInterval));
+    assert(!cInterval.contains(posInfInterval));
+    assert(!cInterval.contains(cPosInfInterval));
+    assert(!cInterval.contains(iPosInfInterval));
+    assert(!cInterval.contains(negInfInterval));
+    assert(!cInterval.contains(cNegInfInterval));
+    assert(!cInterval.contains(iNegInfInterval));
+    assert(iInterval.contains(interval));
+    assert(iInterval.contains(cInterval));
+    assert(iInterval.contains(iInterval));
+    assert(!iInterval.contains(posInfInterval));
+    assert(!iInterval.contains(cPosInfInterval));
+    assert(!iInterval.contains(iPosInfInterval));
+    assert(!iInterval.contains(negInfInterval));
+    assert(!iInterval.contains(cNegInfInterval));
+    assert(!iInterval.contains(iNegInfInterval));
 
     //Verify Examples.
     assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).contains(Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
@@ -19293,9 +19293,9 @@ unittest
     const cdate = Date(2010, 7, 6);
     const cInterval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
     immutable iInterval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
-    static assert(__traits(compiles, interval.isBefore(cdate)));
-    static assert(__traits(compiles, cInterval.isBefore(cdate)));
-    static assert(__traits(compiles, iInterval.isBefore(cdate)));
+    assert(!interval.isBefore(cdate));
+    assert(!cInterval.isBefore(cdate));
+    assert(!iInterval.isBefore(cdate));
 
     //Verify Examples.
     assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isBefore(Date(1994, 12, 24)));
@@ -19361,33 +19361,33 @@ unittest
     auto negInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
-    static assert(__traits(compiles, interval.isBefore(interval)));
-    static assert(__traits(compiles, interval.isBefore(cInterval)));
-    static assert(__traits(compiles, interval.isBefore(iInterval)));
-    static assert(__traits(compiles, interval.isBefore(posInfInterval)));
-    static assert(__traits(compiles, interval.isBefore(cPosInfInterval)));
-    static assert(__traits(compiles, interval.isBefore(iPosInfInterval)));
-    static assert(__traits(compiles, interval.isBefore(negInfInterval)));
-    static assert(__traits(compiles, interval.isBefore(cNegInfInterval)));
-    static assert(__traits(compiles, interval.isBefore(iNegInfInterval)));
-    static assert(__traits(compiles, cInterval.isBefore(interval)));
-    static assert(__traits(compiles, cInterval.isBefore(cInterval)));
-    static assert(__traits(compiles, cInterval.isBefore(iInterval)));
-    static assert(__traits(compiles, cInterval.isBefore(posInfInterval)));
-    static assert(__traits(compiles, cInterval.isBefore(cPosInfInterval)));
-    static assert(__traits(compiles, cInterval.isBefore(iPosInfInterval)));
-    static assert(__traits(compiles, cInterval.isBefore(negInfInterval)));
-    static assert(__traits(compiles, cInterval.isBefore(cNegInfInterval)));
-    static assert(__traits(compiles, cInterval.isBefore(iNegInfInterval)));
-    static assert(__traits(compiles, iInterval.isBefore(interval)));
-    static assert(__traits(compiles, iInterval.isBefore(cInterval)));
-    static assert(__traits(compiles, iInterval.isBefore(iInterval)));
-    static assert(__traits(compiles, iInterval.isBefore(posInfInterval)));
-    static assert(__traits(compiles, iInterval.isBefore(cPosInfInterval)));
-    static assert(__traits(compiles, iInterval.isBefore(iPosInfInterval)));
-    static assert(__traits(compiles, iInterval.isBefore(negInfInterval)));
-    static assert(__traits(compiles, iInterval.isBefore(cNegInfInterval)));
-    static assert(__traits(compiles, iInterval.isBefore(iNegInfInterval)));
+    assert(!interval.isBefore(interval));
+    assert(!interval.isBefore(cInterval));
+    assert(!interval.isBefore(iInterval));
+    assert(!interval.isBefore(posInfInterval));
+    assert(!interval.isBefore(cPosInfInterval));
+    assert(!interval.isBefore(iPosInfInterval));
+    assert(!interval.isBefore(negInfInterval));
+    assert(!interval.isBefore(cNegInfInterval));
+    assert(!interval.isBefore(iNegInfInterval));
+    assert(!cInterval.isBefore(interval));
+    assert(!cInterval.isBefore(cInterval));
+    assert(!cInterval.isBefore(iInterval));
+    assert(!cInterval.isBefore(posInfInterval));
+    assert(!cInterval.isBefore(cPosInfInterval));
+    assert(!cInterval.isBefore(iPosInfInterval));
+    assert(!cInterval.isBefore(negInfInterval));
+    assert(!cInterval.isBefore(cNegInfInterval));
+    assert(!cInterval.isBefore(iNegInfInterval));
+    assert(!iInterval.isBefore(interval));
+    assert(!iInterval.isBefore(cInterval));
+    assert(!iInterval.isBefore(iInterval));
+    assert(!iInterval.isBefore(posInfInterval));
+    assert(!iInterval.isBefore(cPosInfInterval));
+    assert(!iInterval.isBefore(iPosInfInterval));
+    assert(!iInterval.isBefore(negInfInterval));
+    assert(!iInterval.isBefore(cNegInfInterval));
+    assert(!iInterval.isBefore(iNegInfInterval));
 
     //Verify Examples.
     assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isBefore(Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
@@ -19420,9 +19420,9 @@ unittest
     const cdate = Date(2010, 7, 6);
     const cInterval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
     immutable iInterval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
-    static assert(__traits(compiles, interval.isAfter(cdate)));
-    static assert(__traits(compiles, cInterval.isAfter(cdate)));
-    static assert(__traits(compiles, iInterval.isAfter(cdate)));
+    assert(!interval.isAfter(cdate));
+    assert(!cInterval.isAfter(cdate));
+    assert(!iInterval.isAfter(cdate));
 
     //Verify Examples.
     assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAfter(Date(1994, 12, 24)));
@@ -19488,33 +19488,33 @@ unittest
     auto negInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
-    static assert(__traits(compiles, interval.isAfter(interval)));
-    static assert(__traits(compiles, interval.isAfter(cInterval)));
-    static assert(__traits(compiles, interval.isAfter(iInterval)));
-    static assert(__traits(compiles, interval.isAfter(posInfInterval)));
-    static assert(__traits(compiles, interval.isAfter(cPosInfInterval)));
-    static assert(__traits(compiles, interval.isAfter(iPosInfInterval)));
-    static assert(__traits(compiles, interval.isAfter(negInfInterval)));
-    static assert(__traits(compiles, interval.isAfter(cNegInfInterval)));
-    static assert(__traits(compiles, interval.isAfter(iNegInfInterval)));
-    static assert(__traits(compiles, cInterval.isAfter(interval)));
-    static assert(__traits(compiles, cInterval.isAfter(cInterval)));
-    static assert(__traits(compiles, cInterval.isAfter(iInterval)));
-    static assert(__traits(compiles, cInterval.isAfter(posInfInterval)));
-    static assert(__traits(compiles, cInterval.isAfter(cPosInfInterval)));
-    static assert(__traits(compiles, cInterval.isAfter(iPosInfInterval)));
-    static assert(__traits(compiles, cInterval.isAfter(negInfInterval)));
-    static assert(__traits(compiles, cInterval.isAfter(cNegInfInterval)));
-    static assert(__traits(compiles, cInterval.isAfter(iNegInfInterval)));
-    static assert(__traits(compiles, iInterval.isAfter(interval)));
-    static assert(__traits(compiles, iInterval.isAfter(cInterval)));
-    static assert(__traits(compiles, iInterval.isAfter(iInterval)));
-    static assert(__traits(compiles, iInterval.isAfter(posInfInterval)));
-    static assert(__traits(compiles, iInterval.isAfter(cPosInfInterval)));
-    static assert(__traits(compiles, iInterval.isAfter(iPosInfInterval)));
-    static assert(__traits(compiles, iInterval.isAfter(negInfInterval)));
-    static assert(__traits(compiles, iInterval.isAfter(cNegInfInterval)));
-    static assert(__traits(compiles, iInterval.isAfter(iNegInfInterval)));
+    assert(!interval.isAfter(interval));
+    assert(!interval.isAfter(cInterval));
+    assert(!interval.isAfter(iInterval));
+    assert(!interval.isAfter(posInfInterval));
+    assert(!interval.isAfter(cPosInfInterval));
+    assert(!interval.isAfter(iPosInfInterval));
+    assert(!interval.isAfter(negInfInterval));
+    assert(!interval.isAfter(cNegInfInterval));
+    assert(!interval.isAfter(iNegInfInterval));
+    assert(!cInterval.isAfter(interval));
+    assert(!cInterval.isAfter(cInterval));
+    assert(!cInterval.isAfter(iInterval));
+    assert(!cInterval.isAfter(posInfInterval));
+    assert(!cInterval.isAfter(cPosInfInterval));
+    assert(!cInterval.isAfter(iPosInfInterval));
+    assert(!cInterval.isAfter(negInfInterval));
+    assert(!cInterval.isAfter(cNegInfInterval));
+    assert(!cInterval.isAfter(iNegInfInterval));
+    assert(!iInterval.isAfter(interval));
+    assert(!iInterval.isAfter(cInterval));
+    assert(!iInterval.isAfter(iInterval));
+    assert(!iInterval.isAfter(posInfInterval));
+    assert(!iInterval.isAfter(cPosInfInterval));
+    assert(!iInterval.isAfter(iPosInfInterval));
+    assert(!iInterval.isAfter(negInfInterval));
+    assert(!iInterval.isAfter(cNegInfInterval));
+    assert(!iInterval.isAfter(iNegInfInterval));
 
     //Verify Examples.
     assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAfter(Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
@@ -19584,33 +19584,33 @@ unittest
     auto negInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
-    static assert(__traits(compiles, interval.intersects(interval)));
-    static assert(__traits(compiles, interval.intersects(cInterval)));
-    static assert(__traits(compiles, interval.intersects(iInterval)));
-    static assert(__traits(compiles, interval.intersects(posInfInterval)));
-    static assert(__traits(compiles, interval.intersects(cPosInfInterval)));
-    static assert(__traits(compiles, interval.intersects(iPosInfInterval)));
-    static assert(__traits(compiles, interval.intersects(negInfInterval)));
-    static assert(__traits(compiles, interval.intersects(cNegInfInterval)));
-    static assert(__traits(compiles, interval.intersects(iNegInfInterval)));
-    static assert(__traits(compiles, cInterval.intersects(interval)));
-    static assert(__traits(compiles, cInterval.intersects(cInterval)));
-    static assert(__traits(compiles, cInterval.intersects(iInterval)));
-    static assert(__traits(compiles, cInterval.intersects(posInfInterval)));
-    static assert(__traits(compiles, cInterval.intersects(cPosInfInterval)));
-    static assert(__traits(compiles, cInterval.intersects(iPosInfInterval)));
-    static assert(__traits(compiles, cInterval.intersects(negInfInterval)));
-    static assert(__traits(compiles, cInterval.intersects(cNegInfInterval)));
-    static assert(__traits(compiles, cInterval.intersects(iNegInfInterval)));
-    static assert(__traits(compiles, iInterval.intersects(interval)));
-    static assert(__traits(compiles, iInterval.intersects(cInterval)));
-    static assert(__traits(compiles, iInterval.intersects(iInterval)));
-    static assert(__traits(compiles, iInterval.intersects(posInfInterval)));
-    static assert(__traits(compiles, iInterval.intersects(cPosInfInterval)));
-    static assert(__traits(compiles, iInterval.intersects(iPosInfInterval)));
-    static assert(__traits(compiles, iInterval.intersects(negInfInterval)));
-    static assert(__traits(compiles, iInterval.intersects(cNegInfInterval)));
-    static assert(__traits(compiles, iInterval.intersects(iNegInfInterval)));
+    assert(interval.intersects(interval));
+    assert(interval.intersects(cInterval));
+    assert(interval.intersects(iInterval));
+    assert(interval.intersects(posInfInterval));
+    assert(interval.intersects(cPosInfInterval));
+    assert(interval.intersects(iPosInfInterval));
+    assert(interval.intersects(negInfInterval));
+    assert(interval.intersects(cNegInfInterval));
+    assert(interval.intersects(iNegInfInterval));
+    assert(cInterval.intersects(interval));
+    assert(cInterval.intersects(cInterval));
+    assert(cInterval.intersects(iInterval));
+    assert(cInterval.intersects(posInfInterval));
+    assert(cInterval.intersects(cPosInfInterval));
+    assert(cInterval.intersects(iPosInfInterval));
+    assert(cInterval.intersects(negInfInterval));
+    assert(cInterval.intersects(cNegInfInterval));
+    assert(cInterval.intersects(iNegInfInterval));
+    assert(iInterval.intersects(interval));
+    assert(iInterval.intersects(cInterval));
+    assert(iInterval.intersects(iInterval));
+    assert(iInterval.intersects(posInfInterval));
+    assert(iInterval.intersects(cPosInfInterval));
+    assert(iInterval.intersects(iPosInfInterval));
+    assert(iInterval.intersects(negInfInterval));
+    assert(iInterval.intersects(cNegInfInterval));
+    assert(iInterval.intersects(iNegInfInterval));
 
     //Verify Examples.
     assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersects(Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
@@ -19710,33 +19710,33 @@ unittest
     auto negInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
-    static assert(__traits(compiles, interval.intersection(interval)));
-    static assert(__traits(compiles, interval.intersection(cInterval)));
-    static assert(__traits(compiles, interval.intersection(iInterval)));
-    static assert(__traits(compiles, interval.intersection(posInfInterval)));
-    static assert(__traits(compiles, interval.intersection(cPosInfInterval)));
-    static assert(__traits(compiles, interval.intersection(iPosInfInterval)));
-    static assert(__traits(compiles, interval.intersection(negInfInterval)));
-    static assert(__traits(compiles, interval.intersection(cNegInfInterval)));
-    static assert(__traits(compiles, interval.intersection(iNegInfInterval)));
-    static assert(__traits(compiles, cInterval.intersection(interval)));
-    static assert(__traits(compiles, cInterval.intersection(cInterval)));
-    static assert(__traits(compiles, cInterval.intersection(iInterval)));
-    static assert(__traits(compiles, cInterval.intersection(posInfInterval)));
-    static assert(__traits(compiles, cInterval.intersection(cPosInfInterval)));
-    static assert(__traits(compiles, cInterval.intersection(iPosInfInterval)));
-    static assert(__traits(compiles, cInterval.intersection(negInfInterval)));
-    static assert(__traits(compiles, cInterval.intersection(cNegInfInterval)));
-    static assert(__traits(compiles, cInterval.intersection(iNegInfInterval)));
-    static assert(__traits(compiles, iInterval.intersection(interval)));
-    static assert(__traits(compiles, iInterval.intersection(cInterval)));
-    static assert(__traits(compiles, iInterval.intersection(iInterval)));
-    static assert(__traits(compiles, iInterval.intersection(posInfInterval)));
-    static assert(__traits(compiles, iInterval.intersection(cPosInfInterval)));
-    static assert(__traits(compiles, iInterval.intersection(iPosInfInterval)));
-    static assert(__traits(compiles, iInterval.intersection(negInfInterval)));
-    static assert(__traits(compiles, iInterval.intersection(cNegInfInterval)));
-    static assert(__traits(compiles, iInterval.intersection(iNegInfInterval)));
+    assert(!interval.intersection(interval).empty);
+    assert(!interval.intersection(cInterval).empty);
+    assert(!interval.intersection(iInterval).empty);
+    assert(!interval.intersection(posInfInterval).empty);
+    assert(!interval.intersection(cPosInfInterval).empty);
+    assert(!interval.intersection(iPosInfInterval).empty);
+    assert(!interval.intersection(negInfInterval).empty);
+    assert(!interval.intersection(cNegInfInterval).empty);
+    assert(!interval.intersection(iNegInfInterval).empty);
+    assert(!cInterval.intersection(interval).empty);
+    assert(!cInterval.intersection(cInterval).empty);
+    assert(!cInterval.intersection(iInterval).empty);
+    assert(!cInterval.intersection(posInfInterval).empty);
+    assert(!cInterval.intersection(cPosInfInterval).empty);
+    assert(!cInterval.intersection(iPosInfInterval).empty);
+    assert(!cInterval.intersection(negInfInterval).empty);
+    assert(!cInterval.intersection(cNegInfInterval).empty);
+    assert(!cInterval.intersection(iNegInfInterval).empty);
+    assert(!iInterval.intersection(interval).empty);
+    assert(!iInterval.intersection(cInterval).empty);
+    assert(!iInterval.intersection(iInterval).empty);
+    assert(!iInterval.intersection(posInfInterval).empty);
+    assert(!iInterval.intersection(cPosInfInterval).empty);
+    assert(!iInterval.intersection(iPosInfInterval).empty);
+    assert(!iInterval.intersection(negInfInterval).empty);
+    assert(!iInterval.intersection(cNegInfInterval).empty);
+    assert(!iInterval.intersection(iNegInfInterval).empty);
 
     //Verify Examples.
     assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersection(Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))) == Interval!Date(Date(1996, 1 , 2), Date(2000, 8, 2)));
@@ -19812,33 +19812,33 @@ unittest
     auto negInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
-    static assert(__traits(compiles, interval.isAdjacent(interval)));
-    static assert(__traits(compiles, interval.isAdjacent(cInterval)));
-    static assert(__traits(compiles, interval.isAdjacent(iInterval)));
-    static assert(__traits(compiles, interval.isAdjacent(posInfInterval)));
-    static assert(__traits(compiles, interval.isAdjacent(cPosInfInterval)));
-    static assert(__traits(compiles, interval.isAdjacent(iPosInfInterval)));
-    static assert(__traits(compiles, interval.isAdjacent(negInfInterval)));
-    static assert(__traits(compiles, interval.isAdjacent(cNegInfInterval)));
-    static assert(__traits(compiles, interval.isAdjacent(iNegInfInterval)));
-    static assert(__traits(compiles, cInterval.isAdjacent(interval)));
-    static assert(__traits(compiles, cInterval.isAdjacent(cInterval)));
-    static assert(__traits(compiles, cInterval.isAdjacent(iInterval)));
-    static assert(__traits(compiles, cInterval.isAdjacent(posInfInterval)));
-    static assert(__traits(compiles, cInterval.isAdjacent(cPosInfInterval)));
-    static assert(__traits(compiles, cInterval.isAdjacent(iPosInfInterval)));
-    static assert(__traits(compiles, cInterval.isAdjacent(negInfInterval)));
-    static assert(__traits(compiles, cInterval.isAdjacent(cNegInfInterval)));
-    static assert(__traits(compiles, cInterval.isAdjacent(iNegInfInterval)));
-    static assert(__traits(compiles, iInterval.isAdjacent(interval)));
-    static assert(__traits(compiles, iInterval.isAdjacent(cInterval)));
-    static assert(__traits(compiles, iInterval.isAdjacent(iInterval)));
-    static assert(__traits(compiles, iInterval.isAdjacent(posInfInterval)));
-    static assert(__traits(compiles, iInterval.isAdjacent(cPosInfInterval)));
-    static assert(__traits(compiles, iInterval.isAdjacent(iPosInfInterval)));
-    static assert(__traits(compiles, iInterval.isAdjacent(negInfInterval)));
-    static assert(__traits(compiles, iInterval.isAdjacent(cNegInfInterval)));
-    static assert(__traits(compiles, iInterval.isAdjacent(iNegInfInterval)));
+    assert(!interval.isAdjacent(interval));
+    assert(!interval.isAdjacent(cInterval));
+    assert(!interval.isAdjacent(iInterval));
+    assert(!interval.isAdjacent(posInfInterval));
+    assert(!interval.isAdjacent(cPosInfInterval));
+    assert(!interval.isAdjacent(iPosInfInterval));
+    assert(!interval.isAdjacent(negInfInterval));
+    assert(!interval.isAdjacent(cNegInfInterval));
+    assert(!interval.isAdjacent(iNegInfInterval));
+    assert(!cInterval.isAdjacent(interval));
+    assert(!cInterval.isAdjacent(cInterval));
+    assert(!cInterval.isAdjacent(iInterval));
+    assert(!cInterval.isAdjacent(posInfInterval));
+    assert(!cInterval.isAdjacent(cPosInfInterval));
+    assert(!cInterval.isAdjacent(iPosInfInterval));
+    assert(!cInterval.isAdjacent(negInfInterval));
+    assert(!cInterval.isAdjacent(cNegInfInterval));
+    assert(!cInterval.isAdjacent(iNegInfInterval));
+    assert(!iInterval.isAdjacent(interval));
+    assert(!iInterval.isAdjacent(cInterval));
+    assert(!iInterval.isAdjacent(iInterval));
+    assert(!iInterval.isAdjacent(posInfInterval));
+    assert(!iInterval.isAdjacent(cPosInfInterval));
+    assert(!iInterval.isAdjacent(iPosInfInterval));
+    assert(!iInterval.isAdjacent(negInfInterval));
+    assert(!iInterval.isAdjacent(cNegInfInterval));
+    assert(!iInterval.isAdjacent(iNegInfInterval));
 
     //Verify Examples.
     assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAdjacent(Interval!Date(Date(1990, 7, 6), Date(1996, 1, 2))));
@@ -19949,33 +19949,33 @@ unittest
     auto negInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
-    static assert(__traits(compiles, interval.merge(interval)));
-    static assert(__traits(compiles, interval.merge(cInterval)));
-    static assert(__traits(compiles, interval.merge(iInterval)));
-    static assert(__traits(compiles, interval.merge(posInfInterval)));
-    static assert(__traits(compiles, interval.merge(cPosInfInterval)));
-    static assert(__traits(compiles, interval.merge(iPosInfInterval)));
-    static assert(__traits(compiles, interval.merge(negInfInterval)));
-    static assert(__traits(compiles, interval.merge(cNegInfInterval)));
-    static assert(__traits(compiles, interval.merge(iNegInfInterval)));
-    static assert(__traits(compiles, cInterval.merge(interval)));
-    static assert(__traits(compiles, cInterval.merge(cInterval)));
-    static assert(__traits(compiles, cInterval.merge(iInterval)));
-    static assert(__traits(compiles, cInterval.merge(posInfInterval)));
-    static assert(__traits(compiles, cInterval.merge(cPosInfInterval)));
-    static assert(__traits(compiles, cInterval.merge(iPosInfInterval)));
-    static assert(__traits(compiles, cInterval.merge(negInfInterval)));
-    static assert(__traits(compiles, cInterval.merge(cNegInfInterval)));
-    static assert(__traits(compiles, cInterval.merge(iNegInfInterval)));
-    static assert(__traits(compiles, iInterval.merge(interval)));
-    static assert(__traits(compiles, iInterval.merge(cInterval)));
-    static assert(__traits(compiles, iInterval.merge(iInterval)));
-    static assert(__traits(compiles, iInterval.merge(posInfInterval)));
-    static assert(__traits(compiles, iInterval.merge(cPosInfInterval)));
-    static assert(__traits(compiles, iInterval.merge(iPosInfInterval)));
-    static assert(__traits(compiles, iInterval.merge(negInfInterval)));
-    static assert(__traits(compiles, iInterval.merge(cNegInfInterval)));
-    static assert(__traits(compiles, iInterval.merge(iNegInfInterval)));
+    assert(!interval.merge(interval).empty);
+    assert(!interval.merge(cInterval).empty);
+    assert(!interval.merge(iInterval).empty);
+    assert(!interval.merge(posInfInterval).empty);
+    assert(!interval.merge(cPosInfInterval).empty);
+    assert(!interval.merge(iPosInfInterval).empty);
+    assert(!interval.merge(negInfInterval).empty);
+    assert(!interval.merge(cNegInfInterval).empty);
+    assert(!interval.merge(iNegInfInterval).empty);
+    assert(!cInterval.merge(interval).empty);
+    assert(!cInterval.merge(cInterval).empty);
+    assert(!cInterval.merge(iInterval).empty);
+    assert(!cInterval.merge(posInfInterval).empty);
+    assert(!cInterval.merge(cPosInfInterval).empty);
+    assert(!cInterval.merge(iPosInfInterval).empty);
+    assert(!cInterval.merge(negInfInterval).empty);
+    assert(!cInterval.merge(cNegInfInterval).empty);
+    assert(!cInterval.merge(iNegInfInterval).empty);
+    assert(!iInterval.merge(interval).empty);
+    assert(!iInterval.merge(cInterval).empty);
+    assert(!iInterval.merge(iInterval).empty);
+    assert(!iInterval.merge(posInfInterval).empty);
+    assert(!iInterval.merge(cPosInfInterval).empty);
+    assert(!iInterval.merge(iPosInfInterval).empty);
+    assert(!iInterval.merge(negInfInterval).empty);
+    assert(!iInterval.merge(cNegInfInterval).empty);
+    assert(!iInterval.merge(iNegInfInterval).empty);
 
     //Verify Examples.
     assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).merge(Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))) == Interval!Date(Date(1990, 7 , 6), Date(2012, 3, 1)));
@@ -20087,33 +20087,33 @@ unittest
     auto negInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
-    static assert(__traits(compiles, interval.span(interval)));
-    static assert(__traits(compiles, interval.span(cInterval)));
-    static assert(__traits(compiles, interval.span(iInterval)));
-    static assert(__traits(compiles, interval.span(posInfInterval)));
-    static assert(__traits(compiles, interval.span(cPosInfInterval)));
-    static assert(__traits(compiles, interval.span(iPosInfInterval)));
-    static assert(__traits(compiles, interval.span(negInfInterval)));
-    static assert(__traits(compiles, interval.span(cNegInfInterval)));
-    static assert(__traits(compiles, interval.span(iNegInfInterval)));
-    static assert(__traits(compiles, cInterval.span(interval)));
-    static assert(__traits(compiles, cInterval.span(cInterval)));
-    static assert(__traits(compiles, cInterval.span(iInterval)));
-    static assert(__traits(compiles, cInterval.span(posInfInterval)));
-    static assert(__traits(compiles, cInterval.span(cPosInfInterval)));
-    static assert(__traits(compiles, cInterval.span(iPosInfInterval)));
-    static assert(__traits(compiles, cInterval.span(negInfInterval)));
-    static assert(__traits(compiles, cInterval.span(cNegInfInterval)));
-    static assert(__traits(compiles, cInterval.span(iNegInfInterval)));
-    static assert(__traits(compiles, iInterval.span(interval)));
-    static assert(__traits(compiles, iInterval.span(cInterval)));
-    static assert(__traits(compiles, iInterval.span(iInterval)));
-    static assert(__traits(compiles, iInterval.span(posInfInterval)));
-    static assert(__traits(compiles, iInterval.span(cPosInfInterval)));
-    static assert(__traits(compiles, iInterval.span(iPosInfInterval)));
-    static assert(__traits(compiles, iInterval.span(negInfInterval)));
-    static assert(__traits(compiles, iInterval.span(cNegInfInterval)));
-    static assert(__traits(compiles, iInterval.span(iNegInfInterval)));
+    assert(!interval.span(interval).empty);
+    assert(!interval.span(cInterval).empty);
+    assert(!interval.span(iInterval).empty);
+    assert(!interval.span(posInfInterval).empty);
+    assert(!interval.span(cPosInfInterval).empty);
+    assert(!interval.span(iPosInfInterval).empty);
+    assert(!interval.span(negInfInterval).empty);
+    assert(!interval.span(cNegInfInterval).empty);
+    assert(!interval.span(iNegInfInterval).empty);
+    assert(!cInterval.span(interval).empty);
+    assert(!cInterval.span(cInterval).empty);
+    assert(!cInterval.span(iInterval).empty);
+    assert(!cInterval.span(posInfInterval).empty);
+    assert(!cInterval.span(cPosInfInterval).empty);
+    assert(!cInterval.span(iPosInfInterval).empty);
+    assert(!cInterval.span(negInfInterval).empty);
+    assert(!cInterval.span(cNegInfInterval).empty);
+    assert(!cInterval.span(iNegInfInterval).empty);
+    assert(!iInterval.span(interval).empty);
+    assert(!iInterval.span(cInterval).empty);
+    assert(!iInterval.span(iInterval).empty);
+    assert(!iInterval.span(posInfInterval).empty);
+    assert(!iInterval.span(cPosInfInterval).empty);
+    assert(!iInterval.span(iPosInfInterval).empty);
+    assert(!iInterval.span(negInfInterval).empty);
+    assert(!iInterval.span(cNegInfInterval).empty);
+    assert(!iInterval.span(iNegInfInterval).empty);
 
     //Verify Examples.
     assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).span(Interval!Date(Date(1990, 7, 6), Date(1991, 1, 8))) == Interval!Date(Date(1990, 7 , 6), Date(2012, 3, 1)));
@@ -20392,8 +20392,8 @@ unittest
 
     const cInterval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
     immutable iInterval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
-    static assert(__traits(compiles, cInterval.fwdRange(everyDayOfWeek!Date(DayOfWeek.fri))));
-    static assert(__traits(compiles, iInterval.fwdRange(everyDayOfWeek!Date(DayOfWeek.fri))));
+    assert(!cInterval.fwdRange(everyDayOfWeek!Date(DayOfWeek.fri)).empty);
+    assert(!iInterval.fwdRange(everyDayOfWeek!Date(DayOfWeek.fri)).empty);
 }
 
 //Test Interval's bwdRange.
@@ -20458,8 +20458,8 @@ unittest
 
     const cInterval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
     immutable iInterval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
-    static assert(__traits(compiles, cInterval.bwdRange(everyDayOfWeek!Date(DayOfWeek.fri))));
-    static assert(__traits(compiles, iInterval.bwdRange(everyDayOfWeek!Date(DayOfWeek.fri))));
+    assert(!cInterval.bwdRange(everyDayOfWeek!Date(DayOfWeek.fri)).empty);
+    assert(!iInterval.bwdRange(everyDayOfWeek!Date(DayOfWeek.fri)).empty);
 }
 
 //Test Interval's toString().
@@ -20469,8 +20469,8 @@ unittest
 
     const cInterval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
     immutable iInterval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
-    static assert(__traits(compiles, cInterval.toString()));
-    static assert(__traits(compiles, iInterval.toString()));
+    assert(cInterval.toString());
+    assert(iInterval.toString());
 }
 
 
@@ -21520,8 +21520,8 @@ unittest
 
     const cPosInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
     immutable iPosInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
-    static assert(__traits(compiles, cPosInfInterval.begin));
-    static assert(__traits(compiles, iPosInfInterval.begin));
+    assert(cPosInfInterval.begin != Date.init);
+    assert(iPosInfInterval.begin != Date.init);
 
     //Verify Examples.
     assert(PosInfInterval!Date(Date(1996, 1, 2)).begin == Date(1996, 1, 2));
@@ -21537,8 +21537,8 @@ unittest
 
     const cPosInfInterval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
     immutable iPosInfInterval = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7));
-    static assert(__traits(compiles, cPosInfInterval.empty));
-    static assert(__traits(compiles, iPosInfInterval.empty));
+    assert(!cPosInfInterval.empty);
+    assert(!iPosInfInterval.empty);
 
     //Verify Examples.
     assert(!PosInfInterval!Date(Date(1996, 1, 2)).empty);
@@ -21562,9 +21562,9 @@ unittest
     const cdate = Date(2010, 7, 6);
     const cPosInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
     immutable iPosInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
-    static assert(__traits(compiles, posInfInterval.contains(cdate)));
-    static assert(__traits(compiles, cPosInfInterval.contains(cdate)));
-    static assert(__traits(compiles, iPosInfInterval.contains(cdate)));
+    assert(posInfInterval.contains(cdate));
+    assert(cPosInfInterval.contains(cdate));
+    assert(iPosInfInterval.contains(cdate));
 
     //Verify Examples.
     assert(!PosInfInterval!Date(Date(1996, 1, 2)).contains(Date(1994, 12, 24)));
@@ -21626,33 +21626,33 @@ unittest
     auto negInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
-    static assert(__traits(compiles, posInfInterval.contains(interval)));
-    static assert(__traits(compiles, posInfInterval.contains(cInterval)));
-    static assert(__traits(compiles, posInfInterval.contains(iInterval)));
-    static assert(__traits(compiles, posInfInterval.contains(posInfInterval)));
-    static assert(__traits(compiles, posInfInterval.contains(cPosInfInterval)));
-    static assert(__traits(compiles, posInfInterval.contains(iPosInfInterval)));
-    static assert(__traits(compiles, posInfInterval.contains(negInfInterval)));
-    static assert(__traits(compiles, posInfInterval.contains(cNegInfInterval)));
-    static assert(__traits(compiles, posInfInterval.contains(iNegInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.contains(interval)));
-    static assert(__traits(compiles, cPosInfInterval.contains(cInterval)));
-    static assert(__traits(compiles, cPosInfInterval.contains(iInterval)));
-    static assert(__traits(compiles, cPosInfInterval.contains(posInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.contains(cPosInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.contains(iPosInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.contains(negInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.contains(cNegInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.contains(iNegInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.contains(interval)));
-    static assert(__traits(compiles, iPosInfInterval.contains(cInterval)));
-    static assert(__traits(compiles, iPosInfInterval.contains(iInterval)));
-    static assert(__traits(compiles, iPosInfInterval.contains(posInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.contains(cPosInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.contains(iPosInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.contains(negInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.contains(cNegInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.contains(iNegInfInterval)));
+    assert(posInfInterval.contains(interval));
+    assert(posInfInterval.contains(cInterval));
+    assert(posInfInterval.contains(iInterval));
+    assert(posInfInterval.contains(posInfInterval));
+    assert(posInfInterval.contains(cPosInfInterval));
+    assert(posInfInterval.contains(iPosInfInterval));
+    assert(!posInfInterval.contains(negInfInterval));
+    assert(!posInfInterval.contains(cNegInfInterval));
+    assert(!posInfInterval.contains(iNegInfInterval));
+    assert(cPosInfInterval.contains(interval));
+    assert(cPosInfInterval.contains(cInterval));
+    assert(cPosInfInterval.contains(iInterval));
+    assert(cPosInfInterval.contains(posInfInterval));
+    assert(cPosInfInterval.contains(cPosInfInterval));
+    assert(cPosInfInterval.contains(iPosInfInterval));
+    assert(!cPosInfInterval.contains(negInfInterval));
+    assert(!cPosInfInterval.contains(cNegInfInterval));
+    assert(!cPosInfInterval.contains(iNegInfInterval));
+    assert(iPosInfInterval.contains(interval));
+    assert(iPosInfInterval.contains(cInterval));
+    assert(iPosInfInterval.contains(iInterval));
+    assert(iPosInfInterval.contains(posInfInterval));
+    assert(iPosInfInterval.contains(cPosInfInterval));
+    assert(iPosInfInterval.contains(iPosInfInterval));
+    assert(!iPosInfInterval.contains(negInfInterval));
+    assert(!iPosInfInterval.contains(cNegInfInterval));
+    assert(!iPosInfInterval.contains(iNegInfInterval));
 
     //Verify Examples.
     assert(!PosInfInterval!Date(Date(1996, 1, 2)).contains(Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
@@ -21683,9 +21683,9 @@ unittest
     const cdate = Date(2010, 7, 6);
     const cPosInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
     immutable iPosInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
-    static assert(__traits(compiles, posInfInterval.isBefore(cdate)));
-    static assert(__traits(compiles, cPosInfInterval.isBefore(cdate)));
-    static assert(__traits(compiles, iPosInfInterval.isBefore(cdate)));
+    assert(!posInfInterval.isBefore(cdate));
+    assert(!cPosInfInterval.isBefore(cdate));
+    assert(!iPosInfInterval.isBefore(cdate));
 
     //Verify Examples.
     assert(!PosInfInterval!Date(Date(1996, 1, 2)).isBefore(Date(1994, 12, 24)));
@@ -21747,33 +21747,33 @@ unittest
     auto negInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
-    static assert(__traits(compiles, posInfInterval.isBefore(interval)));
-    static assert(__traits(compiles, posInfInterval.isBefore(cInterval)));
-    static assert(__traits(compiles, posInfInterval.isBefore(iInterval)));
-    static assert(__traits(compiles, posInfInterval.isBefore(posInfInterval)));
-    static assert(__traits(compiles, posInfInterval.isBefore(cPosInfInterval)));
-    static assert(__traits(compiles, posInfInterval.isBefore(iPosInfInterval)));
-    static assert(__traits(compiles, posInfInterval.isBefore(negInfInterval)));
-    static assert(__traits(compiles, posInfInterval.isBefore(cNegInfInterval)));
-    static assert(__traits(compiles, posInfInterval.isBefore(iNegInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.isBefore(interval)));
-    static assert(__traits(compiles, cPosInfInterval.isBefore(cInterval)));
-    static assert(__traits(compiles, cPosInfInterval.isBefore(iInterval)));
-    static assert(__traits(compiles, cPosInfInterval.isBefore(posInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.isBefore(cPosInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.isBefore(iPosInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.isBefore(negInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.isBefore(cNegInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.isBefore(iNegInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.isBefore(interval)));
-    static assert(__traits(compiles, iPosInfInterval.isBefore(cInterval)));
-    static assert(__traits(compiles, iPosInfInterval.isBefore(iInterval)));
-    static assert(__traits(compiles, iPosInfInterval.isBefore(posInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.isBefore(cPosInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.isBefore(iPosInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.isBefore(negInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.isBefore(cNegInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.isBefore(iNegInfInterval)));
+    assert(!posInfInterval.isBefore(interval));
+    assert(!posInfInterval.isBefore(cInterval));
+    assert(!posInfInterval.isBefore(iInterval));
+    assert(!posInfInterval.isBefore(posInfInterval));
+    assert(!posInfInterval.isBefore(cPosInfInterval));
+    assert(!posInfInterval.isBefore(iPosInfInterval));
+    assert(!posInfInterval.isBefore(negInfInterval));
+    assert(!posInfInterval.isBefore(cNegInfInterval));
+    assert(!posInfInterval.isBefore(iNegInfInterval));
+    assert(!cPosInfInterval.isBefore(interval));
+    assert(!cPosInfInterval.isBefore(cInterval));
+    assert(!cPosInfInterval.isBefore(iInterval));
+    assert(!cPosInfInterval.isBefore(posInfInterval));
+    assert(!cPosInfInterval.isBefore(cPosInfInterval));
+    assert(!cPosInfInterval.isBefore(iPosInfInterval));
+    assert(!cPosInfInterval.isBefore(negInfInterval));
+    assert(!cPosInfInterval.isBefore(cNegInfInterval));
+    assert(!cPosInfInterval.isBefore(iNegInfInterval));
+    assert(!iPosInfInterval.isBefore(interval));
+    assert(!iPosInfInterval.isBefore(cInterval));
+    assert(!iPosInfInterval.isBefore(iInterval));
+    assert(!iPosInfInterval.isBefore(posInfInterval));
+    assert(!iPosInfInterval.isBefore(cPosInfInterval));
+    assert(!iPosInfInterval.isBefore(iPosInfInterval));
+    assert(!iPosInfInterval.isBefore(negInfInterval));
+    assert(!iPosInfInterval.isBefore(cNegInfInterval));
+    assert(!iPosInfInterval.isBefore(iNegInfInterval));
 
     //Verify Examples.
     assert(!PosInfInterval!Date(Date(1996, 1, 2)).isBefore(Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
@@ -21803,9 +21803,9 @@ unittest
     const cdate = Date(2010, 7, 6);
     const cPosInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
     immutable iPosInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
-    static assert(__traits(compiles, posInfInterval.isAfter(cdate)));
-    static assert(__traits(compiles, cPosInfInterval.isAfter(cdate)));
-    static assert(__traits(compiles, iPosInfInterval.isAfter(cdate)));
+    assert(!posInfInterval.isAfter(cdate));
+    assert(!cPosInfInterval.isAfter(cdate));
+    assert(!iPosInfInterval.isAfter(cdate));
 
     //Verify Examples.
     assert(PosInfInterval!Date(Date(1996, 1, 2)).isAfter(Date(1994, 12, 24)));
@@ -21867,33 +21867,33 @@ unittest
     auto negInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
-    static assert(__traits(compiles, posInfInterval.isAfter(interval)));
-    static assert(__traits(compiles, posInfInterval.isAfter(cInterval)));
-    static assert(__traits(compiles, posInfInterval.isAfter(iInterval)));
-    static assert(__traits(compiles, posInfInterval.isAfter(posInfInterval)));
-    static assert(__traits(compiles, posInfInterval.isAfter(cPosInfInterval)));
-    static assert(__traits(compiles, posInfInterval.isAfter(iPosInfInterval)));
-    static assert(__traits(compiles, posInfInterval.isAfter(negInfInterval)));
-    static assert(__traits(compiles, posInfInterval.isAfter(cNegInfInterval)));
-    static assert(__traits(compiles, posInfInterval.isAfter(iNegInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.isAfter(interval)));
-    static assert(__traits(compiles, cPosInfInterval.isAfter(cInterval)));
-    static assert(__traits(compiles, cPosInfInterval.isAfter(iInterval)));
-    static assert(__traits(compiles, cPosInfInterval.isAfter(posInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.isAfter(cPosInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.isAfter(iPosInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.isAfter(negInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.isAfter(cNegInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.isAfter(iNegInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.isAfter(interval)));
-    static assert(__traits(compiles, iPosInfInterval.isAfter(cInterval)));
-    static assert(__traits(compiles, iPosInfInterval.isAfter(iInterval)));
-    static assert(__traits(compiles, iPosInfInterval.isAfter(posInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.isAfter(cPosInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.isAfter(iPosInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.isAfter(negInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.isAfter(cNegInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.isAfter(iNegInfInterval)));
+    assert(!posInfInterval.isAfter(interval));
+    assert(!posInfInterval.isAfter(cInterval));
+    assert(!posInfInterval.isAfter(iInterval));
+    assert(!posInfInterval.isAfter(posInfInterval));
+    assert(!posInfInterval.isAfter(cPosInfInterval));
+    assert(!posInfInterval.isAfter(iPosInfInterval));
+    assert(!posInfInterval.isAfter(negInfInterval));
+    assert(!posInfInterval.isAfter(cNegInfInterval));
+    assert(!posInfInterval.isAfter(iNegInfInterval));
+    assert(!cPosInfInterval.isAfter(interval));
+    assert(!cPosInfInterval.isAfter(cInterval));
+    assert(!cPosInfInterval.isAfter(iInterval));
+    assert(!cPosInfInterval.isAfter(posInfInterval));
+    assert(!cPosInfInterval.isAfter(cPosInfInterval));
+    assert(!cPosInfInterval.isAfter(iPosInfInterval));
+    assert(!cPosInfInterval.isAfter(negInfInterval));
+    assert(!cPosInfInterval.isAfter(cNegInfInterval));
+    assert(!cPosInfInterval.isAfter(iNegInfInterval));
+    assert(!iPosInfInterval.isAfter(interval));
+    assert(!iPosInfInterval.isAfter(cInterval));
+    assert(!iPosInfInterval.isAfter(iInterval));
+    assert(!iPosInfInterval.isAfter(posInfInterval));
+    assert(!iPosInfInterval.isAfter(cPosInfInterval));
+    assert(!iPosInfInterval.isAfter(iPosInfInterval));
+    assert(!iPosInfInterval.isAfter(negInfInterval));
+    assert(!iPosInfInterval.isAfter(cNegInfInterval));
+    assert(!iPosInfInterval.isAfter(iNegInfInterval));
 
     //Verify Examples.
     assert(!PosInfInterval!Date(Date(1996, 1, 2)).isAfter(Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
@@ -21962,33 +21962,33 @@ unittest
     auto negInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
-    static assert(__traits(compiles, posInfInterval.intersects(interval)));
-    static assert(__traits(compiles, posInfInterval.intersects(cInterval)));
-    static assert(__traits(compiles, posInfInterval.intersects(iInterval)));
-    static assert(__traits(compiles, posInfInterval.intersects(posInfInterval)));
-    static assert(__traits(compiles, posInfInterval.intersects(cPosInfInterval)));
-    static assert(__traits(compiles, posInfInterval.intersects(iPosInfInterval)));
-    static assert(__traits(compiles, posInfInterval.intersects(negInfInterval)));
-    static assert(__traits(compiles, posInfInterval.intersects(cNegInfInterval)));
-    static assert(__traits(compiles, posInfInterval.intersects(iNegInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.intersects(interval)));
-    static assert(__traits(compiles, cPosInfInterval.intersects(cInterval)));
-    static assert(__traits(compiles, cPosInfInterval.intersects(iInterval)));
-    static assert(__traits(compiles, cPosInfInterval.intersects(posInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.intersects(cPosInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.intersects(iPosInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.intersects(negInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.intersects(cNegInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.intersects(iNegInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.intersects(interval)));
-    static assert(__traits(compiles, iPosInfInterval.intersects(cInterval)));
-    static assert(__traits(compiles, iPosInfInterval.intersects(iInterval)));
-    static assert(__traits(compiles, iPosInfInterval.intersects(posInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.intersects(cPosInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.intersects(iPosInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.intersects(negInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.intersects(cNegInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.intersects(iNegInfInterval)));
+    assert(posInfInterval.intersects(interval));
+    assert(posInfInterval.intersects(cInterval));
+    assert(posInfInterval.intersects(iInterval));
+    assert(posInfInterval.intersects(posInfInterval));
+    assert(posInfInterval.intersects(cPosInfInterval));
+    assert(posInfInterval.intersects(iPosInfInterval));
+    assert(posInfInterval.intersects(negInfInterval));
+    assert(posInfInterval.intersects(cNegInfInterval));
+    assert(posInfInterval.intersects(iNegInfInterval));
+    assert(cPosInfInterval.intersects(interval));
+    assert(cPosInfInterval.intersects(cInterval));
+    assert(cPosInfInterval.intersects(iInterval));
+    assert(cPosInfInterval.intersects(posInfInterval));
+    assert(cPosInfInterval.intersects(cPosInfInterval));
+    assert(cPosInfInterval.intersects(iPosInfInterval));
+    assert(cPosInfInterval.intersects(negInfInterval));
+    assert(cPosInfInterval.intersects(cNegInfInterval));
+    assert(cPosInfInterval.intersects(iNegInfInterval));
+    assert(iPosInfInterval.intersects(interval));
+    assert(iPosInfInterval.intersects(cInterval));
+    assert(iPosInfInterval.intersects(iInterval));
+    assert(iPosInfInterval.intersects(posInfInterval));
+    assert(iPosInfInterval.intersects(cPosInfInterval));
+    assert(iPosInfInterval.intersects(iPosInfInterval));
+    assert(iPosInfInterval.intersects(negInfInterval));
+    assert(iPosInfInterval.intersects(cNegInfInterval));
+    assert(iPosInfInterval.intersects(iNegInfInterval));
 
     //Verify Examples.
     assert(PosInfInterval!Date(Date(1996, 1, 2)).intersects(Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
@@ -22086,33 +22086,33 @@ unittest
     auto negInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
-    static assert(__traits(compiles, posInfInterval.intersection(interval)));
-    static assert(__traits(compiles, posInfInterval.intersection(cInterval)));
-    static assert(__traits(compiles, posInfInterval.intersection(iInterval)));
-    static assert(__traits(compiles, posInfInterval.intersection(posInfInterval)));
-    static assert(__traits(compiles, posInfInterval.intersection(cPosInfInterval)));
-    static assert(__traits(compiles, posInfInterval.intersection(iPosInfInterval)));
-    static assert(__traits(compiles, posInfInterval.intersection(negInfInterval)));
-    static assert(__traits(compiles, posInfInterval.intersection(cNegInfInterval)));
-    static assert(__traits(compiles, posInfInterval.intersection(iNegInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.intersection(interval)));
-    static assert(__traits(compiles, cPosInfInterval.intersection(cInterval)));
-    static assert(__traits(compiles, cPosInfInterval.intersection(iInterval)));
-    static assert(__traits(compiles, cPosInfInterval.intersection(posInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.intersection(cPosInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.intersection(iPosInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.intersection(negInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.intersection(cNegInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.intersection(iNegInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.intersection(interval)));
-    static assert(__traits(compiles, iPosInfInterval.intersection(cInterval)));
-    static assert(__traits(compiles, iPosInfInterval.intersection(iInterval)));
-    static assert(__traits(compiles, iPosInfInterval.intersection(posInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.intersection(cPosInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.intersection(iPosInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.intersection(negInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.intersection(cNegInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.intersection(iNegInfInterval)));
+    assert(!posInfInterval.intersection(interval).empty);
+    assert(!posInfInterval.intersection(cInterval).empty);
+    assert(!posInfInterval.intersection(iInterval).empty);
+    assert(!posInfInterval.intersection(posInfInterval).empty);
+    assert(!posInfInterval.intersection(cPosInfInterval).empty);
+    assert(!posInfInterval.intersection(iPosInfInterval).empty);
+    assert(!posInfInterval.intersection(negInfInterval).empty);
+    assert(!posInfInterval.intersection(cNegInfInterval).empty);
+    assert(!posInfInterval.intersection(iNegInfInterval).empty);
+    assert(!cPosInfInterval.intersection(interval).empty);
+    assert(!cPosInfInterval.intersection(cInterval).empty);
+    assert(!cPosInfInterval.intersection(iInterval).empty);
+    assert(!cPosInfInterval.intersection(posInfInterval).empty);
+    assert(!cPosInfInterval.intersection(cPosInfInterval).empty);
+    assert(!cPosInfInterval.intersection(iPosInfInterval).empty);
+    assert(!cPosInfInterval.intersection(negInfInterval).empty);
+    assert(!cPosInfInterval.intersection(cNegInfInterval).empty);
+    assert(!cPosInfInterval.intersection(iNegInfInterval).empty);
+    assert(!iPosInfInterval.intersection(interval).empty);
+    assert(!iPosInfInterval.intersection(cInterval).empty);
+    assert(!iPosInfInterval.intersection(iInterval).empty);
+    assert(!iPosInfInterval.intersection(posInfInterval).empty);
+    assert(!iPosInfInterval.intersection(cPosInfInterval).empty);
+    assert(!iPosInfInterval.intersection(iPosInfInterval).empty);
+    assert(!iPosInfInterval.intersection(negInfInterval).empty);
+    assert(!iPosInfInterval.intersection(cNegInfInterval).empty);
+    assert(!iPosInfInterval.intersection(iNegInfInterval).empty);
 
     //Verify Examples.
     assert(PosInfInterval!Date(Date(1996, 1, 2)).intersection(Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))) == Interval!Date(Date(1996, 1 , 2), Date(2000, 8, 2)));
@@ -22180,33 +22180,33 @@ unittest
     auto negInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
-    static assert(__traits(compiles, posInfInterval.isAdjacent(interval)));
-    static assert(__traits(compiles, posInfInterval.isAdjacent(cInterval)));
-    static assert(__traits(compiles, posInfInterval.isAdjacent(iInterval)));
-    static assert(__traits(compiles, posInfInterval.isAdjacent(posInfInterval)));
-    static assert(__traits(compiles, posInfInterval.isAdjacent(cPosInfInterval)));
-    static assert(__traits(compiles, posInfInterval.isAdjacent(iPosInfInterval)));
-    static assert(__traits(compiles, posInfInterval.isAdjacent(negInfInterval)));
-    static assert(__traits(compiles, posInfInterval.isAdjacent(cNegInfInterval)));
-    static assert(__traits(compiles, posInfInterval.isAdjacent(iNegInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.isAdjacent(interval)));
-    static assert(__traits(compiles, cPosInfInterval.isAdjacent(cInterval)));
-    static assert(__traits(compiles, cPosInfInterval.isAdjacent(iInterval)));
-    static assert(__traits(compiles, cPosInfInterval.isAdjacent(posInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.isAdjacent(cPosInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.isAdjacent(iPosInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.isAdjacent(negInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.isAdjacent(cNegInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.isAdjacent(iNegInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.isAdjacent(interval)));
-    static assert(__traits(compiles, iPosInfInterval.isAdjacent(cInterval)));
-    static assert(__traits(compiles, iPosInfInterval.isAdjacent(iInterval)));
-    static assert(__traits(compiles, iPosInfInterval.isAdjacent(posInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.isAdjacent(cPosInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.isAdjacent(iPosInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.isAdjacent(negInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.isAdjacent(cNegInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.isAdjacent(iNegInfInterval)));
+    assert(!posInfInterval.isAdjacent(interval));
+    assert(!posInfInterval.isAdjacent(cInterval));
+    assert(!posInfInterval.isAdjacent(iInterval));
+    assert(!posInfInterval.isAdjacent(posInfInterval));
+    assert(!posInfInterval.isAdjacent(cPosInfInterval));
+    assert(!posInfInterval.isAdjacent(iPosInfInterval));
+    assert(!posInfInterval.isAdjacent(negInfInterval));
+    assert(!posInfInterval.isAdjacent(cNegInfInterval));
+    assert(!posInfInterval.isAdjacent(iNegInfInterval));
+    assert(!cPosInfInterval.isAdjacent(interval));
+    assert(!cPosInfInterval.isAdjacent(cInterval));
+    assert(!cPosInfInterval.isAdjacent(iInterval));
+    assert(!cPosInfInterval.isAdjacent(posInfInterval));
+    assert(!cPosInfInterval.isAdjacent(cPosInfInterval));
+    assert(!cPosInfInterval.isAdjacent(iPosInfInterval));
+    assert(!cPosInfInterval.isAdjacent(negInfInterval));
+    assert(!cPosInfInterval.isAdjacent(cNegInfInterval));
+    assert(!cPosInfInterval.isAdjacent(iNegInfInterval));
+    assert(!iPosInfInterval.isAdjacent(interval));
+    assert(!iPosInfInterval.isAdjacent(cInterval));
+    assert(!iPosInfInterval.isAdjacent(iInterval));
+    assert(!iPosInfInterval.isAdjacent(posInfInterval));
+    assert(!iPosInfInterval.isAdjacent(cPosInfInterval));
+    assert(!iPosInfInterval.isAdjacent(iPosInfInterval));
+    assert(!iPosInfInterval.isAdjacent(negInfInterval));
+    assert(!iPosInfInterval.isAdjacent(cNegInfInterval));
+    assert(!iPosInfInterval.isAdjacent(iNegInfInterval));
 
     //Verify Examples.
     assert(PosInfInterval!Date(Date(1996, 1, 2)).isAdjacent(Interval!Date(Date(1989, 3, 1), Date(1996, 1, 2))));
@@ -22299,30 +22299,30 @@ unittest
     auto negInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
-    static assert(__traits(compiles, posInfInterval.merge(interval)));
-    static assert(__traits(compiles, posInfInterval.merge(cInterval)));
-    static assert(__traits(compiles, posInfInterval.merge(iInterval)));
-    static assert(__traits(compiles, posInfInterval.merge(posInfInterval)));
-    static assert(__traits(compiles, posInfInterval.merge(cPosInfInterval)));
-    static assert(__traits(compiles, posInfInterval.merge(iPosInfInterval)));
+    assert(!posInfInterval.merge(interval).empty);
+    assert(!posInfInterval.merge(cInterval).empty);
+    assert(!posInfInterval.merge(iInterval).empty);
+    assert(!posInfInterval.merge(posInfInterval).empty);
+    assert(!posInfInterval.merge(cPosInfInterval).empty);
+    assert(!posInfInterval.merge(iPosInfInterval).empty);
     static assert(!__traits(compiles, posInfInterval.merge(negInfInterval)));
     static assert(!__traits(compiles, posInfInterval.merge(cNegInfInterval)));
     static assert(!__traits(compiles, posInfInterval.merge(iNegInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.merge(interval)));
-    static assert(__traits(compiles, cPosInfInterval.merge(cInterval)));
-    static assert(__traits(compiles, cPosInfInterval.merge(iInterval)));
-    static assert(__traits(compiles, cPosInfInterval.merge(posInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.merge(cPosInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.merge(iPosInfInterval)));
+    assert(!cPosInfInterval.merge(interval).empty);
+    assert(!cPosInfInterval.merge(cInterval).empty);
+    assert(!cPosInfInterval.merge(iInterval).empty);
+    assert(!cPosInfInterval.merge(posInfInterval).empty);
+    assert(!cPosInfInterval.merge(cPosInfInterval).empty);
+    assert(!cPosInfInterval.merge(iPosInfInterval).empty);
     static assert(!__traits(compiles, cPosInfInterval.merge(negInfInterval)));
     static assert(!__traits(compiles, cPosInfInterval.merge(cNegInfInterval)));
     static assert(!__traits(compiles, cPosInfInterval.merge(iNegInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.merge(interval)));
-    static assert(__traits(compiles, iPosInfInterval.merge(cInterval)));
-    static assert(__traits(compiles, iPosInfInterval.merge(iInterval)));
-    static assert(__traits(compiles, iPosInfInterval.merge(posInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.merge(cPosInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.merge(iPosInfInterval)));
+    assert(!iPosInfInterval.merge(interval).empty);
+    assert(!iPosInfInterval.merge(cInterval).empty);
+    assert(!iPosInfInterval.merge(iInterval).empty);
+    assert(!iPosInfInterval.merge(posInfInterval).empty);
+    assert(!iPosInfInterval.merge(cPosInfInterval).empty);
+    assert(!iPosInfInterval.merge(iPosInfInterval).empty);
     static assert(!__traits(compiles, iPosInfInterval.merge(negInfInterval)));
     static assert(!__traits(compiles, iPosInfInterval.merge(cNegInfInterval)));
     static assert(!__traits(compiles, iPosInfInterval.merge(iNegInfInterval)));
@@ -22415,30 +22415,30 @@ unittest
     auto negInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
-    static assert(__traits(compiles, posInfInterval.span(interval)));
-    static assert(__traits(compiles, posInfInterval.span(cInterval)));
-    static assert(__traits(compiles, posInfInterval.span(iInterval)));
-    static assert(__traits(compiles, posInfInterval.span(posInfInterval)));
-    static assert(__traits(compiles, posInfInterval.span(cPosInfInterval)));
-    static assert(__traits(compiles, posInfInterval.span(iPosInfInterval)));
+    assert(!posInfInterval.span(interval).empty);
+    assert(!posInfInterval.span(cInterval).empty);
+    assert(!posInfInterval.span(iInterval).empty);
+    assert(!posInfInterval.span(posInfInterval).empty);
+    assert(!posInfInterval.span(cPosInfInterval).empty);
+    assert(!posInfInterval.span(iPosInfInterval).empty);
     static assert(!__traits(compiles, posInfInterval.span(negInfInterval)));
     static assert(!__traits(compiles, posInfInterval.span(cNegInfInterval)));
     static assert(!__traits(compiles, posInfInterval.span(iNegInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.span(interval)));
-    static assert(__traits(compiles, cPosInfInterval.span(cInterval)));
-    static assert(__traits(compiles, cPosInfInterval.span(iInterval)));
-    static assert(__traits(compiles, cPosInfInterval.span(posInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.span(cPosInfInterval)));
-    static assert(__traits(compiles, cPosInfInterval.span(iPosInfInterval)));
+    assert(!cPosInfInterval.span(interval).empty);
+    assert(!cPosInfInterval.span(cInterval).empty);
+    assert(!cPosInfInterval.span(iInterval).empty);
+    assert(!cPosInfInterval.span(posInfInterval).empty);
+    assert(!cPosInfInterval.span(cPosInfInterval).empty);
+    assert(!cPosInfInterval.span(iPosInfInterval).empty);
     static assert(!__traits(compiles, cPosInfInterval.span(negInfInterval)));
     static assert(!__traits(compiles, cPosInfInterval.span(cNegInfInterval)));
     static assert(!__traits(compiles, cPosInfInterval.span(iNegInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.span(interval)));
-    static assert(__traits(compiles, iPosInfInterval.span(cInterval)));
-    static assert(__traits(compiles, iPosInfInterval.span(iInterval)));
-    static assert(__traits(compiles, iPosInfInterval.span(posInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.span(cPosInfInterval)));
-    static assert(__traits(compiles, iPosInfInterval.span(iPosInfInterval)));
+    assert(!iPosInfInterval.span(interval).empty);
+    assert(!iPosInfInterval.span(cInterval).empty);
+    assert(!iPosInfInterval.span(iInterval).empty);
+    assert(!iPosInfInterval.span(posInfInterval).empty);
+    assert(!iPosInfInterval.span(cPosInfInterval).empty);
+    assert(!iPosInfInterval.span(iPosInfInterval).empty);
     static assert(!__traits(compiles, iPosInfInterval.span(negInfInterval)));
     static assert(!__traits(compiles, iPosInfInterval.span(cNegInfInterval)));
     static assert(!__traits(compiles, iPosInfInterval.span(iNegInfInterval)));
@@ -22648,8 +22648,8 @@ unittest
 
     const cPosInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
     immutable iPosInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
-    static assert(__traits(compiles, cPosInfInterval.fwdRange(everyDayOfWeek!Date(DayOfWeek.fri))));
-    static assert(__traits(compiles, iPosInfInterval.fwdRange(everyDayOfWeek!Date(DayOfWeek.fri))));
+    assert(!cPosInfInterval.fwdRange(everyDayOfWeek!Date(DayOfWeek.fri)).empty);
+    assert(!iPosInfInterval.fwdRange(everyDayOfWeek!Date(DayOfWeek.fri)).empty);
 }
 
 //Test PosInfInterval's toString().
@@ -22659,8 +22659,8 @@ unittest
 
     const cPosInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
     immutable iPosInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
-    static assert(__traits(compiles, cPosInfInterval.toString()));
-    static assert(__traits(compiles, iPosInfInterval.toString()));
+    assert(cPosInfInterval.toString());
+    assert(iPosInfInterval.toString());
 }
 
 
@@ -23722,8 +23722,8 @@ unittest
 
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
-    static assert(__traits(compiles, cNegInfInterval.end));
-    static assert(__traits(compiles, iNegInfInterval.end));
+    assert(cNegInfInterval.end != Date.init);
+    assert(iNegInfInterval.end != Date.init);
 
     //Verify Examples.
     assert(NegInfInterval!Date(Date(2012, 3, 1)).end == Date(2012, 3, 1));
@@ -23739,8 +23739,8 @@ unittest
 
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
-    static assert(__traits(compiles, cNegInfInterval.empty));
-    static assert(__traits(compiles, iNegInfInterval.empty));
+    assert(!cNegInfInterval.empty);
+    assert(!iNegInfInterval.empty);
 
     //Verify Examples.
     assert(!NegInfInterval!Date(Date(1996, 1, 2)).empty);
@@ -23764,9 +23764,9 @@ unittest
     const cdate = Date(2010, 7, 6);
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
-    static assert(__traits(compiles, negInfInterval.contains(cdate)));
-    static assert(__traits(compiles, cNegInfInterval.contains(cdate)));
-    static assert(__traits(compiles, iNegInfInterval.contains(cdate)));
+    assert(negInfInterval.contains(cdate));
+    assert(cNegInfInterval.contains(cdate));
+    assert(iNegInfInterval.contains(cdate));
 
     //Verify Examples.
     assert(NegInfInterval!Date(Date(2012, 3, 1)).contains(Date(1994, 12, 24)));
@@ -23829,33 +23829,33 @@ unittest
     immutable iPosInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
-    static assert(__traits(compiles, negInfInterval.contains(interval)));
-    static assert(__traits(compiles, negInfInterval.contains(cInterval)));
-    static assert(__traits(compiles, negInfInterval.contains(iInterval)));
-    static assert(__traits(compiles, negInfInterval.contains(posInfInterval)));
-    static assert(__traits(compiles, negInfInterval.contains(cPosInfInterval)));
-    static assert(__traits(compiles, negInfInterval.contains(iPosInfInterval)));
-    static assert(__traits(compiles, negInfInterval.contains(negInfInterval)));
-    static assert(__traits(compiles, negInfInterval.contains(cNegInfInterval)));
-    static assert(__traits(compiles, negInfInterval.contains(iNegInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.contains(interval)));
-    static assert(__traits(compiles, cNegInfInterval.contains(cInterval)));
-    static assert(__traits(compiles, cNegInfInterval.contains(iInterval)));
-    static assert(__traits(compiles, cNegInfInterval.contains(posInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.contains(cPosInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.contains(iPosInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.contains(negInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.contains(cNegInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.contains(iNegInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.contains(interval)));
-    static assert(__traits(compiles, iNegInfInterval.contains(cInterval)));
-    static assert(__traits(compiles, iNegInfInterval.contains(iInterval)));
-    static assert(__traits(compiles, iNegInfInterval.contains(posInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.contains(cPosInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.contains(iPosInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.contains(negInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.contains(cNegInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.contains(iNegInfInterval)));
+    assert(negInfInterval.contains(interval));
+    assert(negInfInterval.contains(cInterval));
+    assert(negInfInterval.contains(iInterval));
+    assert(!negInfInterval.contains(posInfInterval));
+    assert(!negInfInterval.contains(cPosInfInterval));
+    assert(!negInfInterval.contains(iPosInfInterval));
+    assert(negInfInterval.contains(negInfInterval));
+    assert(negInfInterval.contains(cNegInfInterval));
+    assert(negInfInterval.contains(iNegInfInterval));
+    assert(cNegInfInterval.contains(interval));
+    assert(cNegInfInterval.contains(cInterval));
+    assert(cNegInfInterval.contains(iInterval));
+    assert(!cNegInfInterval.contains(posInfInterval));
+    assert(!cNegInfInterval.contains(cPosInfInterval));
+    assert(!cNegInfInterval.contains(iPosInfInterval));
+    assert(cNegInfInterval.contains(negInfInterval));
+    assert(cNegInfInterval.contains(cNegInfInterval));
+    assert(cNegInfInterval.contains(iNegInfInterval));
+    assert(iNegInfInterval.contains(interval));
+    assert(iNegInfInterval.contains(cInterval));
+    assert(iNegInfInterval.contains(iInterval));
+    assert(!iNegInfInterval.contains(posInfInterval));
+    assert(!iNegInfInterval.contains(cPosInfInterval));
+    assert(!iNegInfInterval.contains(iPosInfInterval));
+    assert(iNegInfInterval.contains(negInfInterval));
+    assert(iNegInfInterval.contains(cNegInfInterval));
+    assert(iNegInfInterval.contains(iNegInfInterval));
 
     //Verify Examples.
     assert(NegInfInterval!Date(Date(2012, 3, 1)).contains(Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
@@ -23886,9 +23886,9 @@ unittest
     const cdate = Date(2010, 7, 6);
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
-    static assert(__traits(compiles, negInfInterval.isBefore(cdate)));
-    static assert(__traits(compiles, cNegInfInterval.isBefore(cdate)));
-    static assert(__traits(compiles, iNegInfInterval.isBefore(cdate)));
+    assert(!negInfInterval.isBefore(cdate));
+    assert(!cNegInfInterval.isBefore(cdate));
+    assert(!iNegInfInterval.isBefore(cdate));
 
     //Verify Examples.
     assert(!NegInfInterval!Date(Date(2012, 3, 1)).isBefore(Date(1994, 12, 24)));
@@ -23951,33 +23951,33 @@ unittest
     immutable iPosInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
-    static assert(__traits(compiles, negInfInterval.isBefore(interval)));
-    static assert(__traits(compiles, negInfInterval.isBefore(cInterval)));
-    static assert(__traits(compiles, negInfInterval.isBefore(iInterval)));
-    static assert(__traits(compiles, negInfInterval.isBefore(posInfInterval)));
-    static assert(__traits(compiles, negInfInterval.isBefore(cPosInfInterval)));
-    static assert(__traits(compiles, negInfInterval.isBefore(iPosInfInterval)));
-    static assert(__traits(compiles, negInfInterval.isBefore(negInfInterval)));
-    static assert(__traits(compiles, negInfInterval.isBefore(cNegInfInterval)));
-    static assert(__traits(compiles, negInfInterval.isBefore(iNegInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.isBefore(interval)));
-    static assert(__traits(compiles, cNegInfInterval.isBefore(cInterval)));
-    static assert(__traits(compiles, cNegInfInterval.isBefore(iInterval)));
-    static assert(__traits(compiles, cNegInfInterval.isBefore(posInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.isBefore(cPosInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.isBefore(iPosInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.isBefore(negInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.isBefore(cNegInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.isBefore(iNegInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.isBefore(interval)));
-    static assert(__traits(compiles, iNegInfInterval.isBefore(cInterval)));
-    static assert(__traits(compiles, iNegInfInterval.isBefore(iInterval)));
-    static assert(__traits(compiles, iNegInfInterval.isBefore(posInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.isBefore(cPosInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.isBefore(iPosInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.isBefore(negInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.isBefore(cNegInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.isBefore(iNegInfInterval)));
+    assert(!negInfInterval.isBefore(interval));
+    assert(!negInfInterval.isBefore(cInterval));
+    assert(!negInfInterval.isBefore(iInterval));
+    assert(!negInfInterval.isBefore(posInfInterval));
+    assert(!negInfInterval.isBefore(cPosInfInterval));
+    assert(!negInfInterval.isBefore(iPosInfInterval));
+    assert(!negInfInterval.isBefore(negInfInterval));
+    assert(!negInfInterval.isBefore(cNegInfInterval));
+    assert(!negInfInterval.isBefore(iNegInfInterval));
+    assert(!cNegInfInterval.isBefore(interval));
+    assert(!cNegInfInterval.isBefore(cInterval));
+    assert(!cNegInfInterval.isBefore(iInterval));
+    assert(!cNegInfInterval.isBefore(posInfInterval));
+    assert(!cNegInfInterval.isBefore(cPosInfInterval));
+    assert(!cNegInfInterval.isBefore(iPosInfInterval));
+    assert(!cNegInfInterval.isBefore(negInfInterval));
+    assert(!cNegInfInterval.isBefore(cNegInfInterval));
+    assert(!cNegInfInterval.isBefore(iNegInfInterval));
+    assert(!iNegInfInterval.isBefore(interval));
+    assert(!iNegInfInterval.isBefore(cInterval));
+    assert(!iNegInfInterval.isBefore(iInterval));
+    assert(!iNegInfInterval.isBefore(posInfInterval));
+    assert(!iNegInfInterval.isBefore(cPosInfInterval));
+    assert(!iNegInfInterval.isBefore(iPosInfInterval));
+    assert(!iNegInfInterval.isBefore(negInfInterval));
+    assert(!iNegInfInterval.isBefore(cNegInfInterval));
+    assert(!iNegInfInterval.isBefore(iNegInfInterval));
 
     //Verify Examples.
     assert(!NegInfInterval!Date(Date(2012, 3, 1)).isBefore(Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
@@ -24009,9 +24009,9 @@ unittest
     const cdate = Date(2010, 7, 6);
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
-    static assert(__traits(compiles, negInfInterval.isAfter(cdate)));
-    static assert(__traits(compiles, cNegInfInterval.isAfter(cdate)));
-    static assert(__traits(compiles, iNegInfInterval.isAfter(cdate)));
+    assert(!negInfInterval.isAfter(cdate));
+    assert(!cNegInfInterval.isAfter(cdate));
+    assert(!iNegInfInterval.isAfter(cdate));
 }
 
 //Test NegInfInterval's isAfter(Interval).
@@ -24069,33 +24069,33 @@ unittest
     immutable iPosInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
-    static assert(__traits(compiles, negInfInterval.isAfter(interval)));
-    static assert(__traits(compiles, negInfInterval.isAfter(cInterval)));
-    static assert(__traits(compiles, negInfInterval.isAfter(iInterval)));
-    static assert(__traits(compiles, negInfInterval.isAfter(posInfInterval)));
-    static assert(__traits(compiles, negInfInterval.isAfter(cPosInfInterval)));
-    static assert(__traits(compiles, negInfInterval.isAfter(iPosInfInterval)));
-    static assert(__traits(compiles, negInfInterval.isAfter(negInfInterval)));
-    static assert(__traits(compiles, negInfInterval.isAfter(cNegInfInterval)));
-    static assert(__traits(compiles, negInfInterval.isAfter(iNegInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.isAfter(interval)));
-    static assert(__traits(compiles, cNegInfInterval.isAfter(cInterval)));
-    static assert(__traits(compiles, cNegInfInterval.isAfter(iInterval)));
-    static assert(__traits(compiles, cNegInfInterval.isAfter(posInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.isAfter(cPosInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.isAfter(iPosInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.isAfter(negInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.isAfter(cNegInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.isAfter(iNegInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.isAfter(interval)));
-    static assert(__traits(compiles, iNegInfInterval.isAfter(cInterval)));
-    static assert(__traits(compiles, iNegInfInterval.isAfter(iInterval)));
-    static assert(__traits(compiles, iNegInfInterval.isAfter(posInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.isAfter(cPosInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.isAfter(iPosInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.isAfter(negInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.isAfter(cNegInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.isAfter(iNegInfInterval)));
+    assert(!negInfInterval.isAfter(interval));
+    assert(!negInfInterval.isAfter(cInterval));
+    assert(!negInfInterval.isAfter(iInterval));
+    assert(!negInfInterval.isAfter(posInfInterval));
+    assert(!negInfInterval.isAfter(cPosInfInterval));
+    assert(!negInfInterval.isAfter(iPosInfInterval));
+    assert(!negInfInterval.isAfter(negInfInterval));
+    assert(!negInfInterval.isAfter(cNegInfInterval));
+    assert(!negInfInterval.isAfter(iNegInfInterval));
+    assert(!cNegInfInterval.isAfter(interval));
+    assert(!cNegInfInterval.isAfter(cInterval));
+    assert(!cNegInfInterval.isAfter(iInterval));
+    assert(!cNegInfInterval.isAfter(posInfInterval));
+    assert(!cNegInfInterval.isAfter(cPosInfInterval));
+    assert(!cNegInfInterval.isAfter(iPosInfInterval));
+    assert(!cNegInfInterval.isAfter(negInfInterval));
+    assert(!cNegInfInterval.isAfter(cNegInfInterval));
+    assert(!cNegInfInterval.isAfter(iNegInfInterval));
+    assert(!iNegInfInterval.isAfter(interval));
+    assert(!iNegInfInterval.isAfter(cInterval));
+    assert(!iNegInfInterval.isAfter(iInterval));
+    assert(!iNegInfInterval.isAfter(posInfInterval));
+    assert(!iNegInfInterval.isAfter(cPosInfInterval));
+    assert(!iNegInfInterval.isAfter(iPosInfInterval));
+    assert(!iNegInfInterval.isAfter(negInfInterval));
+    assert(!iNegInfInterval.isAfter(cNegInfInterval));
+    assert(!iNegInfInterval.isAfter(iNegInfInterval));
 
     //Verify Examples.
     assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAfter(Date(1994, 12, 24)));
@@ -24168,33 +24168,33 @@ unittest
     immutable iPosInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
-    static assert(__traits(compiles, negInfInterval.intersects(interval)));
-    static assert(__traits(compiles, negInfInterval.intersects(cInterval)));
-    static assert(__traits(compiles, negInfInterval.intersects(iInterval)));
-    static assert(__traits(compiles, negInfInterval.intersects(posInfInterval)));
-    static assert(__traits(compiles, negInfInterval.intersects(cPosInfInterval)));
-    static assert(__traits(compiles, negInfInterval.intersects(iPosInfInterval)));
-    static assert(__traits(compiles, negInfInterval.intersects(negInfInterval)));
-    static assert(__traits(compiles, negInfInterval.intersects(cNegInfInterval)));
-    static assert(__traits(compiles, negInfInterval.intersects(iNegInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.intersects(interval)));
-    static assert(__traits(compiles, cNegInfInterval.intersects(cInterval)));
-    static assert(__traits(compiles, cNegInfInterval.intersects(iInterval)));
-    static assert(__traits(compiles, cNegInfInterval.intersects(posInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.intersects(cPosInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.intersects(iPosInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.intersects(negInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.intersects(cNegInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.intersects(iNegInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.intersects(interval)));
-    static assert(__traits(compiles, iNegInfInterval.intersects(cInterval)));
-    static assert(__traits(compiles, iNegInfInterval.intersects(iInterval)));
-    static assert(__traits(compiles, iNegInfInterval.intersects(posInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.intersects(cPosInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.intersects(iPosInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.intersects(negInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.intersects(cNegInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.intersects(iNegInfInterval)));
+    assert(negInfInterval.intersects(interval));
+    assert(negInfInterval.intersects(cInterval));
+    assert(negInfInterval.intersects(iInterval));
+    assert(negInfInterval.intersects(posInfInterval));
+    assert(negInfInterval.intersects(cPosInfInterval));
+    assert(negInfInterval.intersects(iPosInfInterval));
+    assert(negInfInterval.intersects(negInfInterval));
+    assert(negInfInterval.intersects(cNegInfInterval));
+    assert(negInfInterval.intersects(iNegInfInterval));
+    assert(cNegInfInterval.intersects(interval));
+    assert(cNegInfInterval.intersects(cInterval));
+    assert(cNegInfInterval.intersects(iInterval));
+    assert(cNegInfInterval.intersects(posInfInterval));
+    assert(cNegInfInterval.intersects(cPosInfInterval));
+    assert(cNegInfInterval.intersects(iPosInfInterval));
+    assert(cNegInfInterval.intersects(negInfInterval));
+    assert(cNegInfInterval.intersects(cNegInfInterval));
+    assert(cNegInfInterval.intersects(iNegInfInterval));
+    assert(iNegInfInterval.intersects(interval));
+    assert(iNegInfInterval.intersects(cInterval));
+    assert(iNegInfInterval.intersects(iInterval));
+    assert(iNegInfInterval.intersects(posInfInterval));
+    assert(iNegInfInterval.intersects(cPosInfInterval));
+    assert(iNegInfInterval.intersects(iPosInfInterval));
+    assert(iNegInfInterval.intersects(negInfInterval));
+    assert(iNegInfInterval.intersects(cNegInfInterval));
+    assert(iNegInfInterval.intersects(iNegInfInterval));
 
     //Verify Examples.
     assert(NegInfInterval!Date(Date(2012, 3, 1)).intersects(Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
@@ -24292,33 +24292,33 @@ unittest
     immutable iPosInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
-    static assert(__traits(compiles, negInfInterval.intersection(interval)));
-    static assert(__traits(compiles, negInfInterval.intersection(cInterval)));
-    static assert(__traits(compiles, negInfInterval.intersection(iInterval)));
-    static assert(__traits(compiles, negInfInterval.intersection(posInfInterval)));
-    static assert(__traits(compiles, negInfInterval.intersection(cPosInfInterval)));
-    static assert(__traits(compiles, negInfInterval.intersection(iPosInfInterval)));
-    static assert(__traits(compiles, negInfInterval.intersection(negInfInterval)));
-    static assert(__traits(compiles, negInfInterval.intersection(cNegInfInterval)));
-    static assert(__traits(compiles, negInfInterval.intersection(iNegInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.intersection(interval)));
-    static assert(__traits(compiles, cNegInfInterval.intersection(cInterval)));
-    static assert(__traits(compiles, cNegInfInterval.intersection(iInterval)));
-    static assert(__traits(compiles, cNegInfInterval.intersection(posInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.intersection(cPosInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.intersection(iPosInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.intersection(negInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.intersection(cNegInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.intersection(iNegInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.intersection(interval)));
-    static assert(__traits(compiles, iNegInfInterval.intersection(cInterval)));
-    static assert(__traits(compiles, iNegInfInterval.intersection(iInterval)));
-    static assert(__traits(compiles, iNegInfInterval.intersection(posInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.intersection(cPosInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.intersection(iPosInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.intersection(negInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.intersection(cNegInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.intersection(iNegInfInterval)));
+    assert(!negInfInterval.intersection(interval).empty);
+    assert(!negInfInterval.intersection(cInterval).empty);
+    assert(!negInfInterval.intersection(iInterval).empty);
+    assert(!negInfInterval.intersection(posInfInterval).empty);
+    assert(!negInfInterval.intersection(cPosInfInterval).empty);
+    assert(!negInfInterval.intersection(iPosInfInterval).empty);
+    assert(!negInfInterval.intersection(negInfInterval).empty);
+    assert(!negInfInterval.intersection(cNegInfInterval).empty);
+    assert(!negInfInterval.intersection(iNegInfInterval).empty);
+    assert(!cNegInfInterval.intersection(interval).empty);
+    assert(!cNegInfInterval.intersection(cInterval).empty);
+    assert(!cNegInfInterval.intersection(iInterval).empty);
+    assert(!cNegInfInterval.intersection(posInfInterval).empty);
+    assert(!cNegInfInterval.intersection(cPosInfInterval).empty);
+    assert(!cNegInfInterval.intersection(iPosInfInterval).empty);
+    assert(!cNegInfInterval.intersection(negInfInterval).empty);
+    assert(!cNegInfInterval.intersection(cNegInfInterval).empty);
+    assert(!cNegInfInterval.intersection(iNegInfInterval).empty);
+    assert(!iNegInfInterval.intersection(interval).empty);
+    assert(!iNegInfInterval.intersection(cInterval).empty);
+    assert(!iNegInfInterval.intersection(iInterval).empty);
+    assert(!iNegInfInterval.intersection(posInfInterval).empty);
+    assert(!iNegInfInterval.intersection(cPosInfInterval).empty);
+    assert(!iNegInfInterval.intersection(iPosInfInterval).empty);
+    assert(!iNegInfInterval.intersection(negInfInterval).empty);
+    assert(!iNegInfInterval.intersection(cNegInfInterval).empty);
+    assert(!iNegInfInterval.intersection(iNegInfInterval).empty);
 
     //Verify Examples.
     assert(NegInfInterval!Date(Date(2012, 3, 1)).intersection(Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))) == Interval!Date(Date(1990, 7 , 6), Date(2000, 8, 2)));
@@ -24386,33 +24386,33 @@ unittest
     immutable iPosInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
-    static assert(__traits(compiles, negInfInterval.isAdjacent(interval)));
-    static assert(__traits(compiles, negInfInterval.isAdjacent(cInterval)));
-    static assert(__traits(compiles, negInfInterval.isAdjacent(iInterval)));
-    static assert(__traits(compiles, negInfInterval.isAdjacent(posInfInterval)));
-    static assert(__traits(compiles, negInfInterval.isAdjacent(cPosInfInterval)));
-    static assert(__traits(compiles, negInfInterval.isAdjacent(iPosInfInterval)));
-    static assert(__traits(compiles, negInfInterval.isAdjacent(negInfInterval)));
-    static assert(__traits(compiles, negInfInterval.isAdjacent(cNegInfInterval)));
-    static assert(__traits(compiles, negInfInterval.isAdjacent(iNegInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.isAdjacent(interval)));
-    static assert(__traits(compiles, cNegInfInterval.isAdjacent(cInterval)));
-    static assert(__traits(compiles, cNegInfInterval.isAdjacent(iInterval)));
-    static assert(__traits(compiles, cNegInfInterval.isAdjacent(posInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.isAdjacent(cPosInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.isAdjacent(iPosInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.isAdjacent(negInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.isAdjacent(cNegInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.isAdjacent(iNegInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.isAdjacent(interval)));
-    static assert(__traits(compiles, iNegInfInterval.isAdjacent(cInterval)));
-    static assert(__traits(compiles, iNegInfInterval.isAdjacent(iInterval)));
-    static assert(__traits(compiles, iNegInfInterval.isAdjacent(posInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.isAdjacent(cPosInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.isAdjacent(iPosInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.isAdjacent(negInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.isAdjacent(cNegInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.isAdjacent(iNegInfInterval)));
+    assert(!negInfInterval.isAdjacent(interval));
+    assert(!negInfInterval.isAdjacent(cInterval));
+    assert(!negInfInterval.isAdjacent(iInterval));
+    assert(!negInfInterval.isAdjacent(posInfInterval));
+    assert(!negInfInterval.isAdjacent(cPosInfInterval));
+    assert(!negInfInterval.isAdjacent(iPosInfInterval));
+    assert(!negInfInterval.isAdjacent(negInfInterval));
+    assert(!negInfInterval.isAdjacent(cNegInfInterval));
+    assert(!negInfInterval.isAdjacent(iNegInfInterval));
+    assert(!cNegInfInterval.isAdjacent(interval));
+    assert(!cNegInfInterval.isAdjacent(cInterval));
+    assert(!cNegInfInterval.isAdjacent(iInterval));
+    assert(!cNegInfInterval.isAdjacent(posInfInterval));
+    assert(!cNegInfInterval.isAdjacent(cPosInfInterval));
+    assert(!cNegInfInterval.isAdjacent(iPosInfInterval));
+    assert(!cNegInfInterval.isAdjacent(negInfInterval));
+    assert(!cNegInfInterval.isAdjacent(cNegInfInterval));
+    assert(!cNegInfInterval.isAdjacent(iNegInfInterval));
+    assert(!iNegInfInterval.isAdjacent(interval));
+    assert(!iNegInfInterval.isAdjacent(cInterval));
+    assert(!iNegInfInterval.isAdjacent(iInterval));
+    assert(!iNegInfInterval.isAdjacent(posInfInterval));
+    assert(!iNegInfInterval.isAdjacent(cPosInfInterval));
+    assert(!iNegInfInterval.isAdjacent(iPosInfInterval));
+    assert(!iNegInfInterval.isAdjacent(negInfInterval));
+    assert(!iNegInfInterval.isAdjacent(cNegInfInterval));
+    assert(!iNegInfInterval.isAdjacent(iNegInfInterval));
 
     //Verify Examples.
     assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAdjacent(Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
@@ -24507,33 +24507,33 @@ unittest
     immutable iPosInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
-    static assert(__traits(compiles, negInfInterval.merge(interval)));
-    static assert(__traits(compiles, negInfInterval.merge(cInterval)));
-    static assert(__traits(compiles, negInfInterval.merge(iInterval)));
+    assert(!negInfInterval.merge(interval).empty);
+    assert(!negInfInterval.merge(cInterval).empty);
+    assert(!negInfInterval.merge(iInterval).empty);
     static assert(!__traits(compiles, negInfInterval.merge(posInfInterval)));
     static assert(!__traits(compiles, negInfInterval.merge(cPosInfInterval)));
     static assert(!__traits(compiles, negInfInterval.merge(iPosInfInterval)));
-    static assert(__traits(compiles, negInfInterval.merge(negInfInterval)));
-    static assert(__traits(compiles, negInfInterval.merge(cNegInfInterval)));
-    static assert(__traits(compiles, negInfInterval.merge(iNegInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.merge(interval)));
-    static assert(__traits(compiles, cNegInfInterval.merge(cInterval)));
-    static assert(__traits(compiles, cNegInfInterval.merge(iInterval)));
+    assert(!negInfInterval.merge(negInfInterval).empty);
+    assert(!negInfInterval.merge(cNegInfInterval).empty);
+    assert(!negInfInterval.merge(iNegInfInterval).empty);
+    assert(!cNegInfInterval.merge(interval).empty);
+    assert(!cNegInfInterval.merge(cInterval).empty);
+    assert(!cNegInfInterval.merge(iInterval).empty);
     static assert(!__traits(compiles, cNegInfInterval.merge(posInfInterval)));
     static assert(!__traits(compiles, cNegInfInterval.merge(cPosInfInterval)));
     static assert(!__traits(compiles, cNegInfInterval.merge(iPosInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.merge(negInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.merge(cNegInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.merge(iNegInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.merge(interval)));
-    static assert(__traits(compiles, iNegInfInterval.merge(cInterval)));
-    static assert(__traits(compiles, iNegInfInterval.merge(iInterval)));
+    assert(!cNegInfInterval.merge(negInfInterval).empty);
+    assert(!cNegInfInterval.merge(cNegInfInterval).empty);
+    assert(!cNegInfInterval.merge(iNegInfInterval).empty);
+    assert(!iNegInfInterval.merge(interval).empty);
+    assert(!iNegInfInterval.merge(cInterval).empty);
+    assert(!iNegInfInterval.merge(iInterval).empty);
     static assert(!__traits(compiles, iNegInfInterval.merge(posInfInterval)));
     static assert(!__traits(compiles, iNegInfInterval.merge(cPosInfInterval)));
     static assert(!__traits(compiles, iNegInfInterval.merge(iPosInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.merge(negInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.merge(cNegInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.merge(iNegInfInterval)));
+    assert(!iNegInfInterval.merge(negInfInterval).empty);
+    assert(!iNegInfInterval.merge(cNegInfInterval).empty);
+    assert(!iNegInfInterval.merge(iNegInfInterval).empty);
 
     //Verify Examples.
     assert(NegInfInterval!Date(Date(2012, 3, 1)).merge(Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))) == NegInfInterval!Date(Date(2012, 3 , 1)));
@@ -24623,33 +24623,33 @@ unittest
     immutable iPosInfInterval = PosInfInterval!Date(Date(2010, 7, 4));
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
-    static assert(__traits(compiles, negInfInterval.span(interval)));
-    static assert(__traits(compiles, negInfInterval.span(cInterval)));
-    static assert(__traits(compiles, negInfInterval.span(iInterval)));
+    assert(!negInfInterval.span(interval).empty);
+    assert(!negInfInterval.span(cInterval).empty);
+    assert(!negInfInterval.span(iInterval).empty);
     static assert(!__traits(compiles, negInfInterval.span(posInfInterval)));
     static assert(!__traits(compiles, negInfInterval.span(cPosInfInterval)));
     static assert(!__traits(compiles, negInfInterval.span(iPosInfInterval)));
-    static assert(__traits(compiles, negInfInterval.span(negInfInterval)));
-    static assert(__traits(compiles, negInfInterval.span(cNegInfInterval)));
-    static assert(__traits(compiles, negInfInterval.span(iNegInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.span(interval)));
-    static assert(__traits(compiles, cNegInfInterval.span(cInterval)));
-    static assert(__traits(compiles, cNegInfInterval.span(iInterval)));
+    assert(!negInfInterval.span(negInfInterval).empty);
+    assert(!negInfInterval.span(cNegInfInterval).empty);
+    assert(!negInfInterval.span(iNegInfInterval).empty);
+    assert(!cNegInfInterval.span(interval).empty);
+    assert(!cNegInfInterval.span(cInterval).empty);
+    assert(!cNegInfInterval.span(iInterval).empty);
     static assert(!__traits(compiles, cNegInfInterval.span(posInfInterval)));
     static assert(!__traits(compiles, cNegInfInterval.span(cPosInfInterval)));
     static assert(!__traits(compiles, cNegInfInterval.span(iPosInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.span(negInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.span(cNegInfInterval)));
-    static assert(__traits(compiles, cNegInfInterval.span(iNegInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.span(interval)));
-    static assert(__traits(compiles, iNegInfInterval.span(cInterval)));
-    static assert(__traits(compiles, iNegInfInterval.span(iInterval)));
+    assert(!cNegInfInterval.span(negInfInterval).empty);
+    assert(!cNegInfInterval.span(cNegInfInterval).empty);
+    assert(!cNegInfInterval.span(iNegInfInterval).empty);
+    assert(!iNegInfInterval.span(interval).empty);
+    assert(!iNegInfInterval.span(cInterval).empty);
+    assert(!iNegInfInterval.span(iInterval).empty);
     static assert(!__traits(compiles, iNegInfInterval.span(posInfInterval)));
     static assert(!__traits(compiles, iNegInfInterval.span(cPosInfInterval)));
     static assert(!__traits(compiles, iNegInfInterval.span(iPosInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.span(negInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.span(cNegInfInterval)));
-    static assert(__traits(compiles, iNegInfInterval.span(iNegInfInterval)));
+    assert(!iNegInfInterval.span(negInfInterval).empty);
+    assert(!iNegInfInterval.span(cNegInfInterval).empty);
+    assert(!iNegInfInterval.span(iNegInfInterval).empty);
 
     //Verify Examples.
     assert(NegInfInterval!Date(Date(2012, 3, 1)).span(Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))) == NegInfInterval!Date(Date(2012, 3 , 1)));
@@ -24862,8 +24862,8 @@ unittest
 
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
-    static assert(__traits(compiles, cNegInfInterval.bwdRange(everyDayOfWeek!(Date, Direction.bwd)(DayOfWeek.fri))));
-    static assert(__traits(compiles, iNegInfInterval.bwdRange(everyDayOfWeek!(Date, Direction.bwd)(DayOfWeek.fri))));
+    assert(!cNegInfInterval.bwdRange(everyDayOfWeek!(Date, Direction.bwd)(DayOfWeek.fri)).empty);
+    assert(!iNegInfInterval.bwdRange(everyDayOfWeek!(Date, Direction.bwd)(DayOfWeek.fri)).empty);
 }
 
 //Test NegInfInterval's toString().
@@ -24873,8 +24873,8 @@ unittest
 
     const cNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
     immutable iNegInfInterval = NegInfInterval!Date(Date(2012, 1, 7));
-    static assert(__traits(compiles, cNegInfInterval.toString()));
-    static assert(__traits(compiles, iNegInfInterval.toString()));
+    assert(cNegInfInterval.toString());
+    assert(iNegInfInterval.toString());
 }
 
 
@@ -24971,8 +24971,8 @@ unittest
     assert(funcBwd(Date(2010, 9, 7)) == Date(2010, 9, 6));
 
     static assert(!__traits(compiles, everyDayOfWeek!(TimeOfDay)(DayOfWeek.mon)));
-    static assert(__traits(compiles, everyDayOfWeek!(DateTime)(DayOfWeek.mon)));
-    static assert(__traits(compiles, everyDayOfWeek!(SysTime)(DayOfWeek.mon)));
+    assert(everyDayOfWeek!(DateTime)(DayOfWeek.mon) !is null);
+    assert(everyDayOfWeek!(SysTime)(DayOfWeek.mon) !is null);
 }
 
 
@@ -25099,8 +25099,8 @@ unittest
     assert(funcBwd(Date(2011, 7, 30)) == Date(2011, 6, 30));
 
     static assert(!__traits(compiles, everyMonth!(TimeOfDay)(Month.jan)));
-    static assert(__traits(compiles, everyMonth!(DateTime)(Month.jan)));
-    static assert(__traits(compiles, everyMonth!(SysTime)(Month.jan)));
+    assert(everyMonth!(DateTime)(Month.jan) !is null);
+    assert(everyMonth!(SysTime)(Month.jan) !is null);
 }
 
 
@@ -25177,10 +25177,10 @@ unittest
     assert(funcBwd(Date(2010, 1, 23)) == Date(2009, 12, 27));
     assert(funcBwd(Date(2010, 1, 24)) == Date(2009, 12, 28));
 
-    static assert(__traits(compiles, everyDuration!Date(dur!"hnsecs"(1))));
-    static assert(__traits(compiles, everyDuration!TimeOfDay(dur!"hnsecs"(1))));
-    static assert(__traits(compiles, everyDuration!DateTime(dur!"hnsecs"(1))));
-    static assert(__traits(compiles, everyDuration!SysTime(dur!"hnsecs"(1))));
+    assert(everyDuration!Date(dur!"hnsecs"(1)) !is null);
+    assert(everyDuration!TimeOfDay(dur!"hnsecs"(1)) !is null);
+    assert(everyDuration!DateTime(dur!"hnsecs"(1)) !is null);
+    assert(everyDuration!SysTime(dur!"hnsecs"(1)) !is null);
 }
 
 
@@ -25317,10 +25317,10 @@ unittest
         assert(funcBwd(Date(2011, 3, 4)) == Date(2010, 1, 1));
     }
 
-    static assert(__traits(compiles, everyDuration!Date(1, 2, AllowDayOverflow.yes, dur!"hnsecs"(1))));
+    assert(everyDuration!Date(1, 2, AllowDayOverflow.yes, dur!"hnsecs"(1)) !is null);
     static assert(!__traits(compiles, everyDuration!TimeOfDay(1, 2, AllowDayOverflow.yes, dur!"hnsecs"(1))));
-    static assert(__traits(compiles, everyDuration!DateTime(1, 2, AllowDayOverflow.yes, dur!"hnsecs"(1))));
-    static assert(__traits(compiles, everyDuration!SysTime(1, 2, AllowDayOverflow.yes, dur!"hnsecs"(1))));
+    assert(everyDuration!DateTime(1, 2, AllowDayOverflow.yes, dur!"hnsecs"(1)) !is null);
+    assert(everyDuration!SysTime(1, 2, AllowDayOverflow.yes, dur!"hnsecs"(1)) !is null);
 }
 
 
@@ -25653,7 +25653,7 @@ unittest
         assert(range.empty);
 
         const cRange = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7)).fwdRange(everyDayOfWeek!Date(DayOfWeek.fri));
-        static assert(__traits(compiles, cRange.empty));
+        assert(!cRange.empty);
 
         //Apparently, creating an immutable IntervalRange!Date doesn't work, so we can't test if
         //empty works with it. However, since an immutable range is pretty useless, it's no great loss.
@@ -25668,7 +25668,7 @@ unittest
         assert(range.empty);
 
         const cRange = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7)).bwdRange(everyDayOfWeek!(Date, Direction.bwd)(DayOfWeek.fri));
-        static assert(__traits(compiles, cRange.empty));
+        assert(!cRange.empty);
 
         //Apparently, creating an immutable IntervalRange!Date doesn't work, so we can't test if
         //empty works with it. However, since an immutable range is pretty useless, it's no great loss.
@@ -25690,7 +25690,7 @@ unittest
         assert(poppedRange.front == Date(2010, 7, 7));
 
         const cRange = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7)).fwdRange(everyDayOfWeek!Date(DayOfWeek.fri));
-        static assert(__traits(compiles, cRange.front));
+        assert(cRange.front != Date.init);
     }
 
     //bwd
@@ -25705,7 +25705,7 @@ unittest
         assert(poppedRange.front == Date(2012, 1, 4));
 
         const cRange = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7)).bwdRange(everyDayOfWeek!(Date, Direction.bwd)(DayOfWeek.fri));
-        static assert(__traits(compiles, cRange.front));
+        assert(cRange.front != Date.init);
     }
 }
 
@@ -25729,7 +25729,7 @@ unittest
         assert(walkLength(range) == 79);
 
         const cRange = Interval!Date(Date(2010, 7, 4), Date(2012, 1, 7)).fwdRange(everyDayOfWeek!Date(DayOfWeek.fri));
-        static assert(__traits(compiles, cRange.front));
+        assert(cRange.front != Date.init);
     }
 
     //bwd
@@ -25787,7 +25787,7 @@ unittest
         assert(range.interval == interval);
 
         const cRange = range;
-        static assert(__traits(compiles, cRange.interval));
+        assert(!cRange.interval.empty);
     }
 
     //bwd
@@ -25799,7 +25799,7 @@ unittest
         assert(range.interval == interval);
 
         const cRange = range;
-        static assert(__traits(compiles, cRange.interval));
+        assert(!cRange.interval.empty);
     }
 }
 
@@ -25837,7 +25837,7 @@ unittest
         assert(range.direction == Direction.fwd);
 
         const cRange = range;
-        static assert(__traits(compiles, cRange.direction));
+        assert(cRange.direction == Direction.fwd);
     }
 
     //bwd
@@ -25849,7 +25849,7 @@ unittest
         assert(range.direction == Direction.bwd);
 
         const cRange = range;
-        static assert(__traits(compiles, cRange.direction));
+        assert(cRange.direction == Direction.bwd);
     }
 }
 
@@ -26079,7 +26079,7 @@ unittest
     assert(poppedRange.front == Date(2010, 7, 7));
 
     const cRange = PosInfInterval!Date(Date(2010, 7, 4)).fwdRange(everyDayOfWeek!Date(DayOfWeek.fri));
-    static assert(__traits(compiles, cRange.front));
+    assert(cRange.front != Date.init);
 }
 
 //Test PosInfIntervalRange's popFront().
@@ -26119,7 +26119,7 @@ unittest
     assert(range.interval == interval);
 
     const cRange = range;
-    static assert(__traits(compiles, cRange.interval));
+    assert(!cRange.interval.empty);
 }
 
 //Test PosInfIntervalRange's func.
@@ -26366,7 +26366,7 @@ unittest
     assert(poppedRange.front == Date(2012, 1, 4));
 
     const cRange = NegInfInterval!Date(Date(2012, 1, 7)).bwdRange(everyDayOfWeek!(Date, Direction.bwd)(DayOfWeek.fri));
-    static assert(__traits(compiles, cRange.front));
+    assert(cRange.front != Date.init);
 }
 
 //Test NegInfIntervalRange's popFront().
@@ -26407,7 +26407,7 @@ unittest
     assert(range.interval == interval);
 
     const cRange = range;
-    static assert(__traits(compiles, cRange.interval));
+    assert(!cRange.interval.empty);
 }
 
 //Test NegInfIntervalRange's func.
@@ -27710,8 +27710,7 @@ public:
         assert(west.utcToTZ(54_321_234_567_890L) == 54_033_234_567_890L);
 
         const cstz = west;
-        static assert(__traits(compiles, west.utcToTZ(50002)));
-        static assert(__traits(compiles, cstz.utcToTZ(50002)));
+        assert(cstz.utcToTZ(50002) == west.utcToTZ(50002));
     }
 
 
@@ -27738,8 +27737,7 @@ public:
         assert(west.tzToUTC(54_033_234_567_890L) == 54_321_234_567_890L);
 
         const cstz = west;
-        static assert(__traits(compiles, west.tzToUTC(20005)));
-        static assert(__traits(compiles, cstz.tzToUTC(20005)));
+        assert(cstz.tzToUTC(20005) == west.tzToUTC(20005));
     }
 
 

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -1186,6 +1186,7 @@ public:
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         st.year = 12;
+        assert(st.year == 12);
         static assert(!__traits(compiles, cst.year = 12));
         //static assert(!__traits(compiles, ist.year = 12));
     }
@@ -1282,6 +1283,7 @@ public:
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         st.yearBC = 12;
+        assert(st.yearBC == 12);
         static assert(!__traits(compiles, cst.yearBC = 12));
         //static assert(!__traits(compiles, ist.yearBC = 12));
     }
@@ -6839,6 +6841,7 @@ public:
         const cst = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         //immutable ist = SysTime(DateTime(1999, 7, 6, 12, 30, 33));
         st.dayOfYear = 12;
+        assert(st.dayOfYear == 12);
         static assert(!__traits(compiles, cst.dayOfYear = 12));
         //static assert(!__traits(compiles, ist.dayOfYear = 12));
     }
@@ -9567,6 +9570,7 @@ public:
         const cdate = Date(0, 7, 6);
         immutable idate = Date(0, 7, 6);
         date.yearBC = 7;
+        assert(date.yearBC == 7);
         static assert(!__traits(compiles, cdate.yearBC = 7));
         static assert(!__traits(compiles, idate.yearBC = 7));
     }
@@ -12210,6 +12214,7 @@ public:
         const cdate = Date(1999, 7, 6);
         immutable idate = Date(1999, 7, 6);
         date.dayOfGregorianCal = 187;
+        assert(date.dayOfGregorianCal == 187);
         static assert(!__traits(compiles, cdate.dayOfGregorianCal = 187));
         static assert(!__traits(compiles, idate.dayOfGregorianCal = 187));
     }
@@ -15039,6 +15044,7 @@ public:
         const cdt = DateTime(1999, 7, 6, 12, 30, 33);
         immutable idt = DateTime(1999, 7, 6, 12, 30, 33);
         dt.yearBC = 12;
+        assert(dt.yearBC == 12);
         static assert(!__traits(compiles, cdt.yearBC = 12));
         static assert(!__traits(compiles, idt.yearBC = 12));
     }
@@ -15077,6 +15083,7 @@ public:
         const cdt = DateTime(1999, 7, 6, 12, 30, 33);
         immutable idt = DateTime(1999, 7, 6, 12, 30, 33);
         dt.yearBC = 12;
+        assert(dt.yearBC == 12);
         static assert(!__traits(compiles, cdt.yearBC = 12));
         static assert(!__traits(compiles, idt.yearBC = 12));
     }
@@ -16542,6 +16549,7 @@ public:
         const cdt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         immutable idt = DateTime(Date(1999, 7, 6), TimeOfDay(12, 30, 33));
         dt.dayOfYear = 12;
+        assert(dt.dayOfYear == 12);
         static assert(!__traits(compiles, cdt.dayOfYear = 12));
         static assert(!__traits(compiles, idt.dayOfYear = 12));
     }

--- a/std/meta.d
+++ b/std/meta.d
@@ -987,9 +987,9 @@ unittest
     alias b = Alias!(abc);
     static assert(b == 1);
     alias c = Alias!(int);
-    static assert(c.stringof == "(int)");
+    static assert(is(c[0] == int));
     alias d = Alias!(1, abc, int);
-    static assert(d[0] == 1 && d[1] == 1 && d[2].stringof == "int");
+    static assert(d[0] == 1 && d[1] == 1 && is(d[2] == int));
 }
 
 

--- a/std/meta.d
+++ b/std/meta.d
@@ -983,9 +983,13 @@ unittest
 {
     enum abc = 1;
     alias a = Alias!(123);
+    static assert(a == 123);
     alias b = Alias!(abc);
+    static assert(b == 1);
     alias c = Alias!(int);
+    static assert(c.stringof == "(int)");
     alias d = Alias!(1, abc, int);
+    static assert(d[0] == 1 && d[1] == 1 && d[2].stringof == "int");
 }
 
 

--- a/std/meta.d
+++ b/std/meta.d
@@ -982,10 +982,10 @@ template Alias(a...)
 unittest
 {
     enum abc = 1;
-    static assert(__traits(compiles, { alias a = Alias!(123); }));
-    static assert(__traits(compiles, { alias a = Alias!(abc); }));
-    static assert(__traits(compiles, { alias a = Alias!(int); }));
-    static assert(__traits(compiles, { alias a = Alias!(1,abc,int); }));
+    alias a = Alias!(123);
+    alias b = Alias!(abc);
+    alias c = Alias!(int);
+    alias d = Alias!(1, abc, int);
 }
 
 

--- a/std/path.d
+++ b/std/path.d
@@ -1554,9 +1554,9 @@ auto chainPath(Ranges...)(auto ref Ranges ranges)
 
 unittest
 {
-    chainPath(TestAliasedString(null), TestAliasedString(null), TestAliasedString(null));
-    chainPath(TestAliasedString(null), TestAliasedString(null), "");
-    chainPath(TestAliasedString(null), "", TestAliasedString(null));
+    assert(chainPath(TestAliasedString(null), TestAliasedString(null), TestAliasedString(null)).empty);
+    assert(chainPath(TestAliasedString(null), TestAliasedString(null), "").empty);
+    assert(chainPath(TestAliasedString(null), "", TestAliasedString(null)).empty);
     static struct S { string s; }
     static assert(!__traits(compiles, chainPath(TestAliasedString(null), S(""), TestAliasedString(null))));
 }

--- a/std/path.d
+++ b/std/path.d
@@ -1555,9 +1555,8 @@ auto chainPath(Ranges...)(auto ref Ranges ranges)
 unittest
 {
     chainPath(TestAliasedString(null), TestAliasedString(null), TestAliasedString(null));
-    static assert(__traits(compiles, chainPath(TestAliasedString(null), TestAliasedString(null), TestAliasedString(null))));
-    static assert(__traits(compiles, chainPath(TestAliasedString(null), TestAliasedString(null), "")));
-    static assert(__traits(compiles, chainPath(TestAliasedString(null), "", TestAliasedString(null))));
+    chainPath(TestAliasedString(null), TestAliasedString(null), "");
+    chainPath(TestAliasedString(null), "", TestAliasedString(null));
     static struct S { string s; }
     static assert(!__traits(compiles, chainPath(TestAliasedString(null), S(""), TestAliasedString(null))));
 }
@@ -2903,11 +2902,11 @@ unittest
         assert (asRelativePath(TestAliasedString("foo"), TestAliasedString("/bar")).array == "foo");
     else version (Windows)
         assert (asRelativePath(TestAliasedString("foo"), TestAliasedString(`c:\bar`)).array == "foo");
-    static assert(__traits(compiles, asRelativePath(TestAliasedString(null), "")));
-    static assert(__traits(compiles, asRelativePath("", TestAliasedString(null))));
-    static assert(__traits(compiles, asRelativePath(TestAliasedString(null), TestAliasedString(null))));
+    assert(asRelativePath(TestAliasedString("foo"), "bar").array == "foo");
+    assert(asRelativePath("foo", TestAliasedString("bar")).array == "foo");
+    assert(asRelativePath(TestAliasedString("foo"), TestAliasedString("bar")).array == "foo");
     import std.utf : byDchar;
-    static assert(__traits(compiles, asRelativePath(""d.byDchar, TestAliasedString(null))));
+    assert(asRelativePath("foo"d.byDchar, TestAliasedString("bar")).array == "foo");
 }
 
 unittest

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -3944,8 +3944,8 @@ pure unittest
     import std.exception : assertThrown;
 
     static struct S { @disable this(); }
-    zip((S[5]).init[]);
-    auto z = zip(StoppingPolicy.longest, cast(S[]) null, new int[1]);
+    assert(zip((S[5]).init[]).length == 5);
+    assert(zip(StoppingPolicy.longest, cast(S[]) null, new int[1]).length == 1);
     assertThrown(zip(StoppingPolicy.longest, cast(S[]) null, new int[1]).front);
 }
 
@@ -4212,10 +4212,6 @@ unittest
     static assert(!__traits(compiles, {
         foreach (ref a, ref b; lockstep(r1, r2)) { a++; }
     }));
-    foreach (a, ref b; lockstep(r1, r2))
-    {
-        a++;
-    }
 }
 
 /**

--- a/std/range/package.d
+++ b/std/range/package.d
@@ -3871,8 +3871,8 @@ unittest
     }
 
     // BUG 8900
-    static assert(__traits(compiles, zip([1, 2], repeat('a'))));
-    static assert(__traits(compiles, zip(repeat('a'), [1, 2])));
+    assert(zip([1, 2], repeat('a')).array == [tuple(1, 'a'), tuple(2, 'a')]);
+    assert(zip(repeat('a'), [1, 2]).array == [tuple('a', 1), tuple('a', 2)]);
 
     // Doesn't work yet.  Issues w/ emplace.
     // static assert(is(Zip!(immutable int[], immutable float[])));
@@ -3944,7 +3944,7 @@ pure unittest
     import std.exception : assertThrown;
 
     static struct S { @disable this(); }
-    static assert(__traits(compiles, zip((S[5]).init[])));
+    zip((S[5]).init[]);
     auto z = zip(StoppingPolicy.longest, cast(S[]) null, new int[1]);
     assertThrown(zip(StoppingPolicy.longest, cast(S[]) null, new int[1]).front);
 }
@@ -4212,9 +4212,10 @@ unittest
     static assert(!__traits(compiles, {
         foreach (ref a, ref b; lockstep(r1, r2)) { a++; }
     }));
-    static assert(__traits(compiles, {
-        foreach (a, ref b; lockstep(r1, r2)) { a++; }
-    }));
+    foreach (a, ref b; lockstep(r1, r2))
+    {
+        a++;
+    }
 }
 
 /**

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -444,14 +444,14 @@ unittest
 {
     int[] a = new int[10];
     static assert(!__traits(compiles, put(a, 1.0L)));
-    static assert( __traits(compiles, put(a, 1)));
+    put(a, 1);
     /*
      * a[0] = 65;       // OK
      * a[0] = 'A';      // OK
      * a[0] = "ABC"[0]; // OK
      * put(a, "ABC");   // OK
      */
-    static assert( __traits(compiles, put(a, "ABC")));
+    put(a, "ABC");
 }
 
 unittest
@@ -466,11 +466,11 @@ unittest
 
 unittest
 {
-    int[][] a;
-    int[]   b;
+    int[][] a = new int[][10];
+    int[]   b = new int[10];
     int     c;
-    static assert( __traits(compiles, put(b, c)));
-    static assert( __traits(compiles, put(a, b)));
+    put(b, c);
+    put(a, b);
     static assert(!__traits(compiles, put(a, c)));
 }
 

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -445,6 +445,7 @@ unittest
     int[] a = new int[10];
     static assert(!__traits(compiles, put(a, 1.0L)));
     put(a, 1);
+    assert(a.length == 9);
     /*
      * a[0] = 65;       // OK
      * a[0] = 'A';      // OK
@@ -452,6 +453,7 @@ unittest
      * put(a, "ABC");   // OK
      */
     put(a, "ABC");
+    assert(a.length == 6);
 }
 
 unittest
@@ -470,7 +472,9 @@ unittest
     int[]   b = new int[10];
     int     c;
     put(b, c);
+    assert(b.length == 9);
     put(a, b);
+    assert(a.length == 9);
     static assert(!__traits(compiles, put(a, c)));
 }
 

--- a/std/traits.d
+++ b/std/traits.d
@@ -979,7 +979,7 @@ unittest {
     void bar(uint){}
     static assert(arity!bar==1);
     void variadicFoo(uint...){}
-    static assert(__traits(compiles,arity!variadicFoo)==false);
+    static assert(!__traits(compiles, arity!variadicFoo));
 }
 
 /**

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1161,8 +1161,7 @@ unittest
         foreach (v1; AliasSeq!(mv, cv, iv, wv, wcv))
         foreach (v2; AliasSeq!(mv, cv, iv, wv, wcv))
         {
-            static assert(__traits(compiles, v1 < v2),
-                          typeof(v1).stringof ~ " < " ~ typeof(v2).stringof);
+            cast(void) (v1 < v2);
         }
     }
     {
@@ -2176,10 +2175,10 @@ unittest
     {
         auto sm = S1(1);
         immutable si = immutable S1(1);
-        static assert( __traits(compiles, { auto x1 =           Nullable!S1(sm); }));
-        static assert( __traits(compiles, { auto x2 = immutable Nullable!S1(sm); }));
-        static assert( __traits(compiles, { auto x3 =           Nullable!S1(si); }));
-        static assert( __traits(compiles, { auto x4 = immutable Nullable!S1(si); }));
+        auto x1 =           Nullable!S1(sm);
+        auto x2 = immutable Nullable!S1(sm);
+        auto x3 =           Nullable!S1(si);
+        auto x4 = immutable Nullable!S1(si);
     }
 
     auto nm = 10;
@@ -2188,19 +2187,19 @@ unittest
     {
         auto sm = S2(&nm);
         immutable si = immutable S2(&ni);
-        static assert( __traits(compiles, { auto x =           Nullable!S2(sm); }));
-        static assert(!__traits(compiles, { auto x = immutable Nullable!S2(sm); }));
-        static assert(!__traits(compiles, { auto x =           Nullable!S2(si); }));
-        static assert( __traits(compiles, { auto x = immutable Nullable!S2(si); }));
+        auto x1 =           Nullable!S2(sm);
+        static assert(!__traits(compiles, { auto x2 = immutable Nullable!S2(sm); }));
+        static assert(!__traits(compiles, { auto x3 =           Nullable!S2(si); }));
+        auto x4 = immutable Nullable!S2(si);
     }
 
     {
         auto sm = S3(&ni);
         immutable si = immutable S3(&ni);
-        static assert( __traits(compiles, { auto x =           Nullable!S3(sm); }));
-        static assert( __traits(compiles, { auto x = immutable Nullable!S3(sm); }));
-        static assert( __traits(compiles, { auto x =           Nullable!S3(si); }));
-        static assert( __traits(compiles, { auto x = immutable Nullable!S3(si); }));
+        auto x1 =           Nullable!S3(sm);
+        auto x2 = immutable Nullable!S3(sm);
+        auto x3 =           Nullable!S3(si);
+        auto x4 = immutable Nullable!S3(si);
     }
 }
 unittest
@@ -6553,7 +6552,7 @@ public:
         B = 1<<1,
         C = 1<<2
     }
-    static assert(__traits(compiles, BitFlags!Enum));
+    BitFlags!Enum flags1;
 
     // You need to specify the $(D unsafe) parameter for enum with custom values
     enum UnsafeEnum
@@ -6563,8 +6562,8 @@ public:
         C,
         D = B|C
     }
-    static assert(!__traits(compiles, BitFlags!UnsafeEnum));
-    static assert(__traits(compiles, BitFlags!(UnsafeEnum, Yes.unsafe)));
+    static assert(!__traits(compiles, { BitFlags!UnsafeEnum flags2; }));
+    BitFlags!(UnsafeEnum, Yes.unsafe) flags3;
 
     immutable BitFlags!Enum flags_empty;
     // A default constructed BitFlags has no value set

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1161,7 +1161,7 @@ unittest
         foreach (v1; AliasSeq!(mv, cv, iv, wv, wcv))
         foreach (v2; AliasSeq!(mv, cv, iv, wv, wcv))
         {
-            cast(void) (v1 < v2);
+            assert(!(v1 < v2));
         }
     }
     {
@@ -2179,6 +2179,10 @@ unittest
         auto x2 = immutable Nullable!S1(sm);
         auto x3 =           Nullable!S1(si);
         auto x4 = immutable Nullable!S1(si);
+        assert(x1.val == 1);
+        assert(x2.val == 1);
+        assert(x3.val == 1);
+        assert(x4.val == 1);
     }
 
     auto nm = 10;
@@ -2191,6 +2195,8 @@ unittest
         static assert(!__traits(compiles, { auto x2 = immutable Nullable!S2(sm); }));
         static assert(!__traits(compiles, { auto x3 =           Nullable!S2(si); }));
         auto x4 = immutable Nullable!S2(si);
+        assert(*x1.val == 10);
+        assert(*x4.val == 10);
     }
 
     {
@@ -2200,6 +2206,10 @@ unittest
         auto x2 = immutable Nullable!S3(sm);
         auto x3 =           Nullable!S3(si);
         auto x4 = immutable Nullable!S3(si);
+        assert(*x1.val == 10);
+        assert(*x2.val == 10);
+        assert(*x3.val == 10);
+        assert(*x4.val == 10);
     }
 }
 unittest
@@ -6553,6 +6563,7 @@ public:
         C = 1<<2
     }
     BitFlags!Enum flags1;
+    assert(!(flags1 & (Enum.A | Enum.B | Enum.C)));
 
     // You need to specify the $(D unsafe) parameter for enum with custom values
     enum UnsafeEnum

--- a/std/utf.d
+++ b/std/utf.d
@@ -2983,7 +2983,7 @@ const(wchar)* toUTF16z(C)(const(C)[] str) @safe pure
     //toUTFz is already thoroughly tested, so this will just verify that
     //toUTF16z compiles properly for the various string types.
     foreach (S; AliasSeq!(string, wstring, dstring))
-        static assert(__traits(compiles, toUTF16z(to!S("hello world"))));
+        assert(toUTF16z(to!S("hello world")) !is null);
 }
 
 


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=15320

There are still some occurrences remaining:
* 12 in `std/concurency.d`: `spawn`s create threads
* 3 in `std/conv.d`: couldn't figure it out
* 1 in `std/exception.d`: must stay, `__traits(compiles` is called in a loop with different checked results
* 24 in `std/file.d`: file operations
* 3 in `std/numeric.d`: don't know if it can/should be replaced
* 2 in `std/traits.d`: don't know how

The regex used for searching: `static\s+assert\s*\(\s*__traits\s*\(\s*compiles`