### PR TITLE
Fix import issues for std.format and std.stdio to remove deprecation messages

### DIFF
--- a/std/format.d
+++ b/std/format.d
@@ -1074,7 +1074,8 @@ struct FormatSpec(Char)
     //--------------------------------------------------------------------------
     private bool readUpToNextSpec(R)(ref R r)
     {
-        import std.ascii : isLower;
+        import std.ascii : isLower, isWhite;
+        import std.utf : stride;
 
         // Reset content
         if (__ctfe)
@@ -1120,8 +1121,8 @@ struct FormatSpec(Char)
             {
                 if (trailing.ptr[0] == ' ')
                 {
-                    while (!r.empty && std.ascii.isWhite(r.front)) r.popFront();
-                    //r = std.algorithm.find!(not!(std.ascii.isWhite))(r);
+                    while (!r.empty && isWhite(r.front)) r.popFront();
+                    //r = std.algorithm.find!(not!(isWhite))(r);
                 }
                 else
                 {
@@ -1131,7 +1132,7 @@ struct FormatSpec(Char)
                     if (r.front != trailing.front) break;
                     r.popFront();
                 }
-                trailing = trailing[std.utf.stride(trailing, 0) .. $];
+                trailing = trailing[stride(trailing, 0) .. $];
             }
         }
         return false;

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -1295,7 +1295,7 @@ Throws: $(D Exception) if the file is not opened.
             {
                 import std.format : formattedWrite;
 
-                std.format.formattedWrite(w, "%s", arg);
+                formattedWrite(w, "%s", arg);
             }
             else static if (isSomeString!A)
             {
@@ -1322,7 +1322,7 @@ Throws: $(D Exception) if the file is not opened.
                 import std.format : formattedWrite;
 
                 // Most general case
-                std.format.formattedWrite(w, "%s", arg);
+                formattedWrite(w, "%s", arg);
             }
         }
     }
@@ -1349,7 +1349,7 @@ Throws: $(D Exception) if the file is not opened.
     {
         import std.format : formattedWrite;
 
-        std.format.formattedWrite(lockingTextWriter(), fmt, args);
+        formattedWrite(lockingTextWriter(), fmt, args);
     }
 
 /**
@@ -1364,7 +1364,7 @@ Throws: $(D Exception) if the file is not opened.
         import std.format : formattedWrite;
 
         auto w = lockingTextWriter();
-        std.format.formattedWrite(w, fmt, args);
+        formattedWrite(w, fmt, args);
         w.put('\n');
     }
 
@@ -1842,7 +1842,7 @@ Allows to directly use range operations on lines of a file.
                     line = null;
                 }
                 else if (keepTerminator == KeepTerminator.no
-                        && std.algorithm.endsWith(line, terminator))
+                        && endsWith(line, terminator))
                 {
                     static if (isScalarType!Terminator)
                         enum tlen = 1;
@@ -1938,6 +1938,7 @@ the contents may well have changed).
 
     unittest
     {
+        static import std.file;
         auto deleteme = testFilename();
         std.file.write(deleteme, "hi");
         scope(success) std.file.remove(deleteme);
@@ -2214,6 +2215,7 @@ $(XREF file,readText)
 
     unittest
     {
+        static import std.file;
         auto deleteme = testFilename();
         std.file.write(deleteme, "hi");
         scope(success) std.file.remove(deleteme);
@@ -2565,7 +2567,7 @@ $(D Range) that locks the file and allows fast writing to it.
                     else
                     {
                         char[4] buf;
-                        auto b = std.utf.toUTF8(buf, c);
+                        auto b = toUTF8(buf, c);
                         foreach (i ; 0 .. b.length)
                             trustedFPUTC(b[i], handle_);
                     }
@@ -2588,7 +2590,7 @@ $(D Range) that locks the file and allows fast writing to it.
                     else
                     {
                         char[4] buf = void;
-                        auto b = std.utf.toUTF8(buf, c);
+                        auto b = toUTF8(buf, c);
                         foreach (i ; 0 .. b.length)
                             trustedFPUTC(b[i], handle_);
                     }
@@ -4472,6 +4474,7 @@ private size_t readlnImpl(FILE* fps, ref char[] buf, dchar terminator, File.Orie
 
 unittest
 {
+    static import std.file;
     auto deleteme = testFilename();
     scope(exit) std.file.remove(deleteme);
 


### PR DESCRIPTION
I'm doing this on 2 modules that came up first.

1. I don't want to do all of them, because it's a lot of mindless busy work, and if the way I'm doing it isn't acceptable, don't want to waste time.
2. I followed these 2 rules:
    a. In cases where we are selectively importing, and names wouldn't conflict, remove the FQN (not necessary anyway)
    b. In cases where the FQN is required (e.g. using std.file.write in std.stdio, where write is also defined), change import to static.

I found one case where a symbol was being used without being imported. So this new system is definitely finding legitimate bugs.

If this is acceptable, I'll work on the other deprecation messages.