### PR TITLE
Add attributes to most functions in allocator.mallocator and allocator.common.

### DIFF
--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -13,6 +13,8 @@ Ternary type with three thruth values.
 */
 struct Ternary
 {
+    @safe @nogc nothrow pure:
+
     package ubyte value = 6;
     package static Ternary make(ubyte b)
     {
@@ -82,10 +84,11 @@ struct Ternary
     }
 }
 
+@safe @nogc nothrow pure
 unittest
 {
     alias f = Ternary.no, t = Ternary.yes, u = Ternary.unknown;
-    auto truthTableAnd =
+    Ternary[27] truthTableAnd =
     [
         t, t, t,
         t, u, u,
@@ -98,7 +101,7 @@ unittest
         f, f, f,
     ];
 
-    auto truthTableOr =
+    Ternary[27] truthTableOr =
     [
         t, t, t,
         t, u, t,
@@ -111,7 +114,7 @@ unittest
         f, f, f,
     ];
 
-    auto truthTableXor =
+    Ternary[27] truthTableXor =
     [
         t, t, f,
         t, u, u,
@@ -169,6 +172,7 @@ template stateSize(T)
         enum stateSize = T.sizeof;
 }
 
+@safe @nogc nothrow pure
 unittest
 {
     static assert(stateSize!void == 0);
@@ -224,6 +228,7 @@ size_t goodAllocSize(A)(auto ref A a, size_t n)
 /**
 Returns s rounded up to a multiple of base.
 */
+@safe @nogc nothrow pure
 package size_t roundUpToMultipleOf(size_t s, uint base)
 {
     assert(base);
@@ -231,6 +236,7 @@ package size_t roundUpToMultipleOf(size_t s, uint base)
     return rem ? s + base - rem : s;
 }
 
+@safe @nogc nothrow pure
 unittest
 {
     assert(10.roundUpToMultipleOf(11) == 11);
@@ -242,6 +248,7 @@ unittest
 /**
 Returns `n` rounded up to a multiple of alignment, which must be a power of 2.
 */
+@safe @nogc nothrow pure
 package size_t roundUpToAlignment(size_t n, uint alignment)
 {
     assert(alignment.isPowerOf2);
@@ -253,6 +260,7 @@ package size_t roundUpToAlignment(size_t n, uint alignment)
     return result;
 }
 
+@safe @nogc nothrow pure
 unittest
 {
     assert(10.roundUpToAlignment(4) == 12);
@@ -264,12 +272,14 @@ unittest
 /**
 Returns `n` rounded down to a multiple of alignment, which must be a power of 2.
 */
+@safe @nogc nothrow pure
 package size_t roundDownToAlignment(size_t n, uint alignment)
 {
     assert(alignment.isPowerOf2);
     return n & ~size_t(alignment - 1);
 }
 
+@safe @nogc nothrow pure
 unittest
 {
     assert(10.roundDownToAlignment(4) == 8);
@@ -283,6 +293,7 @@ Advances the beginning of `b` to start at alignment `a`. The resulting buffer
 may therefore be shorter. Returns the adjusted buffer, or null if obtaining a
 non-empty buffer is impossible.
 */
+@nogc nothrow pure
 package void[] roundUpToAlignment(void[] b, uint a)
 {
     auto e = b.ptr + b.length;
@@ -291,6 +302,7 @@ package void[] roundUpToAlignment(void[] b, uint a)
     return p[0 .. e - p];
 }
 
+@nogc nothrow pure
 unittest
 {
     void[] empty;
@@ -303,6 +315,7 @@ unittest
 /**
 Like `a / b` but rounds the result up, not down.
 */
+@safe @nogc nothrow pure
 package size_t divideRoundUp(size_t a, size_t b)
 {
     assert(b);
@@ -312,6 +325,7 @@ package size_t divideRoundUp(size_t a, size_t b)
 /**
 Returns `s` rounded up to a multiple of `base`.
 */
+@nogc nothrow pure
 package void[] roundStartToMultipleOf(void[] s, uint base)
 {
     assert(base);
@@ -321,6 +335,7 @@ package void[] roundStartToMultipleOf(void[] s, uint base)
     return p[0 .. end - p];
 }
 
+nothrow pure
 unittest
 {
     void[] p;
@@ -332,6 +347,7 @@ unittest
 /**
 Returns $(D s) rounded up to the nearest power of 2.
 */
+@safe @nogc nothrow pure
 package size_t roundUpToPowerOf2(size_t s)
 {
     import std.meta : AliasSeq;
@@ -348,6 +364,7 @@ package size_t roundUpToPowerOf2(size_t s)
     return s + 1;
 }
 
+@safe @nogc nothrow pure
 unittest
 {
     assert(0.roundUpToPowerOf2 == 0);
@@ -367,6 +384,7 @@ unittest
 /**
 Returns the number of trailing zeros of $(D x).
 */
+@safe @nogc nothrow pure
 package uint trailingZeros(ulong x)
 {
     uint result;
@@ -377,6 +395,7 @@ package uint trailingZeros(ulong x)
     return result;
 }
 
+@safe @nogc nothrow pure
 unittest
 {
     assert(trailingZeros(0) == 64);
@@ -389,6 +408,7 @@ unittest
 /**
 Returns `true` if `ptr` is aligned at `alignment`.
 */
+@nogc nothrow pure
 package bool alignedAt(void* ptr, uint alignment)
 {
     return cast(size_t) ptr % alignment == 0;
@@ -398,11 +418,13 @@ package bool alignedAt(void* ptr, uint alignment)
 Returns the effective alignment of `ptr`, i.e. the largest power of two that is
 a divisor of `ptr`.
 */
+@nogc nothrow pure
 package uint effectiveAlignment(void* ptr)
 {
     return 1U << trailingZeros(cast(size_t) ptr);
 }
 
+@nogc nothrow pure
 unittest
 {
     int x;
@@ -413,6 +435,7 @@ unittest
 Aligns a pointer down to a specified alignment. The resulting pointer is less
 than or equal to the given pointer.
 */
+@nogc nothrow pure
 package void* alignDownTo(void* ptr, uint alignment)
 {
     assert(alignment.isPowerOf2);
@@ -423,6 +446,7 @@ package void* alignDownTo(void* ptr, uint alignment)
 Aligns a pointer up to a specified alignment. The resulting pointer is greater
 than or equal to the given pointer.
 */
+@nogc nothrow pure
 package void* alignUpTo(void* ptr, uint alignment)
 {
     assert(alignment.isPowerOf2);
@@ -434,12 +458,14 @@ package void* alignUpTo(void* ptr, uint alignment)
 /**
 Returns `true` if `x` is a nonzero power of two.
 */
-package bool isPowerOf2(uint x) @nogc
+@safe @nogc nothrow pure
+package bool isPowerOf2(uint x)
 {
     return (x & -x) > (x - 1);
 }
 
-@nogc unittest
+@safe @nogc nothrow pure
+unittest
 {
     assert(!isPowerOf2(0));
     assert(isPowerOf2(1));
@@ -455,12 +481,14 @@ package bool isPowerOf2(uint x) @nogc
     assert(isPowerOf2(1UL << 31));
 }
 
-package bool isGoodStaticAlignment(uint x) @nogc
+@safe @nogc nothrow pure
+package bool isGoodStaticAlignment(uint x)
 {
     return x.isPowerOf2;
 }
 
-package bool isGoodDynamicAlignment(uint x) @nogc
+@safe @nogc nothrow pure
+package bool isGoodDynamicAlignment(uint x)
 {
     return x.isPowerOf2 && x >= (void*).sizeof;
 }

--- a/std/experimental/allocator/mallocator.d
+++ b/std/experimental/allocator/mallocator.d
@@ -21,7 +21,8 @@ struct Mallocator
     paradoxically, $(D malloc) is $(D @safe) but that's only useful to safe
     programs that can afford to leak memory allocated.
     */
-    @nogc @trusted void[] allocate(size_t bytes) shared
+    @trusted @nogc nothrow
+    void[] allocate(size_t bytes) shared
     {
         import core.stdc.stdlib : malloc;
         if (!bytes) return null;
@@ -30,7 +31,8 @@ struct Mallocator
     }
 
     /// Ditto
-    @nogc @system bool deallocate(void[] b) shared
+    @system @nogc nothrow
+    bool deallocate(void[] b) shared
     {
         import core.stdc.stdlib : free;
         free(b.ptr);
@@ -38,7 +40,8 @@ struct Mallocator
     }
 
     /// Ditto
-    @nogc @system bool reallocate(ref void[] b, size_t s) shared
+    @system @nogc nothrow
+    bool reallocate(ref void[] b, size_t s) shared
     {
         import core.stdc.stdlib : realloc;
         if (!s)
@@ -64,16 +67,19 @@ struct Mallocator
 }
 
 ///
-@nogc unittest
+@nogc nothrow
+unittest
 {
     auto buffer = Mallocator.instance.allocate(1024 * 1024 * 4);
     scope(exit) Mallocator.instance.deallocate(buffer);
     //...
 }
 
-@nogc unittest
+@nogc nothrow
+unittest
 {
-    @nogc static void test(A)()
+    @nogc nothrow
+    static void test(A)()
     {
         int* p = null;
         p = cast(int*) A.instance.allocate(int.sizeof);
@@ -84,20 +90,24 @@ struct Mallocator
     test!Mallocator();
 }
 
+@nogc nothrow
 unittest
 {
     static void test(A)()
     {
+        import std.experimental.allocator : make;
         Object p = null;
-        p = new Object;
+        p = A.instance.make!Object();
         assert(p !is null);
     }
 
     test!Mallocator();
 }
 
-version (Posix) private extern(C) @nogc
-int posix_memalign(void**, size_t, size_t);
+version (Posix)
+@nogc nothrow
+private extern(C) int posix_memalign(void**, size_t, size_t);
+
 version (Windows)
 {
     // DMD Win 32 bit, DigitalMars C standard library misses the _aligned_xxx
@@ -111,13 +121,16 @@ version (Windows)
         {
             void* basePtr;
             size_t size;
-            static AlignInfo* opCall(void* ptr) @nogc
+
+            @nogc nothrow
+            static AlignInfo* opCall(void* ptr)
             {
                 return cast(AlignInfo*) (ptr - AlignInfo.sizeof);
             }
         }
 
-        private void* _aligned_malloc(size_t size, size_t alignment) @nogc
+        @nogc nothrow
+        private void* _aligned_malloc(size_t size, size_t alignment)
         {
             import std.c.stdlib: malloc;
             size_t offset = alignment + size_t.sizeof * 2 - 1;
@@ -138,8 +151,8 @@ version (Windows)
             return alignedPtr;
         }
 
+        @nogc nothrow
         private void* _aligned_realloc(void* ptr, size_t size, size_t alignment)
-        @nogc
         {
             import std.c.stdlib: free;
             import std.c.string: memcpy;
@@ -165,7 +178,8 @@ version (Windows)
             return alignedPtr;
         }
 
-        private void _aligned_free(void *ptr) @nogc
+        @nogc nothrow
+        private void _aligned_free(void *ptr)
         {
             import std.c.stdlib: free;
             if (!ptr) return;
@@ -177,9 +191,9 @@ version (Windows)
     // DMD Win 64 bit, uses microsoft standard C library which implements them
     else
     {
-        @nogc private extern(C) void* _aligned_malloc(size_t, size_t);
-        @nogc private extern(C) void _aligned_free(void *memblock);
-        @nogc private extern(C) void* _aligned_realloc(void *, size_t, size_t);
+        @nogc nothrow private extern(C) void* _aligned_malloc(size_t, size_t);
+        @nogc nothrow private extern(C) void _aligned_free(void *memblock);
+        @nogc nothrow private extern(C) void* _aligned_realloc(void *, size_t, size_t);
     }
 }
 
@@ -198,7 +212,8 @@ struct AlignedMallocator
     /**
     Forwards to $(D alignedAllocate(bytes, platformAlignment)).
     */
-    @nogc @trusted void[] allocate(size_t bytes) shared
+    @trusted @nogc nothrow
+    void[] allocate(size_t bytes) shared
     {
         if (!bytes) return null;
         return alignedAllocate(bytes, alignment);
@@ -210,7 +225,8 @@ struct AlignedMallocator
     $(WEB msdn.microsoft.com/en-us/library/8z34s9c6(v=vs.80).aspx,
     $(D __aligned_malloc)) on Windows.
     */
-    version(Posix) @trusted @nogc
+    version(Posix)
+    @trusted @nogc nothrow
     void[] alignedAllocate(size_t bytes, uint a) shared
     {
         import core.stdc.errno : ENOMEM;
@@ -220,7 +236,8 @@ struct AlignedMallocator
         if (code == ENOMEM) return null;
         return result[0 .. bytes];
     }
-    else version(Windows) @trusted @nogc
+    else version(Windows)
+    @trusted @nogc nothrow
     void[] alignedAllocate(size_t bytes, uint a) shared
     {
         auto result = _aligned_malloc(bytes, a);
@@ -233,14 +250,16 @@ struct AlignedMallocator
     $(WEB msdn.microsoft.com/en-US/library/17b5h8td(v=vs.80).aspx,
     $(D __aligned_free(b.ptr))) on Windows.
     */
-    version (Posix) @system @nogc
+    version (Posix)
+    @system @nogc nothrow
     bool deallocate(void[] b) shared
     {
         import core.stdc.stdlib : free;
         free(b.ptr);
         return true;
     }
-    else version (Windows) @system @nogc
+    else version (Windows)
+    @system @nogc nothrow
     bool deallocate(void[] b) shared
     {
         _aligned_free(b.ptr);
@@ -252,12 +271,14 @@ struct AlignedMallocator
     On Posix, forwards to $(D realloc). On Windows, forwards to
     $(D alignedReallocate(b, newSize, platformAlignment)).
     */
-    version (Posix) @system @nogc
+    version (Posix)
+    @system @nogc nothrow
     bool reallocate(ref void[] b, size_t newSize) shared
     {
         return Mallocator.instance.reallocate(b, newSize);
     }
-    version (Windows) @system @nogc
+    version (Windows)
+    @system @nogc nothrow
     bool reallocate(ref void[] b, size_t newSize) shared
     {
         return alignedReallocate(b, newSize, alignment);
@@ -269,7 +290,8 @@ struct AlignedMallocator
     $(WEB msdn.microsoft.com/en-US/library/y69db7sx(v=vs.80).aspx,
     $(D __aligned_realloc(b.ptr, newSize, a))).
     */
-    version (Windows) @system @nogc
+    version (Windows)
+    @system @nogc nothrow
     bool alignedReallocate(ref void[] b, size_t s, uint a) shared
     {
         if (!s)
@@ -293,7 +315,8 @@ struct AlignedMallocator
 }
 
 ///
-@nogc unittest
+@nogc nothrow
+unittest
 {
     auto buffer = AlignedMallocator.instance.alignedAllocate(1024 * 1024 * 4,
         128);
@@ -302,8 +325,12 @@ struct AlignedMallocator
 }
 
 version(unittest) version(CRuntime_DigitalMars)
-    size_t addr(ref void* ptr) @nogc {return cast(size_t) ptr;}
-version(CRuntime_DigitalMars) @nogc unittest
+@nogc nothrow
+size_t addr(ref void* ptr) { return cast(size_t) ptr; }
+
+version(CRuntime_DigitalMars)
+@nogc nothrow
+unittest
 {
     void* m;
 


### PR DESCRIPTION
Also made the attribute style more consistent, because it was all over the place throughout the package.

I looked at the [Phobos styleguide](https://dlang.org/dstyle.html), but I couldn't find anything about this, so I decided to follow the soft limit of 80 chars per line. That's why I put the attributes on their own line.
Overall the scheme is something like this:
```
[@safe] [@nogc] [nothrow] [pure]
[protection-level] [extern] <function-name / unittest>[params] [shared]
```

Let me know if there is an existing style that I need to follow. I only care about adding correct attributes on the functions, not about bikeshedding about the code style.