### PR TITLE
Issue 15702: std.socket.Socket.receive can be @trusted only if buffer has no indirections

### DIFF
--- a/std/socket.d
+++ b/std/socket.d
@@ -51,6 +51,7 @@ import core.stdc.stdint, core.stdc.string, std.string, core.stdc.stdlib, std.con
 import core.stdc.config;
 import core.time : dur, Duration;
 import std.exception;
+import std.traits : hasIndirections;
 
 import std.internal.cstring;
 
@@ -2983,11 +2984,42 @@ public:
     /**
      * Receive data on the connection. If the socket is blocking, $(D receive)
      * waits until there is data to be received.
+     *
      * Returns: The number of bytes actually received, $(D 0) if the remote side
      * has closed the connection, or $(D Socket.ERROR) on failure.
+     *
+     * Prerequisites: Can only be called from `@safe` code if buffer elements
+     * do not contain indirections. If buffer elements contain indirections,
+     * can only be called from `@system` code.
      */
-    //returns number of bytes actually received, 0 on connection closure, or -1 on error
-    ptrdiff_t receive(void[] buf, SocketFlags flags) @trusted
+    ptrdiff_t receive(T)(T[] buf, SocketFlags flags) @trusted
+        if (!hasIndirections!T)
+    {
+        return receiveImpl(buf, flags);
+    }
+
+    /// ditto
+    ptrdiff_t receive(T)(T[] buf, SocketFlags flags) @system
+        if (hasIndirections!T)
+    {
+        return receiveImpl(buf, flags);
+    }
+
+    /// ditto
+    ptrdiff_t receive(T)(T[] buf) @trusted
+        if (!hasIndirections!T)
+    {
+        return receive(buf, SocketFlags.NONE);
+    }
+
+    /// ditto
+    ptrdiff_t receive(T)(T[] buf) @system
+        if (hasIndirections!T)
+    {
+        return receive(buf, SocketFlags.NONE);
+    }
+
+    private ptrdiff_t receiveImpl(void[] buf, SocketFlags flags) @system
     {
         version(Windows)         // Does not use size_t
         {
@@ -3001,10 +3033,19 @@ public:
         }
     }
 
-    /// ditto
-    ptrdiff_t receive(void[] buf)
+    unittest // issue 15702
     {
-        return receive(buf, SocketFlags.NONE);
+        int*[] ptrs = [ new int(1), new int(2), new int(3) ];
+
+        // @safe code cannot call .receive on an array containing indirections.
+        static assert(!__traits(compiles, (Socket sock) @safe {
+            sock.receive(ptrs);
+        }));
+
+        // But @system code can.
+        static assert( __traits(compiles, (Socket sock) @system {
+            sock.receive(ptrs);
+        }));
     }
 
     /**


### PR DESCRIPTION
Anything that receives `void[]` and writes to it cannot be considered `@trusted`, because passing in an array of element with indirections to, say, `std.socket.Socket.receive` will cause overwriting of pointers with arbitrary network data.

So rework the API not to throw away type information about the incoming array until we have checked whether it contains indirections. In order not to break code that needs to call `receive` on arrays with indirections, we still allow the call but it will be `@system` instead of `@trusted`. E.g., a multithreaded program that uses sockets to communicate between threads may be able to legitimately pass pointers via sockets. But since we cannot guarantee `@safe`-ty in this case, such calls to `receive` will be `@system`, and it's up to the user to verify that things work correctly and mark their own code as `@trusted` where applicable.