### PR TITLE
Issue 15695: wrong error message in failed conversion from string to int

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -2228,7 +2228,7 @@ body
     immutable uint beyond = (radix < 10 ? '0' : 'a'-10) + radix;
 
     Target v = 0;
-    size_t atStart = true;
+    bool atStart = true;
 
     for (; !s.empty; s.popFront())
     {

--- a/std/conv.d
+++ b/std/conv.d
@@ -1939,7 +1939,7 @@ Target parse(Target, Source)(ref Source s)
     }
     else
     {
-        // Larger than int types
+        // int or larger types
 
         static if (Target.min < 0)
             bool sign = 0;


### PR DESCRIPTION
Link: https://issues.dlang.org/show_bug.cgi?id=15695

The problem is that the parsing code advances the incoming range too eagerly, so that by the time the error message is constructed, the range has already advanced past the invalid character. Rewrote the code to only advance the range after it's sure that the character is valid.

Also, took the opportunity to fix some misleading comments and minor code issues leftover from who knows when.