### PR TITLE
Update Phobos for druntime PR #1452 core.bitop changes

### DIFF
--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -3766,21 +3766,8 @@ private uint countTrailingZeros(T)(T value) @nogc pure nothrow
     // bsf doesn't give the correct result for 0.
     if (!value)
         return 8 * T.sizeof;
-
-    static if (T.sizeof == 8 && size_t.sizeof == 4)
-    {
-        // bsf's parameter is size_t, so it doesn't work with 64-bit integers
-        // on a 32-bit machine. For this case, we call bsf on each 32-bit half.
-        uint lower = cast(uint)value;
-        if (lower)
-            return bsf(lower);
-        value >>>= 32;
-        return 32 + bsf(cast(uint)value);
-    }
     else
-    {
         return bsf(value);
-    }
 }
 
 ///

--- a/std/numeric.d
+++ b/std/numeric.d
@@ -82,25 +82,6 @@ public enum CustomFloatFlags
     none = 0
 }
 
-// 64-bit version of core.bitop.bsr
-private int bsr64(ulong value)
-{
-    import core.bitop : bsr;
-
-    union Ulong
-    {
-        ulong raw;
-        struct
-        {
-            uint low;
-            uint high;
-        }
-    }
-    Ulong v;
-    v.raw = value;
-    return v.high==0 ? core.bitop.bsr(v.low) : core.bitop.bsr(v.high) + 32;
-}
-
 private template CustomFloatParams(uint bits)
 {
     enum CustomFloatFlags flags = CustomFloatFlags.ieee
@@ -264,7 +245,8 @@ private:
         {
             if(sig > 0)
             {
-                auto shift2 = precision - bsr64(sig);
+                import core.bitop : bsr;
+                auto shift2 = precision - bsr(sig);
                 exp  -= shift2-1;
                 shift += shift2;
             }
@@ -3075,16 +3057,18 @@ void slowFourier4(Ret, R)(R range, Ret buf)
     buf[3] = range[0] + range[1] * C(0, 1) - range[2] - range[3] * C(0, 1);
 }
 
-bool isPowerOfTwo(size_t num)
+bool isPowerOfTwo(N)(N num)
+    if (isScalarType!N && !isFloatingPoint!N)
 {
     import core.bitop : bsf, bsr;
     return bsr(num) == bsf(num);
 }
 
-size_t roundDownToPowerOf2(size_t num)
+N roundDownToPowerOf2(N)(N num)
+    if (isScalarType!N && !isFloatingPoint!N)
 {
     import core.bitop : bsr;
-    return num & (1 << bsr(num));
+    return num & (cast(N) 1 << bsr(num));
 }
 
 unittest


### PR DESCRIPTION
This PR requires [druntime #1452](https://github.com/D-Programming-Language/druntime/pull/1452), which adds `ulong` support to `bsf()`, `bsr()`, and `popcnt()` in `core.bitop`, even on 32-bit systems.

Phobos currently contains three different private implemenataions of `bsr` for `ulong`, one of which appears to not work properly on big endian systems. This updates Phobos to just use the improved `core.bitop.bsr()` everywhere, instead.

It also fixes another minor bug in `std.Numeric`: in `roundDownToPowerOf2()`, this expression: `(1 << bsr(num))` is always 32-bit, whereas it should, at a minimum, match the bit-ness of `num`.

**EDIT:** I noticed that the integer overloads of `ilogb()` are undocumented, so I fixed that too.