### PR TITLE
Fix issue 15480

### DIFF
--- a/std/algorithm/iteration.d
+++ b/std/algorithm/iteration.d
@@ -457,10 +457,6 @@ template map(fun...) if (fun.length >= 1)
 
             alias _funs = staticMap!(unaryFun, fun);
             alias _fun = adjoin!_funs;
-
-            alias ReturnTypes = staticMap!(AppliedReturnType, _funs);
-            static assert(staticIndexOf!(void, ReturnTypes) == -1,
-                          "All mapping functions must not return void.");
         }
         else
         {


### PR DESCRIPTION
Allow map to take multiple lambdas instead of using mixins for multiple lambdas.

Seems it depends on https://issues.dlang.org/show_bug.cgi?id=5710
Introduced as a part of https://github.com/D-Programming-Language/phobos/pull/1917

https://issues.dlang.org/show_bug.cgi?id=15480