### PR TITLE
Issue 15479 - COFF: phobos/win64.mak failed to make clean with MODEL=…

### DIFF
--- a/win64.mak
+++ b/win64.mak
@@ -923,7 +923,7 @@ phobos.zip : zip
 
 clean:
 	cd etc\c\zlib
-	$(MAKE) -f win$(MODEL).mak clean
+	$(MAKE) -f win64.mak MODEL=$(MODEL) clean
 	cd ..\..\..
 	del $(DOCS)
 	del $(UNITTEST_OBJS) unittest.obj unittest.exe


### PR DESCRIPTION
…32mscoff

Tweak a call to inner win64.mak with same hack as the others.