### PR TITLE
Fix Document of process.d with pipe

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -1500,6 +1500,7 @@ Data is written to one end of the _pipe and read from the other.
 ---
 auto p = pipe();
 p.writeEnd.writeln("Hello World");
+p.writeEnd.flush();
 assert (p.readEnd.readln().chomp() == "Hello World");
 ---
 Pipes can, for example, be used for interprocess communication


### PR DESCRIPTION
Current document says:
```d
auto p = pipe();
p.writeEnd.writeln("Hello World");
assert (p.readEnd.readln().chomp() == "Hello World");
```

This means that the buffer of `p.writeEnd` is yet to be flushed.
Therefore `p.readEnd.readln` can't recieve the input, for readln waits forever if the buffer is not flushed.
Then I fixed as follows:
```d
auto p = pipe();
p.writeEnd.writeln("Hello World");
p.writeEnd.flush();
assert (p.readEnd.readln().chomp() == "Hello World");
```