### PR TITLE
Add travis to CI list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: d
+git:
+  depth: 1
+install:
+    - mkdir phobos
+    - ls -1 | grep -v ^phobos | xargs -I{} mv {} phobos
+    - git clone --depth=1 https://github.com/D-Programming-Language/dmd
+    - git clone --depth=1 https://github.com/D-Programming-Language/druntime
+script:
+    - (cd dmd && make -f posix.mak)
+    - (cd druntime && make -f posix.mak)
+    - (cd phobos && make -f posix.mak)
+    - (cd phobos && make -f posix.mak unittest)
+os:
+  - linux
+  - osx


### PR DESCRIPTION
Hi all,

Autotester is great and getting such a wide coverage with free tools is quite hard, however there are great tools like travis out there which run reliable and could assist your PR workflow.

It runs for every commit and PR _reliably_ the unittests on a Linux 64bit machine and on OSX. On every forced push it runs again, too. Everyone can immediately see/follow the _entire_ log.
It takes ~15min for both builds to complete.

You can see an example build here:

https://travis-ci.org/greenify/phobos/builds/111955286

I assume that you all are familiar with travis - it's probably the most popular ci service out there and has a lot of other features in case they might be needed.

PS: If you decide to merge this, don't forget to add travis to the hooks list.