### PR TITLE
PR "Tuple's toString made useful" once again.

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -291,6 +291,18 @@ unittest
     assert(!uf2.isEmpty);
 }
 
+// Used in Tuple.toString
+private template sharedToString(alias field)
+    if(is(typeof(field) == shared))
+{
+    static immutable sharedToString = typeof(field).stringof;
+}
+
+private template sharedToString(alias field)
+    if(!is(typeof(field) == shared))
+{
+    alias sharedToString = field;
+}
 
 /**
 Tuple of values, for example $(D Tuple!(int, string)) is a record that
@@ -759,43 +771,136 @@ template Tuple(Specs...)
             return h;
         }
 
-        void toString(DG)(scope DG sink)
+        ///
+        template toString()
         {
-            enum header = typeof(this).stringof ~ "(",
-                 footer = ")",
-                 separator = ", ";
-            sink(header);
-            foreach (i, Type; Types)
+            /**
+             * Converts to string.
+             *
+             * Returns:
+             *     The string representation of this `Tuple`.
+             */
+            string toString()() const
             {
-                static if (i > 0)
+                import std.array : appender;
+                auto app = appender!string();
+                this.toString((const(char)[] chunk) => app ~= chunk);
+                return app.data;
+            }
+
+            import std.format : FormatSpec;
+
+            /**
+             * Formats `Tuple` with either `%s`, `%(inner%)` or `%(inner%|sep%)`.
+             *
+             * $(TABLE2 Formats supported by Tuple,
+             * $(THEAD Format, Description)
+             * $(TROW $(P `%s`), $(P Format like `Tuple!(types)(elements formatted with %s each)`.))
+             * $(TROW $(P `%(inner%)`), $(P The format `inner` is applied the expanded `Tuple`, so
+             *      it may contain as many formats as the `Tuple` has fields.))
+             * $(TROW $(P `%(inner%|sep%)`), $(P The format `inner` is one format, that is applied
+             *      on all fields of the `Tuple`. The inner format must be compatible to all
+             *      of them.)))
+             * ---
+             *  Tuple!(int, double)[3] tupList = [ tuple(1, 1.0), tuple(2, 4.0), tuple(3, 9.0) ];
+             *
+             *  // Default format
+             *  assert(format("%s", tuple("a", 1)) == `Tuple!(string, int)("a", 1)`);
+             *
+             *  // One Format for each individual component
+             *  assert(format("%(%#x v %.4f w %#x%)", tuple(1, 1.0, 10))         == `0x1 v 1.0000 w 0xa`);
+             *  assert(format(  "%#x v %.4f w %#x"  , tuple(1, 1.0, 10).expand)  == `0x1 v 1.0000 w 0xa`);
+             *
+             *  // One Format for all components
+             *  assert(format("%(>%s<%| & %)", tuple("abc", 1, 2.3, [4, 5])) == `>abc< & >1< & >2.3< & >[4, 5]<`);
+             *
+             *  // Array of Tuples
+             *  assert(format("%(%(f(%d) = %.1f%);  %)", tupList) == `f(1) = 1.0;  f(2) = 4.0;  f(3) = 9.0`);
+             *
+             *
+             *  // Error: %( %) missing.
+             *  assertThrown!FormatException(
+             *      format("%d, %f", tuple(1, 2.0)) == `1, 2.0`
+             *  );
+             *
+             *  // Error: %( %| %) missing.
+             *  assertThrown!FormatException(
+             *      format("%d", tuple(1, 2)) == `1, 2`
+             *  );
+             *
+             *  // Error: %d inadequate for double.
+             *  assertThrown!FormatException(
+             *      format("%(%d%|, %)", tuple(1, 2.0)) == `1, 2.0`
+             *  );
+             * ---
+             */
+            void toString(DG)(scope DG sink) const
+            {
+                toString(sink, FormatSpec!char());
+            }
+
+            /// ditto
+            void toString(DG, Char)(scope DG sink, FormatSpec!Char fmt) const
+            {
+                import std.format : formatElement, formattedWrite, FormatException;
+                if (fmt.nested)
                 {
-                    sink(separator);
+                    if (fmt.sep)
+                    {
+                        foreach (i, Type; Types)
+                        {
+                            static if (i > 0)
+                            {
+                                sink(fmt.sep);
+                            }
+                            // TODO: Change this once formattedWrite() works for shared objects.
+                            static if (is(Type == class) && is(Type == shared))
+                            {
+                                sink(Type.stringof);
+                            }
+                            else
+                            {
+                                formattedWrite(sink, fmt.nested, this.field[i]);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        formattedWrite(sink, fmt.nested, staticMap!(sharedToString, this.expand));
+                    }
                 }
-                // TODO: Change this once toString() works for shared objects.
-                static if (is(Type == class) && is(typeof(Type.init) == shared))
+                else if (fmt.spec == 's')
                 {
-                    sink(Type.stringof);
+                    enum header = Unqual!(typeof(this)).stringof ~ "(",
+                         footer = ")",
+                         separator = ", ";
+                    sink(header);
+                    foreach (i, Type; Types)
+                    {
+                        static if (i > 0)
+                        {
+                            sink(separator);
+                        }
+                        // TODO: Change this once formatElement() works for shared objects.
+                        static if (is(Type == class) && is(Type == shared))
+                        {
+                            sink(Type.stringof);
+                        }
+                        else
+                        {
+                            FormatSpec!Char f;
+                            formatElement(sink, field[i], f);
+                        }
+                    }
+                    sink(footer);
                 }
                 else
                 {
-                    import std.format : FormatSpec, formatElement;
-                    FormatSpec!char f;
-                    formatElement(sink, field[i], f);
+                    throw new FormatException(
+                        "Expected '%s' or '%(...%)' or '%(...%|...%)' format specifier for type '" ~
+                            Unqual!(typeof(this)).stringof ~ "', not '%" ~ fmt.spec ~ "'.");
                 }
             }
-            sink(footer);
-        }
-
-        /**
-         * Converts to string.
-         *
-         * Returns:
-         *     The string representation of this `Tuple`.
-         */
-        string toString()()
-        {
-            import std.conv : to;
-            return this.to!string;
         }
     }
 }
@@ -1293,6 +1398,46 @@ unittest
     alias T = Tuple!(string, "s");
     T x;
     x = T.init;
+}
+
+@safe unittest
+{
+    import std.format : format, FormatException;
+    import std.exception : assertThrown;
+
+    // enum tupStr = tuple(1, 1.0).toString; // toString is *impure*.
+    //static assert (tupStr == `Tuple!(int, double)(1, 1)`);
+
+    Tuple!(int, double)[3] tupList = [ tuple(1, 1.0), tuple(2, 4.0), tuple(3, 9.0) ];
+
+    // Default format
+    assert(format("%s", tuple("a", 1)) == `Tuple!(string, int)("a", 1)`);
+
+    // One Format for each individual component
+    assert(format("%(%#x v %.4f w %#x%)", tuple(1, 1.0, 10))         == `0x1 v 1.0000 w 0xa`);
+    assert(format(  "%#x v %.4f w %#x"  , tuple(1, 1.0, 10).expand)  == `0x1 v 1.0000 w 0xa`);
+
+    // One Format for all components
+    assert(format("%(>%s<%| & %)", tuple("abc", 1, 2.3, [4, 5])) == `>abc< & >1< & >2.3< & >[4, 5]<`);
+
+    // Array of Tuples
+    assert(format("%(%(f(%d) = %.1f%);  %)", tupList) == `f(1) = 1.0;  f(2) = 4.0;  f(3) = 9.0`);
+
+
+    // Error: %( %) missing.
+    assertThrown!FormatException(
+        format("%d, %f", tuple(1, 2.0)) == `1, 2.0`
+    );
+
+    // Error: %( %| %) missing.
+    assertThrown!FormatException(
+        format("%d", tuple(1, 2)) == `1, 2`
+    );
+
+    // Error: %d inadequate for double
+    assertThrown!FormatException(
+        format("%(%d%|, %)", tuple(1, 2.0)) == `1, 2.0`
+    );
 }
 
 /**


### PR DESCRIPTION
For the conversation and reasons for the reopening see [here](github.com/D-Programming-Language/phobos/pull/3594). In a nutshell, I did a wrong rebase.

From [Forum: Make Tuple.toString useful](http://forum.dlang.org/thread/srofuqyrdzphgzylbwds@forum.dlang.org):
With this, you can easily format a `Tuple` from its content, similar how to do with an array.
The `toString(delegate, FormatSpec)` function takes the formats `%(nested%)` and `%(nested%|separator%)` a bit different: The second one treats the Tuple as it was an array. The first one applies the nested format to the expanded fields, like `format(nested, tup.expand)` did.
With this, the forum question [Formatted output of range of tuples](http://forum.dlang.org/post/ntqawkupddjcijwtwovp@forum.dlang.org) gets a trivial answer: Use `"%(%(%s%| %)\n%)"` instead of `"%(%(%s %)\n%)"`.
It can be expected not to break any existing code.
(This is more or less the old message.)