### PR TITLE
Enable getSymbolsByUDA to retrieve private members.

### DIFF
--- a/std/internal/test/uda.d
+++ b/std/internal/test/uda.d
@@ -1,0 +1,16 @@
+/**
+For testing only.
+Provides a struct with UDA's defined in an external module.
+Useful for validating behavior with member privacy.
+*/
+module std.internal.test.uda;
+
+enum Attr;
+
+struct HasPrivateMembers
+{
+  @Attr int a;
+  int b;
+  @Attr private int c;
+  private int d;
+}


### PR DESCRIPTION
Resolves #15335: getSymbolsByUDA fails if type has private members.
Generous (ab)use of mixins allows getSymbolsByUDA to reference symbols
without trying to access them, allowing it to inspect private members
without failing.

Testing this required private symbols defined outside of std.traits.
This adds std.internal.test.uda, which defines a struct containing
private members that is used in a unittest added to std.traits.

My previous implementation, #3817, simply ignored private members.