### PR TITLE
Add missing import

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -470,6 +470,7 @@ void upload(Conn = AutoProtocol)(string loadFromPath, const(char)[] url, Conn co
 
     static if (is(Conn : HTTP) || is(Conn : FTP))
     {
+        import std.stdio : File;
         auto f = File(loadFromPath, "rb");
         conn.onSend = buf => f.rawRead(buf).length;
         auto sz = f.size;


### PR DESCRIPTION
The upload function needs std.stdio.File, but the import is missing.