### PR TITLE
[Issue 15305] bitfields! setter erroneously clears subsequent fields

### DIFF
--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -88,7 +88,7 @@ private template createAccessors(
             // setter
                 ~"@property void " ~ name ~ "(bool v) @safe pure nothrow @nogc { "
                 ~"if (v) "~store~" |= "~myToString(maskAllElse)~";"
-                ~"else "~store~" &= ~"~myToString(maskAllElse)~";}\n";
+                ~"else "~store~" &= ~cast(typeof("~store~"))"~myToString(maskAllElse)~";}\n";
         }
         else
         {
@@ -694,6 +694,22 @@ unittest
                   bool, "y", 1,
                   ubyte, "z", 5));
     }
+}
+
+unittest
+{
+    // Issue #15305
+    struct S {
+            mixin(bitfields!(
+                    bool, "alice", 1,
+                    ulong, "bob", 63,
+            ));
+    }
+
+    S s;
+    s.bob = long.max - 1;
+    s.alice = false;
+    assert(s.bob == long.max - 1);
 }
 
 /**


### PR DESCRIPTION
```d
@property void alice(bool v) @safe pure nothrow @nogc { if (v) _alice_bob |= 1U;else _alice_bob &= ~1U;}
```

This getter is wrong because the `&=~1U` would clear not just the first bit, but bits 32-64 as well. This in turn because of the code in `myToString`, which picks the smallest type suffix, `U` in this case.

Fixed by casting the `1U` to the type of the storage, before negating.