### PR TITLE
Adjust expected result of test to match ARM and others

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -2230,7 +2230,7 @@ unittest
             [ 0x1p+80L,      real.infinity            ], // far overflow
             [ real.infinity, real.infinity            ],
             [-0x1.6p+9L,     0x1.44a3824e5285fp-1016L ], // near underflow
-            [-0x1.64p+9L,    0x0.06f84920bb2d3p-1022L ], // near underflow - subnormal
+            [-0x1.64p+9L,    0x0.06f84920bb2d4p-1022L ], // near underflow - subnormal
             [-0x1.743p+9L,   0x0.0000000000001p-1022L ], // ditto
             [-0x1.8p+9L,     0                        ], // close underflow
             [-0x1p30L,       0                        ], // far underflow


### PR DESCRIPTION
From the conversation and comparing of results in #3483 - the following was found for the result of ``exp(-0x1.64p+9L)``:

Win64 | ARM | ARM libm (expl) | x86 (double) | x86 libm (exp) | LLVM intrinsic | GCC intrinsic
----- | ----- | ----- | ----- | ----- | ----- | ----- 
0x0.06f84920bb2d3p-1022 | 0x0.06f84920bb2d4p-1022 | 0x0.06f84920bb2d4p-1022 | 0x0.06f84920bb2d4p-1022 | 0x0.06f84920bb2d4p-1022 | 0x0.06f84920bb2d4p-1022 | 0x0.06f84920bb2d4p-1022 

With feqrel giving the following number of mantissa bits in common (53 means identical to ``0x0.06f84920bb2d3p-1022L``).

Win64 | ARM | ARM libm (expl) | x86 (double) | x86 libm (exp) | LLVM intrinsic | GCC intrinsic
----- | ----- | ----- | ----- | ----- | ----- | ----- 
53 | 51 | 51 | 51* | 51* | 51 | 36*

[*] UPDATE: Whoops, I forgot to set rounding mode as per unittest.  These are now correct, except for the GCC intrinsic, which const-folded the result.  :-)

Changing the test to the mode result returned yields (53 means identical to ``0x0.06f84920bb2d4p-1022L``

Win64 | ARM | ARM libm (expl) | x86 (double) | x86 libm (exp) | LLVM intrinsic | GCC intrinsic
----- | ----- | ----- | ----- | ----- | ----- | ----- 
51 | 53 | 53 | 53 | 53 | 53 | 53

So Win64 is the odd one out (but we are not sure why) and the rest produce the exact same result.