### PR TITLE
Fix Issue 15553 - topN very inefficient [slower than sort, even for topN(0)] but should be O(n)

### DIFF
--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -2904,18 +2904,34 @@ Range minPos(alias pred = "a < b", Range)(Range range)
         is(typeof(binaryFun!pred(range.front, range.front))))
 {
     if (range.empty) return range;
-    auto result = range.save;
 
-    for (range.popFront(); !range.empty; range.popFront())
+    static if (hasSlicing!Range && isRandomAccessRange!Range && hasLength!Range)
     {
-        //Note: Unlike minCount, we do not care to find equivalence, so a single pred call is enough
-        if (binaryFun!pred(range.front, result.front))
+        // Prefer index-based access
+        size_t pos = 0;
+        foreach (i; 1 .. range.length)
         {
-            // change the min
-            result = range.save;
+            if (binaryFun!pred(range[i], range[pos]))
+            {
+                pos = i;
+            }
         }
+        return range[pos .. $];
     }
-    return result;
+    else
+    {
+        auto result = range.save;
+        for (range.popFront(); !range.empty; range.popFront())
+        {
+            //Note: Unlike minCount, we do not care to find equivalence, so a single pred call is enough
+            if (binaryFun!pred(range.front, result.front))
+            {
+                // change the min
+                result = range.save;
+            }
+        }
+        return result;
+    }
 }
 
 ///

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -2903,8 +2903,6 @@ Range minPos(alias pred = "a < b", Range)(Range range)
     if (isForwardRange!Range && !isInfinite!Range &&
         is(typeof(binaryFun!pred(range.front, range.front))))
 {
-    if (range.empty) return range;
-
     static if (hasSlicing!Range && isRandomAccessRange!Range && hasLength!Range)
     {
         // Prefer index-based access
@@ -2920,6 +2918,7 @@ Range minPos(alias pred = "a < b", Range)(Range range)
     }
     else
     {
+        if (range.empty) return range;
         auto result = range.save;
         for (range.popFront(); !range.empty; range.popFront())
         {

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -2918,11 +2918,12 @@ Range minPos(alias pred = "a < b", Range)(Range range)
     }
     else
     {
-        if (range.empty) return range;
         auto result = range.save;
+        if (range.empty) return result;
         for (range.popFront(); !range.empty; range.popFront())
         {
-            //Note: Unlike minCount, we do not care to find equivalence, so a single pred call is enough
+            // Note: Unlike minCount, we do not care to find equivalence, so a
+            // single pred call is enough.
             if (binaryFun!pred(range.front, result.front))
             {
                 // change the min

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -2174,35 +2174,27 @@ auto topN(alias less = "a < b",
         }
         auto pivot = r.getPivot!less;
         assert(!binaryFun!less(r[pivot], r[pivot]));
-        static if (is(typeof({ auto local = r[pivot]; })))
-        {
-            // Create a local copy of the pivot, it's faster
-            auto local = r[pivot];
-            auto right = r.partition!(a => binaryFun!less(a, local), ss);
-        }
-        else
-        {
-            // Data is noncopyable, conservatively use swap
-            swap(r[pivot], r.back);
-            auto right = r.partition!(a => binaryFun!less(a, r.back), ss);
-            swap(right.front, r.back);
-        }
+        swap(r[pivot], r.back);
+        auto right = r.partition!(a => binaryFun!less(a, r.back), ss);
         assert(right.length >= 1);
         pivot = r.length - right.length;
-        if (pivot == nth)
-        {
-            break;
-        }
         if (pivot < nth)
         {
             ++pivot;
             r = r[pivot .. $];
             nth -= pivot;
         }
-        else
+        else if (pivot > nth)
         {
             assert(pivot < r.length);
             r = r[0 .. pivot];
+        }
+        else
+        {
+            // Happy case!
+            // Swap the pivot to where it should be
+            swap(right.front, r.back);
+            break;
         }
     }
     return ret;

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -2206,24 +2206,23 @@ auto topN(alias less = "a < b",
         auto right = r.partition!(a => binaryFun!less(a, r.back), ss);
         assert(right.length >= 1);
         pivot = r.length - right.length;
-        if (pivot < nth)
+        if (pivot > nth)
         {
-            ++pivot;
-            r = r[pivot .. $];
-            nth -= pivot;
-        }
-        else if (pivot > nth)
-        {
+            // We don't care to swap the pivot back, won't be visited anymore
             assert(pivot < r.length);
             r = r[0 .. pivot];
+            continue;
         }
-        else
+        // Swap the pivot to where it should be
+        swap(right.front, r.back);
+        if (pivot == nth)
         {
-            // Happy case!
-            // Swap the pivot to where it should be
-            swap(right.front, r.back);
+            // Found Waldo!
             break;
         }
+        ++pivot; // skip the pivot
+        r = r[pivot .. $];
+        nth -= pivot;
     }
     return ret;
 }


### PR DESCRIPTION
* Replace random selection with getPivot, which is also used by sort. 
* Use a local copy instead of swapping range elements around when possible
* Special-case n==0, which may be either requested from the beginning or occur naturally toward the end of the search.