### PR TITLE
Allow getSymbolsByUDA if type has private members.

### DIFF
--- a/std/internal/test/uda.d
+++ b/std/internal/test/uda.d
@@ -1,0 +1,15 @@
+/**
+For testing only.
+Provides a struct with UDA's defined in an external module.
+Useful for validating behavior with member privacy.
+*/
+
+enum Attr;
+
+struct HasPrivateMembers
+{
+  @Attr int a;
+  int b;
+  @Attr private int c;
+  private int d;
+}

--- a/std/traits.d
+++ b/std/traits.d
@@ -6801,6 +6801,15 @@ unittest
     static assert(getSymbolsByUDA!(C, UDA)[1].stringof == "d");
 }
 
+// #15335: getSymbolsByUDA fail to compile if symbol has private members
+unittest
+{
+  // two members are marked with Attr, but one is private
+  // this should compile but only return the visible member
+  import std.internal.test.uda;
+  static assert(getSymbolsByUDA!(HasPrivateMembers, Attr).length == 1);
+}
+
 /**
    Returns: $(D true) iff all types $(D T) are the same.
 */

--- a/std/traits.d
+++ b/std/traits.d
@@ -6726,6 +6726,7 @@ unittest
  * Gets all symbols within `symbol` that have the given user-defined attribute.
  * This is not recursive; it will not search for symbols within symbols such as
  * nested structs or unions.
+ * Only searches public members.
  */
 template getSymbolsByUDA(alias symbol, alias attribute)
 {
@@ -6733,8 +6734,14 @@ template getSymbolsByUDA(alias symbol, alias attribute)
 
     static enum hasSpecificUDA(alias S) = hasUDA!(S, attribute);
     alias StringToSymbol(alias Name) = Identity!(__traits(getMember, symbol, Name));
+
+    // filter out members that are inacessible to due to privacy
+    enum isAccessible(alias Name) =
+        __traits(compiles, __traits(getMember, symbol, Name));
+    alias accessibleSymbols = Filter!(isAccessible, __traits(allMembers, symbol));
+
     alias getSymbolsByUDA = Filter!(hasSpecificUDA, TypeTuple!(symbol,
-        staticMap!(StringToSymbol, __traits(allMembers, symbol))));
+        staticMap!(StringToSymbol, accessibleSymbols)));
 }
 
 ///


### PR DESCRIPTION
Previously, getSymbolsByUDA would fail if given a type that had _any_
private members (even if they weren't marked with an attribute).
This patch prevents getSymbolsByUDA from checking inaccesible members.
This means private symbols with the desired UDA will not be included.
Resolves #15335.

I'm actually not sure if this is the way to go. On one hand, its nice to not totally fail just because some unrelated member is private. On the other hand, having private members silently excluded might be more suprising than a compilation failure.

Thoughts?