### PR TITLE
fix issue 14804 - Comparing two Nullables does not check if either is null

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1922,14 +1922,14 @@ Returns:
     }
 
 /**
-Forwads $(D T) opEquals to handle the null state.
+Forwards $(D T) opEquals to handle the null state.
 
 Returns:
     $(D true) if two nullables are in null state,
     $(D false) if two nullables have a different null state,
     the values comparison result otherwise.
 */
-    bool opEquals(R)(R rhs)
+    bool opEquals(R)(R rhs) const
     if(is(R == typeof(this)) || is(R : T))
     {
         static if (is(R == typeof(this)))

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -1921,19 +1921,32 @@ Returns:
         return _value;
     }
 
-///
-unittest
-{
-    import std.exception: assertThrown, assertNotThrown;
+/**
+Forwads $(D T) opEquals to handle the null state.
 
-    Nullable!int ni;
-    //`get` is implicitly called. Will throw
-    //an AssertError in non-release mode
-    assertThrown!Throwable(ni == 0);
-
-    ni = 0;
-    assertNotThrown!Throwable(ni == 0);
-}
+Returns:
+    $(D true) if two nullables are in null state,
+    $(D false) if two nullables have a different null state,
+    the values comparison result otherwise.
+*/
+    bool opEquals(R)(R rhs)
+    if(is(R == typeof(this)) || is(R : T))
+    {
+        static if (is(R == typeof(this)))
+        {
+            if (rhs.isNull && isNull)
+                return true;
+            else if (rhs.isNull != isNull)
+                return false;
+            else
+                return get() == rhs.get;
+        }
+        else
+        {
+            if (isNull) return false;
+            else return get == rhs;
+        }
+    }
 
 /**
 Implicitly converts to $(D T).
@@ -1972,6 +1985,17 @@ unittest
     {
         //Add the customer to the database
     }
+}
+
+unittest
+{
+    // issue 14804
+	Nullable!int n1 = 0;
+	Nullable!int n2;
+	Nullable!int n3;
+
+	assert(n1 != n2);
+	assert(n2 == n3);
 }
 
 unittest


### PR DESCRIPTION
The problem in the [issue](https://issues.dlang.org/show_bug.cgi?id=14804), is not well exposed since the reporter does not take in account the fact that the assertion failure wion't happen in `-release` mode.

However it's true that comparing an uninitialized nullable with a value or with a another nullable could lead to think that the to arguments are equals, while they're not, because the null state was not handled at all.

with the fix, the following code:
```D
void main()
{
    Nullable!int n1 = 0;
    Nullable!int n2;
    writeln(n1 != n2);
    writeln(n2 != 0);
} 
```

outputs:
>true
true

instead of 

>false
false

currently.

 

