### PR TITLE
Fix issue 15645 - Tuple.slice() causes memory corruption

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -740,10 +740,10 @@ template Tuple(Specs...)
          *     the original.
          */
         @property
-        ref Tuple!(sliceSpecs!(from, to)) slice(size_t from, size_t to)() @trusted
+        Tuple!(sliceSpecs!(from, to)) slice(size_t from, size_t to)() @safe const
         if (from <= to && to <= Types.length)
         {
-            return *cast(typeof(return)*) &(field[from]);
+            return typeof(return)(field[from .. to]);
         }
 
         ///
@@ -755,6 +755,14 @@ template Tuple(Specs...)
             auto s = a.slice!(1, 3);
             static assert(is(typeof(s) == Tuple!(string, float)));
             assert(s[0] == "abc" && s[1] == 4.5);
+
+            // Phobos issue #15645
+            Tuple!(int, int, long) b;
+            b[1] = 42;
+            b[2] = 101;
+            auto t = b.slice!(1, 3);
+            static assert(is(typeof(t) == Tuple!(int, long)));
+            assert(t[0] == 42 && t[1] == 102);
         }
 
         /**

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -743,7 +743,7 @@ template Tuple(Specs...)
         inout(Tuple!(sliceSpecs!(from, to))) slice(size_t from, size_t to)() inout
         if (from <= to && to <= Types.length)
         {
-            return Tuple!(sliceSpecs!(from, to))(field[from .. to]);
+            return Tuple!(sliceSpecs!(from, to))(expand[from .. to]);
         }
 
         ///

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -740,14 +740,14 @@ template Tuple(Specs...)
          *     the original.
          */
         @property
-        Tuple!(sliceSpecs!(from, to)) slice(size_t from, size_t to)() @safe const
+        inout(Tuple!(sliceSpecs!(from, to))) slice(size_t from, size_t to)() inout
         if (from <= to && to <= Types.length)
         {
-            return typeof(return)(field[from .. to]);
+            return Tuple!(sliceSpecs!(from, to))(field[from .. to]);
         }
 
         ///
-        unittest
+        @safe unittest
         {
             Tuple!(int, string, float, double) a;
             a[1] = "abc";
@@ -755,14 +755,6 @@ template Tuple(Specs...)
             auto s = a.slice!(1, 3);
             static assert(is(typeof(s) == Tuple!(string, float)));
             assert(s[0] == "abc" && s[1] == 4.5);
-
-            // Phobos issue #15645
-            Tuple!(int, int, long) b;
-            b[1] = 42;
-            b[2] = 101;
-            auto t = b.slice!(1, 3);
-            static assert(is(typeof(t) == Tuple!(int, long)));
-            assert(t[0] == 42 && t[1] == 102);
         }
 
         /**
@@ -990,6 +982,24 @@ private template ReverseTupleType(T)
     static if (is(T : Tuple!A, A...))
         alias ReverseTupleType = Tuple!(ReverseTupleSpecs!A);
 }
+
+/* Phobos issue #15645: Tuple.slice() causes memory corruption
+   https://issues.dlang.org/show_bug.cgi?id=15645 */
+@safe unittest
+{
+    Tuple!(int, int, long) b;
+    b[1] = 42;
+    b[2] = 101;
+    auto t = b.slice!(1, 3);
+    static assert(is(typeof(t) == Tuple!(int, long)));
+    assert(t[0] == 42 && t[1] == 102);
+
+    const auto c = tuple!("a", "b", "c")(42, true, "somestring");
+    auto u = c.slice!(1, 3);
+    static assert(is(typeof(u) == const(Tuple!(bool, "b", string, "c"))));
+    assert(c.b == true && c.c == "somestring");
+}
+
 
 /* Reverse the Specs of a Tuple. */
 private template ReverseTupleSpecs(T...)


### PR DESCRIPTION
This approach fixes the issue without changing the layout of the tuple.

Changes that need consideration:
1. Return type of Tuple.slice - 'ref' removed. Does this affect how
Tuple.slice() is expected to behave?