### PR TITLE
SList and Dlist should be forward ranges

### DIFF
--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -304,6 +304,7 @@ Complexity: $(BIGOH n).
     {
         return DList(this[]);
     }
+    alias save = dup;
 
 /**
 Returns a range that iterates over all elements of the container, in
@@ -514,6 +515,7 @@ Complexity: $(BIGOH 1).
 
     /// ditto
     alias stableRemoveFront = removeFront;
+    alias popFront = removeFront;
 
     /// ditto
     void removeBack()
@@ -525,6 +527,7 @@ Complexity: $(BIGOH 1).
 
     /// ditto
     alias stableRemoveBack = removeBack;
+    alias popBack = removeBack;
 
 /**
 Removes $(D howMany) values at the front or back of the
@@ -943,4 +946,13 @@ private:
     auto a = DList!int();
     a.insertFront(iota(0, 5)); // can insert range with non-ref front
     assert(a.front == 0 && a.back == 4);
+}
+
+unittest
+{
+    import std.range;
+    // should be an input, forward and bidirectional range
+    assert(isInputRange!(DList!int));
+    assert(isForwardRange!(DList!int));
+    assert(isBidirectionalRange!(DList!int));
 }

--- a/std/container/slist.d
+++ b/std/container/slist.d
@@ -210,6 +210,7 @@ Complexity: $(BIGOH n).
     {
         return SList(this[]);
     }
+    alias save = dup;
 
 /**
 Returns a range that iterates over all elements of the container, in
@@ -373,6 +374,7 @@ Complexity: $(BIGOH 1).
 
     /// ditto
     alias stableRemoveFront = removeFront;
+    alias popFront = removeFront;
 
 /**
 Removes $(D howMany) values at the front or back of the
@@ -777,4 +779,12 @@ unittest
     // issue 15659
     SList!int s;
     s.clear();
+}
+
+unittest
+{
+    import std.range;
+    // should be an input and forward range
+    assert(isInputRange!(SList!int));
+    assert(isForwardRange!(SList!int));
 }


### PR DESCRIPTION
I was a bit shocked first when I realized that the primitives and therefore all related functions from std.algorithms don't work with SList/DList. 

There I propose to add a few aliases in order to stick the primitives and so that it can be used with other Phobos algorithms ;-)