### PR TITLE
Fix precision bug in poly unittest

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -6719,7 +6719,7 @@ body
 ///
 @safe nothrow @nogc unittest
 {
-    double x = 3.1;
+    real x = 3.1;
     static real[] pp = [56.1, 32.7, 6];
 
     assert(poly(x, pp) == (56.1L + (32.7L + 6.0L * x) * x));


### PR DESCRIPTION
I get:
```
poly(3.1, pp)
= 215.13000000000000622168982999937725

(56.1L + (32.7L + 6.0L * 3.1) * 3.1)
= 215.13000000000000896949181594663969
```
Using the non-IASM paths in ``polyImpl``.