### PR TITLE
std.file whitespace fix

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -10,10 +10,10 @@ Macros:
 WIKI = Phobos/StdFile
 
 Copyright: Copyright Digital Mars 2007 - 2011.
-See_Also:  The $(WEB ddili.org/ders/d.en/files.html, official tutorial) for an 
-introduction to working with files in D, module 
-$(LINK2 std_stdio.html,$(D std.stdio)) for opening files and manipulating them 
-via handles, and module $(LINK2 std_path.html,$(D std.path)) for manipulating 
+See_Also:  The $(WEB ddili.org/ders/d.en/files.html, official tutorial) for an
+introduction to working with files in D, module
+$(LINK2 std_stdio.html,$(D std.stdio)) for opening files and manipulating them
+via handles, and module $(LINK2 std_path.html,$(D std.path)) for manipulating
 path strings.
 License:   $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors:   $(WEB digitalmars.com, Walter Bright),


### PR DESCRIPTION
I merged a comment only PR that added a litte bit of doc.
It containted whitespace at the end.

This PR removes that whitespace.