### PR TITLE
Fix Too Permissive Template Constraint in topN

### DIFF
--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -2155,7 +2155,7 @@ Stable topN has not been implemented yet.
 auto topN(alias less = "a < b",
         SwapStrategy ss = SwapStrategy.unstable,
         Range)(Range r, size_t nth)
-    if (isRandomAccessRange!(Range) && hasLength!Range)
+    if (isRandomAccessRange!(Range) && hasLength!Range && hasSlicing!Range)
 {
     import std.algorithm : swap; // FIXME
     import std.random : uniform;


### PR DESCRIPTION
The code requires slicing but the template does not specify that.

Ping @MartinNowak, this is a bug fix that should go into 2.070