### PR TITLE
Add reference to std.path

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -10,7 +10,11 @@ Macros:
 WIKI = Phobos/StdFile
 
 Copyright: Copyright Digital Mars 2007 - 2011.
-See_Also:  The $(WEB ddili.org/ders/d.en/files.html, official tutorial) for an introduction to working with files in D.
+See_Also:  The $(WEB ddili.org/ders/d.en/files.html, official tutorial) for an 
+introduction to working with files in D, module 
+$(LINK2 std_stdio.html,$(D std.stdio)) for opening files and manipulating them 
+via handles, and module $(LINK2 std_path.html,$(D std.path)) for manipulating 
+path strings.
 License:   $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   $(WEB digitalmars.com, Walter Bright),
            $(WEB erdani.org, Andrei Alexandrescu),


### PR DESCRIPTION
Add std.path to the See Also section, because it is relevant to users of std.file.

This replaces my earlier [3826](https://github.com/D-Programming-Language/phobos/pull/3826). I did not change the top paragraph, as requested in the previous PR.