### PR TITLE
s/takeOne/take/ in std.container package documentation

### DIFF
--- a/std/container/package.d
+++ b/std/container/package.d
@@ -152,7 +152,7 @@ algorithms return the same range type as their input range.
 ---
 import std.algorithm : equal, find;
 import std.container;
-import std.range : takeOne;
+import std.range : take;
 
 auto array = make!Array(1, 2, 3);
 
@@ -165,7 +165,7 @@ array = make!Array(1, 2, 3);
 
 // the range given to `linearRemove` is a Take!(Array!int.Range)
 // spanning just the element "2"
-array.linearRemove(array[].find(2).takeOne());
+array.linearRemove(array[].find(2).take(1));
 
 assert(array[].equal([1, 3]));
 ---


### PR DESCRIPTION
takeOne returns a special type for ranges without slicing, so it just
happened to work with Array, but it doesn't work with say, linked lists.