### PR TITLE
Replace sort with topN in ndslice example

### DIFF
--- a/std/experimental/ndslice/package.d
+++ b/std/experimental/ndslice/package.d
@@ -203,13 +203,13 @@ Returns:
 +/
 T median(Range, T)(Range r, T[] buf)
 {
-    import std.algorithm.sorting: sort;
+    import std.algorithm.sorting: topN;
     size_t n;
     foreach (e; r)
         buf[n++] = e;
-    buf[0 .. n].sort();
-    immutable m = n >> 1;
-    return n & 1 ? buf[m] : cast(T)((buf[m - 1] + buf[m]) / 2);
+    auto m = n >> 1;
+    buf[0 .. n].topN(m);
+    return buf[m];
 }
 -------
 
@@ -328,13 +328,13 @@ unittest
 
     static T median(Range, T)(Range r, T[] buf)
     {
-        import std.algorithm.sorting: sort;
+        import std.algorithm.sorting: topN;
         size_t n;
         foreach (e; r)
             buf[n++] = e;
-        buf[0 .. n].sort();
-        immutable m = n >> 1;
-        return n & 1 ? buf[m] : cast(T)((buf[m - 1] + buf[m]) / 2);
+        auto m = n >> 1;
+        buf[0 .. n].topN(m);
+        return buf[m];
     }
 
     import std.conv: to;


### PR DESCRIPTION
See also #3921 - _Fix Issue 15553 - topN very inefficient [slower than sort, even for topN(0)] but should be O(n)_
______
- 3x3 blocks: the new `topN` 90% faster than old `topN` and 10% slower than `sort`
- 7x7 blocks: the new `topN` 110% faster than old `topN` and 10% faster than `sort`