### PR TITLE
RandomSample.front was not documented

### DIFF
--- a/std/random.d
+++ b/std/random.d
@@ -2438,6 +2438,7 @@ struct RandomSample(Range, UniformRNG = void)
         return _toSelect == 0;
     }
 
+/// Ditto
     @property auto ref front()
     {
         assert(!empty);


### PR DESCRIPTION
The documentation of std.random.RandomSample shows all range primitives except .front