### PR TITLE
add documentation example for DList

### DIFF
--- a/std/container/dlist.d
+++ b/std/container/dlist.d
@@ -20,6 +20,39 @@ Authors: Steven Schveighoffer, $(WEB erdani.com, Andrei Alexandrescu)
 */
 module std.container.dlist;
 
+///
+unittest
+{
+    import std.container: DList;
+    import std.algorithm: equal;
+
+    auto s = DList!int(1, 2, 3);
+    assert(equal(s[], [1, 2, 3]));
+
+    s.removeFront();
+    assert(equal(s[], [2, 3]));
+    s.removeBack();
+    assert(equal(s[], [2]));
+
+    s.insertFront([4, 5]);
+    assert(equal(s[], [4, 5, 2]));
+    s.insertBack([6, 7]);
+    assert(equal(s[], [4, 5, 2, 6, 7]));
+
+    // If you want to apply range operations, simply slice it.
+    import std.algorithm: countUntil;
+    import std.range: popFrontN, popBackN, walkLength;
+
+    auto sl = DList!int([1, 2, 3, 4, 5]);
+    assert(countUntil(sl[], 2) == 1);
+
+    auto r = sl[];
+    popFrontN(r, 2);
+    popBackN(r, 2);
+    assert(r.equal([3]));
+    assert(walkLength(r) == 1);
+}
+
 import std.range.primitives;
 import std.traits;
 


### PR DESCRIPTION
Like #4039 - here's an example for the documentation for DList.