### PR TITLE
Don't use selective import in std.math due to DMD issue 314.

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -128,6 +128,7 @@ version (Win64)
         version = Win64_DMD_InlineAsm;
 }
 
+import core.bitop;
 import core.math;
 import core.stdc.math;
 import std.traits;
@@ -2623,8 +2624,6 @@ unittest
         }
     }
 }
-
-import core.bitop : bsr;
 
 /******************************************
  * Extracts the exponent of x as a signed integral value.


### PR DESCRIPTION
This fixes a small mistake I made in [#3888](https://github.com/D-Programming-Language/phobos/pull/3888).