### PR TITLE
Android update

### DIFF
--- a/std/experimental/allocator/building_blocks/stats_collector.d
+++ b/std/experimental/allocator/building_blocks/stats_collector.d
@@ -664,15 +664,12 @@ unittest
     alloc.reallocate(b, 20);
     alloc.deallocate(b);
 
+    import std.file : deleteme, remove;
     import std.stdio : File;
     import std.range : walkLength;
-    version(Posix)
-        auto f = "/tmp/dlang.std.experimental.allocator.stats_collector.txt";
-    version(Windows)
-    {
-        import std.process: environment;
-        auto f = environment.get("temp") ~ r"\dlang.std.experimental.allocator.stats_collector.txt";
-    }
+
+    auto f = deleteme ~ "-dlang.std.experimental.allocator.stats_collector.txt";
+    scope(exit) remove(f);
     Allocator.reportPerCallStatistics(File(f, "w"));
     alloc.reportStatistics(File(f, "a"));
     assert(File(f).byLine.walkLength == 22);

--- a/std/file.d
+++ b/std/file.d
@@ -3118,6 +3118,7 @@ private void copyImpl(const(char)[] f, const(char)[] t, const(FSChar)* fromz, co
     else version(Posix)
     {
         import core.stdc.stdio;
+        static import std.conv;
 
         immutable fd = core.sys.posix.fcntl.open(fromz, O_RDONLY);
         cenforce(fd != -1, f, fromz);
@@ -3158,7 +3159,7 @@ private void copyImpl(const(char)[] f, const(char)[] t, const(FSChar)* fromz, co
                 size -= toxfer;
             }
             if (preserve)
-                cenforce(fchmod(fdw, statbuf.st_mode) == 0, f, fromz);
+                cenforce(fchmod(fdw, std.conv.to!mode_t(statbuf.st_mode)) == 0, f, fromz);
         }
 
         cenforce(core.sys.posix.unistd.close(fdw) != -1, f, fromz);
@@ -3901,6 +3902,11 @@ string tempDir() @trusted
             wchar[MAX_PATH + 2] buf;
             DWORD len = GetTempPathW(buf.length, buf.ptr);
             if (len) cache = toUTF8(buf[0 .. len]);
+        }
+        else version(Android)
+        {
+            // Don't check for a global temporary directory as
+            // Android doesn't have one.
         }
         else version(Posix)
         {

--- a/std/format.d
+++ b/std/format.d
@@ -1793,9 +1793,7 @@ unittest
         formatTest( to!(    const T)(5.5), "5.5" );
         formatTest( to!(immutable T)(5.5), "5.5" );
 
-        // bionic doesn't support lower-case string formatting of nan yet
-        version(CRuntime_Bionic) { formatTest( T.nan, "NaN" ); }
-        else { formatTest( T.nan, "nan" ); }
+        formatTest( T.nan, "nan" );
     }
 }
 
@@ -3722,13 +3720,6 @@ unittest
             || stream.data == "1.67 -0X1.47AE147AE147BP+0 nan", // MSVCRT 14+ (VS 2015)
                 stream.data);
     }
-    else version (CRuntime_Bionic)
-    {
-        // bionic doesn't support hex formatting of floating point numbers
-        // or lower-case string formatting of nan yet, but it was committed
-        // recently (April 2014):
-        // https://code.google.com/p/android/issues/detail?id=64886
-    }
     else
     {
         assert(stream.data == "1.67 -0X1.47AE147AE147BP+0 nan",
@@ -3757,12 +3748,6 @@ unittest
     version (CRuntime_Microsoft)
         assert(stream.data == "0x1.51eb85p+0 0X1.B1EB86P+2"
             || stream.data == "0x1.51eb851eb851fp+0 0X1.B1EB860000000P+2"); // MSVCRT 14+ (VS 2015)
-    else version (CRuntime_Bionic)
-    {
-        // bionic doesn't support hex formatting of floating point numbers,
-        // but it was committed recently (April 2014):
-        // https://code.google.com/p/android/issues/detail?id=64886
-    }
     else
         assert(stream.data == "0x1.51eb851eb851fp+0 0X1.B1EB86P+2");
     stream.clear();
@@ -6118,13 +6103,6 @@ unittest
     else version (CRuntime_Microsoft)
         assert(s == "1.67 -0X1.47AE14P+0 nan"
             || s == "1.67 -0X1.47AE147AE147BP+0 nan", s); // MSVCRT 14+ (VS 2015)
-    else version (CRuntime_Bionic)
-    {
-        // bionic doesn't support hex formatting of floating point numbers
-        // or lower-case string formatting of nan yet, but it was committed
-        // recently (April 2014):
-        // https://code.google.com/p/android/issues/detail?id=64886
-    }
     else
         assert(s == "1.67 -0X1.47AE147AE147BP+0 nan", s);
 

--- a/std/process.d
+++ b/std/process.d
@@ -724,10 +724,10 @@ private bool isExecutable(in char[] path) @trusted nothrow @nogc //TODO: @safe
 version (Posix) unittest
 {
     import std.algorithm;
-    auto unamePath = searchPathFor("uname");
-    assert (!unamePath.empty);
-    assert (unamePath[0] == '/');
-    assert (unamePath.endsWith("uname"));
+    auto lsPath = searchPathFor("ls");
+    assert (!lsPath.empty);
+    assert (lsPath[0] == '/');
+    assert (lsPath.endsWith("ls"));
     auto unlikely = searchPathFor("lkmqwpoialhggyaofijadsohufoiqezm");
     assert (unlikely is null, "Are you kidding me?");
 }
@@ -1474,7 +1474,12 @@ unittest // tryWait() and kill()
         TestScript prog = "while true; do sleep 1; done";
     }
     auto pid = spawnProcess(prog.path);
-    Thread.sleep(dur!"seconds"(1));
+    // Android appears to automatically kill sleeping processes very quickly,
+    // so shorten the wait before killing here.
+    version (Android)
+        Thread.sleep(dur!"msecs"(5));
+    else
+        Thread.sleep(dur!"seconds"(1));
     kill(pid);
     version (Windows)    assert (wait(pid) == 1);
     else version (Posix) assert (wait(pid) == -SIGTERM);
@@ -2147,6 +2152,10 @@ unittest
        "echo|set /p=%~1
         echo|set /p=%~2 1>&2
         exit 123";
+    else version (Android) TestScript prog =
+       `echo -n $1
+        echo -n $2 >&2
+        exit 123`;
     else version (Posix) TestScript prog =
        `printf '%s' $1
         printf '%s' $2 >&2
@@ -2239,17 +2248,15 @@ $(LREF nativeShell).
 */
 @property string userShell() @safe
 {
-    version (Windows)      return environment.get("COMSPEC", "cmd.exe");
-    else version (Android) return environment.get("SHELL", "/system/bin/sh");
-    else version (Posix)   return environment.get("SHELL", "/bin/sh");
+    version (Windows)      return environment.get("COMSPEC", nativeShell);
+    else version (Posix)   return environment.get("SHELL", nativeShell);
 }
 
 /**
 The platform-specific native shell path.
 
-On Windows, this function returns $(D "cmd.exe").
-
-On POSIX, $(D nativeShell) returns $(D "/bin/sh").
+This function returns $(D "cmd.exe") on Windows, $(D "/bin/sh") on POSIX, and
+$(D "/system/bin/sh") on Android.
 */
 @property string nativeShell() @safe @nogc pure nothrow
 {
@@ -2344,8 +2351,7 @@ private struct TestScript
         else version (Posix)
         {
             auto ext = "";
-            version(Android) auto firstLine = "#!" ~ userShell;
-            else auto firstLine = "#!/bin/sh";
+            auto firstLine = "#!" ~ nativeShell;
         }
         path = uniqueTempPath()~ext;
         std.file.write(path, firstLine~std.ascii.newline~code~std.ascii.newline);

--- a/std/socket.d
+++ b/std/socket.d
@@ -466,9 +466,11 @@ class Protocol
 }
 
 
+// Skip this test on Android because getprotobyname/number are
+// unimplemented in bionic.
+version(CRuntime_Bionic) {} else
 unittest
 {
-    // getprotobyname,number are unimplemented in bionic
     softUnittest({
         Protocol proto = new Protocol;
         assert(proto.getProtocolByType(ProtocolType.TCP));


### PR DESCRIPTION
Merge [fixes](https://gist.github.com/joakim-noah/5d399fdcd5e484d6aaa2) from [latest Android work](https://gist.github.com/joakim-noah/5c03801fa6c59b1e90df), comments and explanations provided inline.  The version of this PR from the first link was the first to get all tests passing on Android/x86 a couple months ago, with phobos from git master.

There are two additional workarounds I found for prior Android versions, but didn't include here:

* [Bionic up till Android 4.1 didn't support calling `getcwd` with null and 0 arguments](https://github.com/android/platform_bionic/commit/04a83a48ed89f433c78e31106ed50059764797a0), so [I allocated a static array and passed it in](https://gist.github.com/joakim-noah/5c03801fa6c59b1e90df#file-phobos_ldc_arm-L375).  However, [the share of 4.1 and older Android versions is at 14.1%](http://developer.android.com/about/dashboards/index.html) and [dropping](http://blog.davidecoppola.com/2015/12/android-version-distribution-over-time-december-2013-to-2015/), so I don't think it's worth working around them.
* There was a regression in Android 5.0 where calling `flockfile` on `stdout`/`stdin`/`stderr` makes it hang because of an uninitialized mutex, which was [subsequently](https://github.com/android/platform_bionic/commit/6a03abcfd23f31d1df06eb0059830e22621282bb#diff-9265e3b8114248ee4d2f8901e8ffdbcdR174) [fixed](https://github.com/android/platform_bionic/commit/c48c3e4bb3d1665f3e9fa2785daafa72dfe59399) in 5.1.  The regression likely wasn't noticed because [Android sends `stdout` and `stderr` to `/dev/null` by default, though you can configure it not to in debugging mode](http://developer.android.com/tools/debugging/debugging-log.html#viewingStd).

    I hit this issue in command-line binaries that call `writefln` and a couple unit tests in two modules, `std.stdio` and `std.socket`.  I have [a workaround that checks if the mutex is initialized and does so if it isn't](https://gist.github.com/joakim-noah/5c03801fa6c59b1e90df#file-phobos_ldc_arm-L591), but it's complicated by the fact that [the layout of bionic's `__sfileext`](https://github.com/android/platform_bionic/blob/master/libc/stdio/local.h#L109) changed [because `wchar_io_data` was expanded in 5.0](https://github.com/android/platform_bionic/commit/01ae00f3170ad0e36c1657f6ff8c89dfa730fd37#diff-dcae935a751b9c9ab2f68dc7396901d6R38).

    As a result, the workaround only works on 4.4 because it happens to pull some other word that is consistently non-zero initialized (not sure what, didn't look that deep).  While this has been tested and works on 4.4 onwards, it can't be relied upon because prior versions of bionic may not have had the same memory layout.  Perhaps it's best to punt on this issue, as most will not call `writefln`, or `flockfile` on `stdout`, on Android.