### PR TITLE
Move deprecations along.

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -3285,45 +3285,6 @@ if (is(typeof(binaryFun!pred(r.front, s.front)) : bool)
                 return ret;
             }
         }
-
-        // Bidirectional functionality as suggested by Brad Roberts.
-        static if (isBidirectionalRange!Range && isBidirectionalRange!Separator)
-        {
-            //Deprecated. It will be removed in December 2015
-            deprecated("splitter!(Range, Range) cannot be iterated backwards (due to separator overlap).")
-            @property Range back()
-            {
-                ensureBackLength();
-                return _input[_input.length - _backLength .. _input.length];
-            }
-
-            //Deprecated. It will be removed in December 2015
-            deprecated("splitter!(Range, Range) cannot be iterated backwards (due to separator overlap).")
-            void popBack()
-            {
-                ensureBackLength();
-                if (_backLength == _input.length)
-                {
-                    // done
-                    _input = _input[0 .. 0];
-                    _frontLength = _frontLength.max;
-                    _backLength = _backLength.max;
-                    return;
-                }
-                if (_backLength + separatorLength == _input.length)
-                {
-                    // Special case: popping the first-to-first item; there is
-                    // an empty item right before this. Leave the separator in.
-                    _input = _input[0 .. 0];
-                    _frontLength = 0;
-                    _backLength = 0;
-                    return;
-                }
-                // Normal case
-                _input = _input[0 .. _input.length - _backLength - separatorLength];
-                _backLength = _backLength.max;
-            }
-        }
     }
 
     return Result(r, s);

--- a/std/bitmanip.d
+++ b/std/bitmanip.d
@@ -1239,19 +1239,15 @@ public:
         return hash;
     }
 
-    // @@@DEPRECATED_2016-01@@@
-    /++
-        $(RED Deprecated. Please use the constructor instead. This will be
-              removed in January 2016.)
-      +/
-    deprecated("Please use the constructor instead.")
+    // Explictly undocumented. It will be removed in January 2017. @@@DEPRECATED_2017-01@@@
+    deprecated("Use the constructor instead.")
     void init(bool[] ba) pure nothrow
     {
         this = BitArray(ba);
     }
 
-    /// ditto
-    deprecated("Please use the constructor instead.")
+    // Explictly undocumented. It will be removed in January 2017. @@@DEPRECATED_2017-01@@@
+    deprecated("Use the constructor instead.")
     void init(void[] v, size_t numbits) pure nothrow
     {
         this = BitArray(v, numbits);

--- a/std/c/fenv.d
+++ b/std/c/fenv.d
@@ -1,15 +1,16 @@
+// @@@DEPRECATED_2017-06@@@
 
 /**
- * $(RED Deprecated. Please use $(D core.stdc.fenv) instead.  This module will
- *       be removed in December 2015.)
+ * $(RED Deprecated. Use $(D core.stdc.fenv) instead. This module will be
+ *       removed in June 2017.)
+ *
  * C's &lt;fenv.h&gt;
  * Authors: Walter Bright, Digital Mars, http://www.digitalmars.com
  * License: Public Domain
  * Macros:
  *      WIKI=Phobos/StdCFenv
  */
-
-/// Please import core.stdc.fenv instead. This module will be deprecated in DMD 2.068.
+deprecated("Import core.stdc.fenv instead")
 module std.c.fenv;
 
 public import core.stdc.fenv;

--- a/std/c/freebsd/socket.d
+++ b/std/c/freebsd/socket.d
@@ -1,10 +1,12 @@
 // Written in the D programming language.
 
-/*
- * This module is just for making std.socket work under FreeBSD, and these
- * definitions should actually be in druntime. (core.sys.posix.netdb or sth)
- */
-/// Please import the core.sys.posix.* modules you need instead. This module will be deprecated in DMD 2.068.
+// @@@DEPRECATED_2017-06@@@
+
+/++
+    $(RED Deprecated. Use the appropriate $(D core.sys.posix.*) modules instead.
+          This module will be removed in June 2017.)
+  +/
+deprecated("Import the appropriate core.sys.posix.* modules instead")
 module std.c.freebsd.socket;
 
 version (FreeBSD):

--- a/std/c/linux/linux.d
+++ b/std/c/linux/linux.d
@@ -1,3 +1,4 @@
+// @@@DEPRECATED_2017-06@@@
 
 /* Written by Walter Bright, Christopher E. Miller, and many others.
  * http://www.digitalmars.com/d/
@@ -6,7 +7,11 @@
  * countries.
  */
 
-/// Please import the core.sys.posix.* modules you need instead. This module will be deprecated in DMD 2.068.
+/++
+    $(RED Deprecated. Use the appropriate $(D core.sys.posix.*) modules instead.
+          This module will be removed in June 2017.)
+  +/
+deprecated("Import the appropriate core.sys.posix.* modules instead")
 module std.c.linux.linux;
 
 version (linux):

--- a/std/c/linux/linuxextern.d
+++ b/std/c/linux/linuxextern.d
@@ -1,3 +1,4 @@
+// @@@DEPRECATED_2017-06@@@
 
 /* Written by Walter Bright.
  * www.digitalmars.com
@@ -6,11 +7,11 @@
  * countries.
  */
 
-/* These are all the globals defined by the linux C runtime library.
- * Put them separate so they'll be externed - do not link in linuxextern.o
- */
-
-/// Please remove this import. This module is empty and will be deprecated in DMD 2.068.
+/++
+    $(RED Deprecated. Remove this import. This module no longer contains
+          anything.)
+  +/
+deprecated("This module no longer contains anything. Just remove the import.")
 module std.c.linux.linuxextern;
 
 // No longer needed since "extern" storage class

--- a/std/c/linux/pthread.d
+++ b/std/c/linux/pthread.d
@@ -1,9 +1,16 @@
+// @@@DEPRECATED_2017-06@@@
+
 /* Written by Walter Bright, Christopher E. Miller, and many others.
  * www.digitalmars.com
  * Placed into public domain.
  */
 
-/// Please import core.sys.posix.pthread or the other core.sys.posix.* modules you need instead. This module will be deprecated in DMD 2.068.
+/++
+    $(RED Deprecated. Use $(core.sys.posix.pthread) or the appropriate
+          $(D core.sys.posix.*) modules instead. This module will be removed in
+          June 2017.)
+  +/
+deprecated("Import core.sys.posix.pthread or the appropriate core.sys.posix.* modules instead")
 module std.c.linux.pthread;
 
 version (linux):

--- a/std/c/linux/socket.d
+++ b/std/c/linux/socket.d
@@ -3,8 +3,13 @@
     Placed into public domain.
 */
 
+// @@@DEPRECATED_2017-06@@@
 
-/// Please import the core.sys.posix.* modules you need instead. This module will be deprecated in DMD 2.068.
+/++
+    $(RED Deprecated. Use the appropriate $(D core.sys.posix.*) modules instead.
+          This module will be removed in June 2017.)
+  +/
+deprecated("Import the appropriate core.sys.posix.* modules instead")
 module std.c.linux.socket;
 
 version (linux):

--- a/std/c/linux/termios.d
+++ b/std/c/linux/termios.d
@@ -1,6 +1,11 @@
+// @@@DEPRECATED_2017-06@@@
 
 
-/// Please import core.sys.posix.termios instead. This module will be deprecated in DMD 2.068.
+/++
+    $(RED Deprecated. Use $(D core.sys.posix.termios) instead. This module will
+          be removed in June 2017.)
+  +/
+deprecated("Import core.sys.posix.termios instead")
 module std.c.linux.termios;
 
 version (linux):

--- a/std/c/linux/tipc.d
+++ b/std/c/linux/tipc.d
@@ -1,6 +1,9 @@
+// @@@DEPRECATED_2017-06@@@
+
 /**
- * $(RED Deprecated. Please use $(D core.sys.linux.tipc) instead.  This module
- *       will be removed in December 2015.)
+ * $(RED Deprecated. Use $(D core.sys.linux.tipc) instead.  This module will be
+ *       removed in June 2017.)
+ *
  * Interface for Linux TIPC sockets, /usr/include/linux/tipc.h
  *
  * Copyright: Public Domain
@@ -8,7 +11,7 @@
  * Authors:   Leandro Lucarella
  */
 
-/// Please import core.sys.linux.tipc instead. This module will be deprecated in DMD 2.068.
+deprecated("Import core.sys.linux.tipc instead")
 module std.c.linux.tipc;
 
 public import core.sys.linux.tipc;

--- a/std/c/locale.d
+++ b/std/c/locale.d
@@ -1,6 +1,9 @@
+// @@@DEPRECATED_2017-06@@@
+
 /**
- * $(RED Deprecated. Please use $(D core.stdc.locale) instead.  This module will
- *       be removed in December 2015.)
+ * $(RED Deprecated. Use $(D core.stdc.locale) instead. This module will be
+ *       removed in June 2017.)
+ *
  * C's &lt;locale.h&gt;
  * License: Public Domain
  * Standards:
@@ -8,7 +11,7 @@
  * Macros:
  *      WIKI=Phobos/StdCLocale
  */
-/// Please import core.stdc.locale instead. This module will be deprecated in DMD 2.068.
+deprecated("Import core.stdc.locale instead")
 module std.c.locale;
 
 public import core.stdc.locale;

--- a/std/c/math.d
+++ b/std/c/math.d
@@ -1,15 +1,16 @@
+// @@@DEPRECATED_2017-06@@@
 
 /**
- * $(RED Deprecated. Please use $(D core.stdc.math) instead.  This module will
- *       be removed in December 2015.)
+ * $(RED Deprecated. Use $(D core.stdc.math) instead. This module will be
+ *       removed in June 2017.)
+ *
  * C's &lt;math.h&gt;
  * Authors: Walter Bright, Digital Mars, www.digitalmars.com
  * License: Public Domain
  * Macros:
  *      WIKI=Phobos/StdCMath
  */
-
-/// Please import core.stdc.math instead. This module will be deprecated in DMD 2.068.
+deprecated("Import core.stdc.math instead")
 module std.c.math;
 
 public import core.stdc.math;

--- a/std/c/osx/socket.d
+++ b/std/c/osx/socket.d
@@ -3,8 +3,13 @@
     Placed into public domain.
 */
 
+// @@@DEPRECATED_2017-06@@@
 
-/// Please import the core.sys.posix.* modules you need instead. This module will be deprecated in DMD 2.068.
+/++
+    $(RED Deprecated. Use the appropriate $(D core.sys.posix.*) modules instead.
+          This module will be removed in June 2017.)
+  +/
+deprecated("Import the appropriate core.sys.posix.* instead")
 module std.c.osx.socket;
 
 version (OSX):

--- a/std/c/process.d
+++ b/std/c/process.d
@@ -1,15 +1,17 @@
+// @@@DEPRECATED_2017-06@@@
 
 /**
- * $(RED Deprecated. Please use $(D core.stdc.stdlib) or the core.sys.posix.*
- *       modules you need instead.  This module will be removed in December 2015.)
+ * $(RED Deprecated. Use $(D core.stdc.stdlib) or the appropriate
+ *       core.sys.posix.* modules instead. This module will be removed in June
+ *       2017.)
+ *
  * C's &lt;process.h&gt;
  * Authors: Walter Bright, Digital Mars, www.digitalmars.com
  * License: Public Domain
  * Macros:
  *      WIKI=Phobos/StdCProcess
  */
-
-/// Please import core.stdc.stdlib or the core.sys.posix.* modules you need instead. This module will be deprecated in DMD 2.068.
+deprecated("Import core.stdc.stdlib or the appropriate core.sys.posix.* modules instead")
 module std.c.process;
 
 private import core.stdc.stddef;

--- a/std/c/stdarg.d
+++ b/std/c/stdarg.d
@@ -1,17 +1,16 @@
+// @@@DEPRECATED_2017-06@@@
 
 /**
- * $(RED Deprecated. Please use $(D core.stdc.stdarg) instead.  This module will
- *       be removed in December 2015.)
+ * $(RED Deprecated. Use $(D core.stdc.stdarg) instead. This module will be
+ *       removed in June 2017.)
+ *
  * C's &lt;stdarg.h&gt;
  * Authors: Hauke Duden and Walter Bright, Digital Mars, www.digitalmars.com
  * License: Public Domain
  * Macros:
  *      WIKI=Phobos/StdCStdarg
  */
-
-/* This is for use with extern(C) variable argument lists. */
-
-/// Please import core.stdc.stdarg instead. This module will be deprecated in DMD 2.068.
+deprecated("Import core.stdc.stdarg instead")
 module std.c.stdarg;
 
 public import core.stdc.stdarg;

--- a/std/c/stddef.d
+++ b/std/c/stddef.d
@@ -1,15 +1,16 @@
+// @@@DEPRECATED_2017-06@@@
 
 /**
- * $(RED Deprecated. Please use $(D core.stdc.stddef) instead.  This module will
- *       be removed in December 2015.)
+ * $(RED Deprecated. Use $(D core.stdc.stddef) instead. This module will be
+ *       removed in June 2017.)
+ *
  * C's &lt;stddef.h&gt;
  * Authors: Walter Bright, Digital Mars, http://www.digitalmars.com
  * License: Public Domain
  * Macros:
  *      WIKI=Phobos/StdCStddef
  */
-
-/// Please import core.stdc.stddef instead. This module will be deprecated in DMD 2.068.
+deprecated("Import core.stdc.stddef instead")
 module std.c.stddef;
 
 public import core.stdc.stddef;

--- a/std/c/stdio.d
+++ b/std/c/stdio.d
@@ -1,17 +1,16 @@
+// @@@DEPRECATED_2017-06@@@
 
 /**
- * $(RED Deprecated. Please use $(D core.stdc.stdio) instead.  This module will
- *       be removed in December 2015.)
+ * $(RED Deprecated. Use $(D core.stdc.stdio) instead. This module will be
+ *       removed in June 2017.)
+ *
  * C's &lt;stdio.h&gt; for the D programming language
  * Authors: Walter Bright, Digital Mars, http://www.digitalmars.com
  * License: Public Domain
  * Macros:
  *      WIKI=Phobos/StdCStdio
  */
-
-
-
-/// Please import core.stdc.stdio instead. This module will be deprecated in DMD 2.068.
+deprecated("Import core.stdc.stdio instead")
 module std.c.stdio;
 
 public import core.stdc.stdio;

--- a/std/c/stdlib.d
+++ b/std/c/stdlib.d
@@ -1,6 +1,9 @@
+// @@@DEPRECATED_2017-06@@@
+
 /**
- * $(RED Deprecated. Please use $(D core.stdc.stdlib) or $(D core.sys.posix.stdlib)
- *       instead.  This module will be removed in December 2015.)
+ * $(RED Deprecated. Use $(D core.stdc.stdlib) or $(D core.sys.posix.stdlib)
+ *       instead. This module will be removed in June 2017.)
+ *
  * C's &lt;stdlib.h&gt;
  * D Programming Language runtime library
  * Authors: Walter Bright, Digital Mars, http://www.digitalmars.com
@@ -8,9 +11,7 @@
  * Macros:
  *      WIKI=Phobos/StdCStdlib
  */
-
-
-/// Please import core.stdc.stdlib or core.sys.posix.stdlib instead. This module will be deprecated in DMD 2.068.
+deprecated("Import core.stdc.stdlib or core.sys.posix.stdlib instead")
 module std.c.stdlib;
 
 public import core.stdc.stdlib;

--- a/std/c/string.d
+++ b/std/c/string.d
@@ -1,15 +1,16 @@
+// @@@DEPRECATED_2017-06@@@
 
 /**
- * $(RED Deprecated. Please use $(D core.stdc.string) instead.  This module will
- *       be removed in December 2015.)
+ * $(RED Deprecated. Use $(D core.stdc.string) instead. This module will be
+ *       removed in June 2017.)
+ *
  * C's &lt;string.h&gt;
  * Authors: Walter Bright, Digital Mars, http://www.digitalmars.com
  * License: Public Domain
  * Macros:
  *      WIKI=Phobos/StdCString
  */
-
-/// Please import core.stdc.string instead. This module will be deprecated in DMD 2.068.
+deprecated("Import core.stdc.string instead")
 module std.c.string;
 
 public import core.stdc.string;

--- a/std/c/time.d
+++ b/std/c/time.d
@@ -1,15 +1,16 @@
+// @@@DEPRECATED_2017-06@@@
 
 /**
- * $(RED Deprecated. Please use $(D core.stdc.time) instead.  This module will
- *       be removed in December 2015.)
+ * $(RED Deprecated. Use $(D core.stdc.time) instead. This module will be
+ *       removed in June 2017.)
+ *
  * C's &lt;time.h&gt;
  * Authors: Walter Bright, Digital Mars, www.digitalmars.com
  * License: Public Domain
  * Macros:
  *      WIKI=Phobos/StdCTime
  */
-
-/// Please import core.stdc.time instead. This module will be deprecated in DMD 2.068.
+deprecated("Import core.stdc.time instead")
 module std.c.time;
 
 public import core.stdc.time;

--- a/std/c/wcharh.d
+++ b/std/c/wcharh.d
@@ -1,15 +1,16 @@
+// @@@DEPRECATED_2017-06@@@
 
 /**
- * $(RED Deprecated. Please use $(D core.stdc.wchar_) instead.  This module will
- *       be removed in December 2015.)
+ * $(RED Deprecated. Use $(D core.stdc.wchar_) instead. This module will be
+ *       removed in June 2017.)
+ *
  * C's &lt;wchar.h&gt;
  * Authors: Walter Bright, Digital Mars, www.digitalmars.com
  * License: Public Domain
  * Macros:
  *      WIKI=Phobos/StdCWchar
  */
-
-/// Please import core.stdc.wchar_ instead. This module will be deprecated in DMD 2.068.
+deprecated("Import core.stdc.wchar_ instead")
 module std.c.wcharh;
 
 public import core.stdc.wchar_;

--- a/std/c/windows/com.d
+++ b/std/c/windows/com.d
@@ -1,4 +1,10 @@
-/// Please import core.sys.windows.com instead. This module will be deprecated in DMD 2.068.
+// @@@DEPRECATED_2017-06@@@
+
+/++
+    $(RED Deprecated. Use $(D core.sys.windows.com instead. This module will be
+          removed in June 2017.)
+  +/
+deprecated("Import core.sys.windows.com instead")
 module std.c.windows.com;
 
 version (Windows):

--- a/std/c/windows/stat.d
+++ b/std/c/windows/stat.d
@@ -2,7 +2,13 @@
 /// Placed into public domain
 /// Author: Walter Bright
 
-/// Please import core.sys.windows.stat instead. This module will be deprecated in DMD 2.068.
+// @@@DEPRECATED_2017-06@@@
+
+/++
+    $(RED Deprecated. Use $(D core.sys.windows.stat instead. This module will be
+          removed in June 2017.)
+  +/
+deprecated("Import core.sys.windows.stat instead")
 module std.c.windows.stat;
 
 version (Windows):

--- a/std/c/windows/windows.d
+++ b/std/c/windows/windows.d
@@ -2,7 +2,13 @@
 /* Windows is a registered trademark of Microsoft Corporation in the United
 States and other countries. */
 
-/// Please import core.sys.windows.windows instead. This module will be deprecated in DMD 2.068.
+// @@@DEPRECATED_2017-06@@@
+
+/++
+    $(RED Deprecated. Use $(D core.sys.windows.windows instead. This module will
+          be removed in June 2017.)
+  +/
+deprecated("Import core.sys.windows.windows instead")
 module std.c.windows.windows;
 
 version (Windows):

--- a/std/c/windows/winsock.d
+++ b/std/c/windows/winsock.d
@@ -3,8 +3,13 @@
     Placed into public domain.
 */
 
+// @@@DEPRECATED_2017-06@@@
 
-/// Please import core.sys.windows.winsock2 instead.This module will be deprecated in DMD 2.068.
+/++
+    $(RED Deprecated. Use $(D core.sys.windows.winsock2 instead. This module
+          will be removed in June 2017.)
+  +/
+deprecated("Import core.sys.windows.winsock2 instead")
 module std.c.windows.winsock;
 
 version (Windows):

--- a/std/format.d
+++ b/std/format.d
@@ -6477,23 +6477,6 @@ unittest
  * Format arguments into buffer $(I buf) which must be large
  * enough to hold the result. Throws RangeError if it is not.
  * Returns: The slice of $(D buf) containing the formatted string.
- *
- *  $(RED sformat's current implementation has been replaced with $(LREF xsformat)'s
- *        implementation in November 2012.
- *        This is seamless for most code, but it makes it so that the only
- *        argument that can be a format string is the first one, so any
- *        code which used multiple format strings has broken. Please change
- *        your calls to sformat accordingly.
- *
- *        e.g.:
- *        ----
- *        sformat(buf, "key = %s", key, ", value = %s", value)
- *        ----
- *        needs to be rewritten as:
- *        ----
- *        sformat(buf, "key = %s, value = %s", key, value)
- *        ----
- *   )
  */
 char[] sformat(Char, Args...)(char[] buf, in Char[] fmt, Args args)
 {

--- a/std/windows/iunknown.d
+++ b/std/windows/iunknown.d
@@ -1,6 +1,12 @@
 // Written in the D programming language.
 
-/// Please import core.sys.windows.com instead. This module will be deprecated in DMD 2.068.
+// @@@DEPRECATED_2017-06@@@
+
+/++
+    $(RED Deprecated. Use $(D core.sys.windows.com instead. This module
+          will be removed in June 2017.)
+  +/
+deprecated("Import core.sys.windows.com instead")
 module std.windows.iunknown;
 
 // Replaced by:


### PR DESCRIPTION
This includes deprecating std.c.*, which apparently was marked as
scheduled for deprecation in 2.068 but never actually deprecated (though
it looks like it was previously removed from the documentation build,
since it doesn't show up on dlang.org).