### PR TITLE
Fix Phobos Issue 15586

### DIFF
--- a/std/utf.d
+++ b/std/utf.d
@@ -2426,11 +2426,6 @@ pure
 {
 
 char[] toUTF8(return out char[4] buf, dchar c) nothrow @nogc @safe
-in
-{
-    assert(isValidDchar(c));
-}
-body
 {
     if (c <= 0x7F)
     {
@@ -2445,23 +2440,30 @@ body
     }
     else if (c <= 0xFFFF)
     {
+        if (c >= 0xD800 && c <= 0xDFFF)
+            c = replacementDchar;
+
+    L3:
         buf[0] = cast(char)(0xE0 | (c >> 12));
         buf[1] = cast(char)(0x80 | ((c >> 6) & 0x3F));
         buf[2] = cast(char)(0x80 | (c & 0x3F));
         return buf[0 .. 3];
     }
-    else if (c <= 0x10FFFF)
+    else
     {
+        if (c > 0x10FFFF)
+        {
+            c = replacementDchar;
+            goto L3;
+        }
+
         buf[0] = cast(char)(0xF0 | (c >> 18));
         buf[1] = cast(char)(0x80 | ((c >> 12) & 0x3F));
         buf[2] = cast(char)(0x80 | ((c >> 6) & 0x3F));
         buf[3] = cast(char)(0x80 | (c & 0x3F));
         return buf[0 .. 4];
     }
-
-    assert(0);
 }
-
 
 /*******************
  * Encodes string $(D_PARAM s) into UTF-8 and returns the encoded string.


### PR DESCRIPTION
`std.utf.toUTF8()` violates memory safety when fed an invalid `dchar` value, causing segfaults or other wrong behaviour: https://issues.dlang.org/show_bug.cgi?id=15586

While this PR is technically independent, the related DMD issue (https://issues.dlang.org/show_bug.cgi?id=15585) really ought to be fixed at the same time. PR here: https://github.com/D-Programming-Language/dmd/pull/5229