### PR TITLE
Add reference to std.path

### DIFF
--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1930,11 +1930,11 @@ unittest
 
 // schwartzSort
 /**
+Returns the same output as an equivalent call to $(D sort), but it will be faster when the sort comparison requires an expensive computation. $(D schwartzSort) allocates a temporary array to cache the sort keys. It can therefore be slower than $(D sort) in other cases.
+
 Sorts a range using an algorithm akin to the $(WEB
 wikipedia.org/wiki/Schwartzian_transform, Schwartzian transform), also
-known as the decorate-sort-undecorate pattern in Python and Lisp.
-This function is helpful when the sort comparison includes
-an expensive computation. The complexity is the same as that of the
+known as the decorate-sort-undecorate pattern in Python and Lisp. The complexity is the same as that of the
 corresponding $(D sort), but $(D schwartzSort) evaluates $(D
 transform) only $(D r.length) times (less than half when compared to
 regular sorting). The usage can be best illustrated with an example.

--- a/std/file.d
+++ b/std/file.d
@@ -3,14 +3,13 @@
 /**
 Utilities for manipulating files and scanning directories. Functions
 in this module handle files as a unit, e.g., read or write one _file
-at a time. For opening files and manipulating them via handles refer
-to module $(LINK2 std_stdio.html,$(D std.stdio)).
+at a time.
 
 Macros:
 WIKI = Phobos/StdFile
 
 Copyright: Copyright Digital Mars 2007 - 2011.
-See_Also:  The $(WEB ddili.org/ders/d.en/files.html, official tutorial) for an introduction to working with files in D.
+See_Also:  The $(WEB ddili.org/ders/d.en/files.html, official tutorial) for an introduction to working with files in D, module $(LINK2 std_stdio.html,$(D std.stdio)) for opening files and manipulating them via handles, and module $(LINK2 std_path.html,$(D std.path)) for manipulating path strings.
 License:   $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   $(WEB digitalmars.com, Walter Bright),
            $(WEB erdani.org, Andrei Alexandrescu),


### PR DESCRIPTION
- Add std.path to the See Also section, because it is relevant to users of std.file.
- Move reference to std.stdio to the See Also section.