### PR TITLE
std.net.curl: _basicHTTP: use Appender

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -8,6 +8,9 @@ $(BUGSTITLE Library Changes,
 
 $(LI $(REF GCAllocator.goodAllocSize, std,experimental,allocator,gc_allocator)
 was added.)
+$(LI High-level API of $(STDMODREF net_curl, std.net.curl) now uses $(XREF array, Appender)
+for received content. Which generally makes all calls slightly faster. Up to 200ms for large
+amounts of data.)
 
 )
 

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -956,7 +956,8 @@ private auto _basicHTTP(T)(const(char)[] url, const(void)[] sendData, HTTP clien
     }
     client.url = url;
     HTTP.StatusLine statusLine;
-    ubyte[] content;
+    import std.array : appender;
+    auto content = appender!(ubyte[])();
     string[string] headers;
     client.onReceive = (ubyte[] data)
     {
@@ -994,6 +995,10 @@ private auto _basicHTTP(T)(const(char)[] url, const(void)[] sendData, HTTP clien
     client.onReceiveHeader = (in char[] key,
                               in char[] value)
     {
+        if (key == "content-length") {
+            import std.conv : to;
+            content.reserve(value.to!size_t);
+        }
         if (auto v = key in headers)
         {
             *v ~= ", ";
@@ -1019,7 +1024,7 @@ private auto _basicHTTP(T)(const(char)[] url, const(void)[] sendData, HTTP clien
         }
     }
 
-    return _decodeContent!T(content, charset);
+    return _decodeContent!T(content.data, charset);
 }
 
 unittest


### PR DESCRIPTION
Added use of `Appender` instead of plain `~=`. And call `reserve` on receive of "content-length" header.

It makes `get` slightly (50-200ms) faster for large files. Still quite [slower][0] than vibe.d's API.

[0]: http://forum.dlang.org/post/pwfstlnodtstqojcxlyz@forum.dlang.org