### PR TITLE
Fix a typo in stack allocator usage example

### DIFF
--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -168,7 +168,7 @@ void fun(size_t n)
     // Use a stack-installed allocator for up to 64KB
     StackFront!65536 myAllocator;
     int[] a2 = myAllocator.makeArray!int(n);
-    scope(exit) theAllocator.dispose(a2);
+    scope(exit) myAllocator.dispose(a2);
     ...
 }
 ----


### PR DESCRIPTION
Objs should be deallocated by the same allocator used to allocate them.