### PR TITLE
Add goodAllocationSize to GCAllocator

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -1,7 +1,7 @@
 Ddoc
 
-$(COMMENT Pending changelog for 2.069. This will get copied to dlang.org and
-    cleared when master gets merged into stable prior to 2.069.
+$(COMMENT Pending changelog for 2.071. This will get copied to dlang.org and
+    cleared when master gets merged into stable prior to 2.071.
 )
 
 $(BUGSTITLE Library Changes,
@@ -11,6 +11,8 @@ $(LI The package $(STDMODREF experimental_ndslice, std.experimental.ndslice) was
 It is also available as part of the $(LINK2 https://github.com/DlangScience/mir, Mir library).)
 $(LI Default LogLevel of FileLogger was changed to LogLevel.all.)
 $(LI Access to the internal `ptr` and `len` fields of $(XREF bitmanip, BitArray) was deprecated.)
+$(LI $(XREF experimental.allocator.gc_allocator, GCAllocator.goodAllocSize)
+was added.)
 )
 
 $(BUGSTITLE Library Changes,

--- a/std/experimental/allocator/building_blocks/free_tree.d
+++ b/std/experimental/allocator/building_blocks/free_tree.d
@@ -330,12 +330,12 @@ struct FreeTree(ParentAllocator)
         a.deallocate(b1);
         a.deallocate(b3);
         a.deallocate(b2);
-        assert(a.formatSizes == "(20000 (10000 30000))", a.formatSizes);
+        assert(a.formatSizes == "(20480 (12288 32768))", a.formatSizes);
 
         b1 = a.allocate(10000);
-        assert(a.formatSizes == "(20000 (_ 30000))", a.formatSizes);
+        assert(a.formatSizes == "(20480 (_ 32768))", a.formatSizes);
         b1 = a.allocate(30000);
-        assert(a.formatSizes == "(20000)", a.formatSizes);
+        assert(a.formatSizes == "(20480)", a.formatSizes);
         b1 = a.allocate(20000);
         assert(a.formatSizes == "(_)", a.formatSizes);
     }

--- a/std/experimental/allocator/gc_allocator.d
+++ b/std/experimental/allocator/gc_allocator.d
@@ -144,6 +144,11 @@ unittest
         scope(exit) GCAllocator.instance.deallocate(buffer);
 
         assert(GC.sizeOf(buffer.ptr) == s);
+
+        auto buffer2 = GCAllocator.instance.allocate(s - (s / 2) + 1);
+        scope(exit) GCAllocator.instance.deallocate(buffer2);
+
+        assert(GC.sizeOf(buffer2.ptr) == s);
     }
 
     // anything above a page is simply rounded up to next page

--- a/std/experimental/allocator/gc_allocator.d
+++ b/std/experimental/allocator/gc_allocator.d
@@ -85,15 +85,14 @@ struct GCAllocator
     {
         if(n == 0)
             return 0;
+        if(n <= 16)
+            return 16;
+
         import core.bitop: bsr;
 
-        auto largestBit = bsr(n);
-        if (largestBit < 4) // less than 16
-            return 16;
-        if (size_t(1) << largestBit == n) // is a power of 2
-            return n;
-        if (largestBit < 12) // less than 4096
-            return size_t(1) << (largestBit + 1);
+        auto largestBit = bsr(n-1) + 1;
+        if (largestBit <= 12) // 4096 or less
+            return size_t(1) << largestBit;
 
         // larger, we use a multiple of 4096.
         return ((n + 4095) / 4096) * 4096;


### PR DESCRIPTION
GC always allocates from bins, and has very well-defined behavior here. So goodAllocSize can be implemented quite easily.

Rules:

1. If allocation size < 16, allocate 16 bytes
2. For allocations of 16 to 8192, use the power of 2 size that will hold it.
3. For allocations greater than 8192, use the multiple of 4096 that will hold it.

I had to change some other unit tests because of the assumptions made for the default implementation of `IAllocator.goodAllocSize`