### PR TITLE
Added Extra Message for Static Arrays in isInputRange

### DIFF
--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -148,6 +148,9 @@ Returns:
  */
 template isInputRange(R)
 {
+    static if (isStaticArray!R)
+        pragma(msg, "Error: Static arrays are not ranges. Try using slices instead.");
+
     enum bool isInputRange = is(typeof(
     (inout int = 0)
     {


### PR DESCRIPTION
Trying to pass static arrays to range based functions is a very, very common mistake for new comers. This PR would output a specific message to these people along with the normal DMD message that none of the overloads matched the given arguments. If a `static assert` was used in place of `static if` and `pragma(msg)`, then the normal DMD error would be lost.