### PR TITLE
fix problems that prevent implementing import shadowing protection

### DIFF
--- a/std/internal/digest/sha_SSSE3.d
+++ b/std/internal/digest/sha_SSSE3.d
@@ -228,7 +228,7 @@ version(USE_SSSE3)
             }
             if (i1 < seq1.length)
             {
-                res ~= seq1[i1..std.algorithm.min(i1+dist,$)];
+                res ~= seq1[i1..min(i1+dist,$)];
                 i1 += dist;
             }
         }

--- a/std/process.d
+++ b/std/process.d
@@ -1451,7 +1451,7 @@ void kill(Pid pid, int codeOrSignal)
     }
     else version (Posix)
     {
-        import core.sys.posix.signal;
+        import core.sys.posix.signal : kill;
         if (kill(pid.osHandle, codeOrSignal) == -1)
             throw ProcessException.newFromErrno();
     }

--- a/std/zip.d
+++ b/std/zip.d
@@ -283,7 +283,7 @@ final class ZipArchive
     import std.bitmanip : littleEndianToNative, nativeToLittleEndian;
     import std.algorithm : max;
     import std.conv : to;
-    import std.zlib : compress;
+    static import std.zlib;
     import std.datetime : DosFileTime;
 
     string comment;     /// Read/Write: the archive comment. Must be less than 65536 bytes in length.


### PR DESCRIPTION
Changing the language so that local imports no longer 'shadow' other symbols revealed some problems in Phobos, which this addresses.