### PR TITLE
use DDLINK/DDSUBLINK instead of LINK2 and raw HTML

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -3915,14 +3915,14 @@ $(LI In all other cases, a simple element by element addition is done.)
 )
 
 For floating point inputs, calculations are made in
-$(LINK2 ../spec/type.html, $(D real))
+$(DDLINK spec/type, Types, $(D real))
 precision for $(D real) inputs and in $(D double) precision otherwise
 (Note this is a special case that deviates from $(D reduce)'s behavior,
 which would have kept $(D float) precision for a $(D float) range).
 For all other types, the calculations are done in the same type obtained
 from from adding two elements of the range, which may be a different
 type from the elements themselves (for example, in case of
-$(LINK2 ../spec/type.html#integer-promotions, integral promotion)).
+$(DDSUBLINK spec/type,integer-promotions, integral promotion)).
 
 A seed may be passed to $(D sum). Not only will this seed be used as an initial
 value, but its type will override all the above, and determine the algorithm

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -265,7 +265,8 @@ Following arguments works the same way as $(D bitfield)'s. The bitfield must fit
 bits known to be zero because of the pointer alignment.
 
 $(RED Warning: Don't use $(D taggedPointer) with pointers to garbage collected objects, as it will result in
-undefined behaviour. See $(LINK ../spec/garbage.html) for details.)
+undefined behaviour. See
+$(DDLINK spec/garbage, Garbage Collection, Garbage Collection) for details.)
 */
 
 template taggedPointer(T : T*, string name, Ts...) {
@@ -300,7 +301,8 @@ The example above creates a tagged reference to an Object in the struct A. This 
 as $(D taggedPointer), except the first argument which must be a class type instead of a pointer type.
 
 $(RED Warning: Don't use $(D taggedClassRef) with references to garbage collected objects, as it will result in
-undefined behaviour. See $(LINK ../spec/garbage.html) for details.)
+undefined behaviour. See
+$(DDLINK spec/garbage, Garbage Collection, Garbage Collection) for details.)
 */
 
 template taggedClassRef(T, string name, Ts...) if(is(T == class)) {

--- a/std/complex.d
+++ b/std/complex.d
@@ -3,7 +3,8 @@
 /** This module contains the $(LREF Complex) type, which is used to represent
     _complex numbers, along with related mathematical operations and functions.
 
-    $(LREF Complex) will eventually $(LINK2 ../deprecate.html, replace)
+    $(LREF Complex) will eventually
+    $(DDLINK deprecate, Deprecated Features, replace)
     the built-in types $(D cfloat), $(D cdouble), $(D creal), $(D ifloat),
     $(D idouble), and $(D ireal).
 

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -89,7 +89,8 @@ auto restoredTime = SysTime.fromISOExtString(timeString);
         $(LREF DateTimeException)).
 
     See_Also:
-        <a href="../intro-to-datetime.html">Introduction to std&#46;_datetime </a><br>
+        $(DDLINK intro-to-_datetime, Introduction to std.datetime,
+                 Introduction to std&#46;_datetime)<br>
         $(WEB en.wikipedia.org/wiki/ISO_8601, ISO 8601)<br>
         $(WEB en.wikipedia.org/wiki/Tz_database,
               Wikipedia entry on TZ Database)<br>

--- a/std/system.d
+++ b/std/system.d
@@ -25,7 +25,7 @@ immutable
             $(D version(linux)), etc.
 
         See_Also:
-            $(LINK2 ../spec/version.html#PredefinedVersions, Predefined Versions)
+            $(DDSUBLINK spec/version,PredefinedVersions, Predefined Versions)
       +/
     enum OS
     {
@@ -60,7 +60,7 @@ immutable
             $(D version(LittleEndian)).
 
         See_Also:
-            $(LINK2 ../spec/version.html#PredefinedVersions, Predefined Versions)
+            $(DDSUBLINK spec/version,PredefinedVersions, Predefined Versions)
       +/
     enum Endian
     {

--- a/std/traits.d
+++ b/std/traits.d
@@ -6599,7 +6599,7 @@ unittest
 
 /**
  * Determine if a symbol has a given
- * $(LINK2 ../spec/attribute.html#uda, user-defined attribute).
+ * $(DDSUBLINK spec/attribute,uda, user-defined attribute).
  */
 template hasUDA(alias symbol, alias attribute)
 {
@@ -6666,7 +6666,7 @@ unittest
 }
 
 /**
- * Gets the $(LINK2 ../spec/attribute.html#uda, user-defined attributes) of the
+ * Gets the $(DDSUBLINK spec/attribute,uda, user-defined attributes) of the
  * given type from the given symbol.
  */
 template getUDAs(alias symbol, alias attribute)

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -5209,7 +5209,7 @@ unittest
 
 /**
     There is one exception to the fact that the new type is not related to the
-    old type. $(LINK2 ../spec/function.html#pseudo-member, Pseudo-member)
+    old type. $(DDSUBLINK spec/function,pseudo-member, Pseudo-member)
     functions are usable with the new type; they will be forwarded on to the
     proxied value.
  */


### PR DESCRIPTION
DDLINK/DDSUBLINK use ROOT_DIR which is more robust than a relative path.

Together with https://github.com/D-Programming-Language/dlang.org/pull/1159 this fixes the links in the online DDox docs.