### PR TITLE
Fix Tid.toString().

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -339,6 +339,17 @@ public:
 
 }
 
+unittest
+{
+    import std.conv : text;
+    Tid tid;
+    assert(text(tid) == "Tid(0)");
+    auto tid2 = thisTid;
+    assert(text(tid2) != "Tid(0)");
+    auto tid3 = tid2;
+    assert(text(tid2) == text(tid3));
+}
+
 
 /**
  * Returns the caller's Tid.

--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -334,7 +334,7 @@ public:
     void toString(scope void delegate(const(char)[]) sink)
     {
         import std.format;
-        formattedWrite(sink, "Tid(%x)", &mbox);
+        formattedWrite(sink, "Tid(%x)", cast(void*)mbox);
     }
 
 }


### PR DESCRIPTION
The previous behavior generated a string that was different for every copy of the same Tid. With this change it outputs the address of the unique MessageBox instance instead.