### PR TITLE
[2.070][ndslice] update win*.mak & uncomment unittest with dummyranges

### DIFF
--- a/std/experimental/ndslice/slice.d
+++ b/std/experimental/ndslice/slice.d
@@ -301,7 +301,6 @@ pure nothrow unittest
 Allocates an array through a specified allocator and creates an n-dimensional slice over it.
 See also $(LINK2 std_experimental_allocator.html, std.experimental.allocator).
 +/
-version(Posix)
 unittest
 {
     import std.experimental.allocator;

--- a/std/experimental/ndslice/slice.d
+++ b/std/experimental/ndslice/slice.d
@@ -611,7 +611,7 @@ $(TR $(TD A $(BLUE fully defined slice) is an empty sequence
 
 $(H3 Internal Binary Representation)
 
-Multidimensional $(SUBREF slice, Slice) is a structure that consists of lengths, strides, and a pointer.
+Multidimensional Slice is a structure that consists of lengths, strides, and a pointer.
 For ranges, a shell is used instead of a pointer.
 This shell contains a shift of the current initial element of a multidimensional slice
 and the range itself. With the exception of overloaded operators, no functions in this

--- a/std/experimental/ndslice/slice.d
+++ b/std/experimental/ndslice/slice.d
@@ -2315,8 +2315,8 @@ private struct PtrShell(Range)
     auto ref opIndex(sizediff_t index)
     in
     {
-        assert(_shift + index >= 0);
         import std.range.primitives: hasLength;
+        assert(_shift + index >= 0);
         static if (hasLength!Range)
             assert(_shift + index <= _range.length);
     }
@@ -2330,6 +2330,7 @@ private struct PtrShell(Range)
         auto ref opIndexAssign(T)(T value, sizediff_t index)
         in
         {
+            import std.range.primitives: hasLength;
             assert(_shift + index >= 0);
             static if (hasLength!Range)
                 assert(_shift + index <= _range.length);
@@ -2342,6 +2343,7 @@ private struct PtrShell(Range)
         auto ref opIndexOpAssign(string op, T)(T value, sizediff_t index)
         in
         {
+            import std.range.primitives: hasLength;
             assert(_shift + index >= 0);
             static if (hasLength!Range)
                 assert(_shift + index <= _range.length);
@@ -2349,6 +2351,19 @@ private struct PtrShell(Range)
         body
         {
             mixin (`return _range[_shift + index] ` ~ op ~ `= value;`);
+        }
+
+        auto ref opIndexUnary(string op)(sizediff_t index)
+        in
+        {
+            import std.range.primitives: hasLength;
+            assert(_shift + index >= 0);
+            static if (hasLength!Range)
+                assert(_shift + index <= _range.length);
+        }
+        body
+        {
+            mixin (`return ` ~ op ~ `_range[_shift + index];`);
         }
     }
 
@@ -2367,14 +2382,13 @@ private auto ptrShell(Range)(Range range, sizediff_t shift = 0)
     return PtrShell!Range(shift, range);
 }
 
-version(none) // TODO: Remove before merge
-// @safe pure nothrow ?
-unittest
+@safe pure nothrow unittest
 {
     import std.internal.test.dummyrange;
     foreach (RB; AliasSeq!(ReturnBy.Reference, ReturnBy.Value))
     {
         DummyRange!(RB, Length.Yes, RangeType.Random) range;
+        range.reinit;
         assert(range.length >= 10);
         auto ptr = range.ptrShell;
         assert(ptr[0] == range[0]);
@@ -2383,6 +2397,25 @@ unittest
         ++ptr[0];
         assert(ptr[0] == save0 + 11);
         (ptr + 5)[2] = 333;
+        assert(range[7] == 333);
+    }
+}
+
+pure nothrow unittest
+{
+    import std.internal.test.dummyrange;
+    foreach (RB; AliasSeq!(ReturnBy.Reference, ReturnBy.Value))
+    {
+        DummyRange!(RB, Length.Yes, RangeType.Random) range;
+        range.reinit;
+        assert(range.length >= 10);
+        auto slice = range.sliced(10);
+        assert(slice[0] == range[0]);
+        auto save0 = range[0];
+        slice[0] += 10;
+        ++slice[0];
+        assert(slice[0] == save0 + 11);
+        slice[5 .. $][2] = 333;
         assert(range[7] == 333);
     }
 }
@@ -2521,13 +2554,13 @@ private void _indexAssign(bool lastStrideEquals1, string op, size_t N, size_t RN
 {
     static if (N == 1)
     {
-        static if(lastStrideEquals1 && (isPointer!Range || isDynamicArray!Range) && (isPointer!RRange || isDynamicArray!RRange))
+        static if (lastStrideEquals1 && (isPointer!Range || isDynamicArray!Range) && (isPointer!RRange || isDynamicArray!RRange))
         {
-            static if(isPointer!Range)
+            static if (isPointer!Range)
                 auto l = slice._ptr;
             else
                 auto l = slice._ptr._range[slice._ptr._shift .. slice._ptr._shift + slice._lengths[0]];
-            static if(isPointer!RRange)
+            static if (isPointer!RRange)
                 auto r = value._ptr;
             else
                 auto r = value._ptr._range[value._ptr._shift .. value._ptr._shift + value._lengths[0]];
@@ -2573,9 +2606,9 @@ private void _indexAssign(bool lastStrideEquals1, string op, size_t N, Range, T)
     assert(slice.length == value.length, __FUNCTION__ ~ ": argument must have the same length.");
     static if (N == 1)
     {
-        static if(lastStrideEquals1 && (isPointer!Range || isDynamicArray!Range))
+        static if (lastStrideEquals1 && (isPointer!Range || isDynamicArray!Range))
         {
-            static if(isPointer!Range)
+            static if (isPointer!Range)
                 auto l = slice._ptr;
             else
                 auto l = slice._ptr._range[slice._ptr._shift .. slice._ptr._shift + slice._lengths[0]];
@@ -2622,9 +2655,9 @@ private void _indexAssign(bool lastStrideEquals1, string op, size_t N, Range, T)
 {
     static if (N == 1)
     {
-        static if(lastStrideEquals1 && (isPointer!Range || isDynamicArray!Range))
+        static if (lastStrideEquals1 && (isPointer!Range || isDynamicArray!Range))
         {
-            static if(isPointer!Range)
+            static if (isPointer!Range)
                 auto l = slice._ptr;
             else
                 auto l = slice._ptr._range[slice._ptr._shift .. $];

--- a/win32.mak
+++ b/win32.mak
@@ -432,6 +432,10 @@ DOCS=	$(DOC)\object.html \
 	$(DOC)\std_experimental_allocator_showcase.html \
 	$(DOC)\std_experimental_allocator_typed.html \
 	$(DOC)\std_experimental_allocator.html \
+	$(DOC)\std_experimental_ndslice_iteration.html \
+	$(DOC)\std_experimental_ndslice_selection.html \
+	$(DOC)\std_experimental_ndslice_slice.html \
+	$(DOC)\std_experimental_ndslice.html \
 	$(DOC)\std_windows_charset.html \
 	$(DOC)\std_windows_registry.html \
 	$(DOC)\std_c_fenv.html \
@@ -958,6 +962,18 @@ $(DOC)\std_experimental_allocator_typed.html : $(STDDOC) std\experimental\alloca
 
 $(DOC)\std_experimental_allocator.html : $(STDDOC) std\experimental\allocator\package.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_allocator.html $(STDDOC) std\experimental\allocator\package.d
+
+$(DOC)\std_experimental_ndslice_iteration.html : $(STDDOC) std\experimental\ndslice\iteration.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_ndslice_iteration.html $(STDDOC) std\experimental\ndslice\iteration.d
+
+$(DOC)\std_experimental_ndslice_selection.html : $(STDDOC) std\experimental\ndslice\selection.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_ndslice_selection.html $(STDDOC) std\experimental\ndslice\selection.d
+
+$(DOC)\std_experimental_ndslice_slice.html : $(STDDOC) std\experimental\ndslice\slice.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_ndslice_slice.html $(STDDOC) std\experimental\ndslice\slice.d
+
+$(DOC)\std_experimental_ndslice.html : $(STDDOC) std\experimental\ndslice\package.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_ndslice.html $(STDDOC) std\experimental\ndslice\package.d
 
 $(DOC)\std_digest_crc.html : $(STDDOC) std\digest\crc.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_digest_crc.html $(STDDOC) std\digest\crc.d

--- a/win64.mak
+++ b/win64.mak
@@ -456,6 +456,10 @@ DOCS=	$(DOC)\object.html \
 	$(DOC)\std_experimental_allocator_showcase.html \
 	$(DOC)\std_experimental_allocator_typed.html \
 	$(DOC)\std_experimental_allocator.html \
+	$(DOC)\std_experimental_ndslice_iteration.html \
+	$(DOC)\std_experimental_ndslice_selection.html \
+	$(DOC)\std_experimental_ndslice_slice.html \
+	$(DOC)\std_experimental_ndslice.html \
 	$(DOC)\std_windows_charset.html \
 	$(DOC)\std_windows_registry.html \
 	$(DOC)\std_c_fenv.html \
@@ -937,6 +941,18 @@ $(DOC)\std_experimental_allocator_typed.html : $(STDDOC) std\experimental\alloca
 
 $(DOC)\std_experimental_allocator.html : $(STDDOC) std\experimental\allocator\package.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_allocator.html $(STDDOC) std\experimental\allocator\package.d
+
+$(DOC)\std_experimental_ndslice_iteration.html : $(STDDOC) std\experimental\ndslice\iteration.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_ndslice_iteration.html $(STDDOC) std\experimental\ndslice\iteration.d
+
+$(DOC)\std_experimental_ndslice_selection.html : $(STDDOC) std\experimental\ndslice\selection.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_ndslice_selection.html $(STDDOC) std\experimental\ndslice\selection.d
+
+$(DOC)\std_experimental_ndslice_slice.html : $(STDDOC) std\experimental\ndslice\slice.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_ndslice_slice.html $(STDDOC) std\experimental\ndslice\slice.d
+
+$(DOC)\std_experimental_ndslice.html : $(STDDOC) std\experimental\ndslice\package.d
+	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_experimental_ndslice.html $(STDDOC) std\experimental\ndslice\package.d
 
 $(DOC)\std_digest_crc.html : $(STDDOC) std\digest\crc.d
 	$(DMD) -c -o- $(DDOCFLAGS) -Df$(DOC)\std_digest_crc.html $(STDDOC) std\digest\crc.d


### PR DESCRIPTION
@MartinNowak this PR upgrades the win*.mak files to build docs on windows and uncomments a unittest with dummyranges. The unittets was commented before #3806 was merged.
