### PR TITLE
An extra example is added for spawn function.

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -462,7 +462,7 @@ private template isSpawnable(F, T...)
  *     auto tid2 = spawn(&f2, str.dup);
  *
  *     // New thread with anonymous function
- *     spawn( (){ writeln("This is so great!"); } );
+ *     spawn({ writeln("This is so great!"); });
  * }
  * ---
  */

--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -460,6 +460,9 @@ private template isSpawnable(F, T...)
  *
  *     // Fails:  char[] has mutable aliasing.
  *     auto tid2 = spawn(&f2, str.dup);
+ *
+ *     // New thread with anonymous function
+ *     spawn( (){ writeln("This is so great!"); } );
  * }
  * ---
  */


### PR DESCRIPTION
It shows how to create a thread in the air with an anonymous function without requiring to define separately.