### PR TITLE
Fix testAliasedString() unit test helper

### DIFF
--- a/std/string.d
+++ b/std/string.d
@@ -174,7 +174,18 @@ private:
 
     bool testAliasedString(alias func, Args...)(string s, Args args)
     {
-        return func(TestAliasedString(s), args) == func(s, args);
+        import std.algorithm.comparison : equal;
+        auto a = func(TestAliasedString(s), args);
+        auto b = func(s, args);
+        static if (is(typeof(equal(a, b))))
+        {
+            // For ranges, compare contents instead of object identity.
+            return equal(a, b);
+        }
+        else
+        {
+            return a == b;
+        }
     }
 }
 

--- a/std/uni.d
+++ b/std/uni.d
@@ -672,7 +672,18 @@ private:
 
     bool testAliasedString(alias func, Args...)(string s, Args args)
     {
-        return func(TestAliasedString(s), args) == func(s, args);
+        import std.algorithm.comparison : equal;
+        auto a = func(TestAliasedString(s), args);
+        auto b = func(s, args);
+        static if (is(typeof(equal(a, b))))
+        {
+            // For ranges, compare contents instead of object identity.
+            return equal(a, b);
+        }
+        else
+        {
+            return a == b;
+        }
     }
 }
 


### PR DESCRIPTION
Many of the functions for which this wrapper is used return
string ranges. Comparing these for object identity does not
make a lot of sense.

This is actually an issue, because toUTF, which is used in quite
a few of the tested functions, contains a void-initialized buffer,
so the identity comparison is not guaranteed to succeed. The tests
just so happen to pass on current DMD regardless, but this is not
the case for an optimized LDC build.