### PR TITLE
Fix Issue 15419 - "@@@BUG@@@ the size of China"

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -1837,15 +1837,19 @@ unittest
     }
 }
 
-/***************************************************************
- * The $(D_PARAM parse) family of functions works quite like the
- * $(D_PARAM to) family, except that (1) it only works with character ranges
- * as input, (2) takes the input by reference and advances it to
- * the position following the conversion, and (3) does not throw if it
- * could not convert the entire input. It still throws if an overflow
- * occurred during conversion or if no character of the input
- * was meaningfully converted.
- */
+/**
+The $(D parse) family of functions works quite like the $(D to)
+family, except that:
+$(OL
+    $(LI It only works with character ranges as input.)
+    $(LI It takes the input by reference. (This means that rvalues - such
+    as string literals - are not accepted: use $(D to) instead.))
+    $(LI It advances the input to the position following the conversion.)
+    $(LI It does not throw if it could not convert the entire input.))
+
+It still throws if an overflow occurred during conversion or if no character
+of the input was meaningfully converted.
+*/
 Target parse(Target, Source)(ref Source s)
     if (isInputRange!Source &&
         isSomeChar!(ElementType!Source) &&

--- a/std/conv.d
+++ b/std/conv.d
@@ -2267,36 +2267,20 @@ Lerr:
 
 @safe pure unittest
 {
-    // @@@BUG@@@ the size of China
-        // foreach (i; 2..37)
-        // {
-        //      assert(parse!int("0",i) == 0);
-        //      assert(parse!int("1",i) == 1);
-        //      assert(parse!byte("10",i) == i);
-        // }
-        foreach (i; 2..37)
-        {
-            string s = "0";
-                assert(parse!int(s,i) == 0);
-            s = "1";
-                assert(parse!int(s,i) == 1);
-            s = "10";
-                assert(parse!byte(s,i) == i);
-        }
-    // Same @@@BUG@@@ as above
-        //assert(parse!int("0011001101101", 2) == 0b0011001101101);
-        // assert(parse!int("765",8) == 0765);
-        // assert(parse!int("fCDe",16) == 0xfcde);
-    auto s = "0011001101101";
-        assert(parse!int(s, 2) == 0b0011001101101);
-    s = "765";
-        assert(parse!int(s, 8) == octal!765);
-    s = "fCDe";
-        assert(parse!int(s, 16) == 0xfcde);
+    string s; // parse doesn't accept rvalues
+    foreach (i; 2..37)
+    {
+        assert(parse!int(s = "0", i) == 0);
+        assert(parse!int(s = "1", i) == 1);
+        assert(parse!byte(s = "10", i) == i);
+    }
+
+    assert(parse!int(s = "0011001101101", 2) == 0b0011001101101);
+    assert(parse!int(s = "765", 8) == octal!765);
+    assert(parse!int(s = "fCDe", 16) == 0xfcde);
 
     // 6609
-    s = "-42";
-    assert(parse!int(s, 10) == -42);
+    assert(parse!int(s = "-42", 10) == -42);
 }
 
 @safe pure unittest // bugzilla 7302


### PR DESCRIPTION
This is a fix for [Phobos Issue #15419](https://issues.dlang.org/show_bug.cgi?id=15419): `std.conv.parse()` does not accept string literals.

I saw someone complaining about this on [dlang.org "Learn"](http://forum.dlang.org/post/n451e6$jg6$1@digitalmars.com). This also resolves the bug report embedded in a (pre-PR) `unittest`, with the somewhat silly label, `@@@BUG@@@ the size of China`.

For now, I have added a simple wrapper to handle character arrays, specifically; I don't see an easy way to support arbitrary rvalues. The long-term solution to this problem would be `scope ref`, but who knows when that will be fully implemented...