### PR TITLE
Add example of how to use a custom predicate with canFind.

### DIFF
--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -2207,13 +2207,13 @@ template canFind(alias pred="a == b")
  */
 @safe unittest
 {
-    auto words1 = [
+    auto words = [
         "apple",
         "beeswax",
         "cardboard"
     ];
-    assert(!canFind(words1, "bees"));
-    assert( canFind!((string a, string b) => a.startsWith(b))(words1, "bees"));
+    assert(!canFind(words, "bees"));
+    assert( canFind!((string a, string b) => a.startsWith(b))(words, "bees"));
 }
 
 @safe unittest

--- a/std/algorithm/searching.d
+++ b/std/algorithm/searching.d
@@ -2201,6 +2201,21 @@ template canFind(alias pred="a == b")
     assert(canFind([0, 1, 2, 3], [1, 3], [2, 4]) == 0);
 }
 
+/**
+ * Example using a custom predicate.
+ * Note that the needle appears as the second argument of the predicate.
+ */
+@safe unittest
+{
+    auto words1 = [
+        "apple",
+        "beeswax",
+        "cardboard"
+    ];
+    assert(!canFind(words1, "bees"));
+    assert( canFind!((string a, string b) => a.startsWith(b))(words1, "bees"));
+}
+
 @safe unittest
 {
     import std.algorithm.internal : rndstuff;


### PR DESCRIPTION
Rationale: it's not immediately obvious what the order of arguments passed to the predicate is (is it haystack item first, or needle first?).

Also, the "obvious" call:
````
haystack.canFind!startsWith(needle)
````
as well as the simpler call
````
haystack.canFind!((a,b) => a.startsWith(b))(needle)
````
actually do not compile, because the current compiler's template inference doesn't seem to be able to deduce the right types. The full incantation, including specifying `string` types, appears to be necessary to make it work. This would be far from obvious to a newbie, and thus justifies explicit documentation.