### PR TITLE
convert docstring examples to unittests

### DIFF
--- a/std/internal/cstring.d
+++ b/std/internal/cstring.d
@@ -4,27 +4,6 @@ Helper functions for working with $(I C strings).
 This module is intended to provide fast, safe and garbage free
 way to work with $(I C strings).
 
-Example:
----
-version(Posix):
-
-import core.stdc.stdlib: free;
-import core.sys.posix.stdlib: setenv;
-import std.exception: enforce;
-
-void setEnvironment(in char[] name, in char[] value)
-{ enforce(setenv(name.tempCString(), value.tempCString(), 1) != -1); }
----
----
-version(Windows):
-
-import core.sys.windows.windows: SetEnvironmentVariableW;
-import std.exception: enforce;
-
-void setEnvironment(in char[] name, in char[] value)
-{ enforce(SetEnvironmentVariableW(name.tempCStringW(), value.tempCStringW())); }
----
-
 Copyright: Denis Shelomovskij 2013-2014
 
 License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
@@ -36,6 +15,28 @@ COREREF = $(HTTP dlang.org/phobos/core_$1.html#$2, $(D core.$1.$2))
 */
 module std.internal.cstring;
 
+///
+unittest
+{
+    version(Posix)
+    {
+        import core.stdc.stdlib: free;
+        import core.sys.posix.stdlib: setenv;
+        import std.exception: enforce;
+
+        void setEnvironment(in char[] name, in char[] value)
+        { enforce(setenv(name.tempCString(), value.tempCString(), 1) != -1); }
+    }
+
+    version(Windows)
+    {
+        import core.sys.windows.windows: SetEnvironmentVariableW;
+        import std.exception: enforce;
+
+        void setEnvironment(in char[] name, in char[] value)
+        { enforce(SetEnvironmentVariableW(name.tempCStringW(), value.tempCStringW())); }
+    }
+}
 
 import std.traits;
 import std.range;

--- a/std/string.d
+++ b/std/string.d
@@ -6228,30 +6228,6 @@ unittest
  * in one of a known set of strings, and the program will helpfully
  * autocomplete the string once sufficient characters have been
  * entered that uniquely identify it.
- * Example:
- * ---
- * import std.stdio;
- * import std.string;
- *
- * void main()
- * {
- *    static string[] list = [ "food", "foxy" ];
- *
- *    auto abbrevs = std.string.abbrev(list);
- *
- *    foreach (key, value; abbrevs)
- *    {
- *       writefln("%s => %s", key, value);
- *    }
- * }
- * ---
- * produces the output:
- * <pre>
- * fox =&gt; foxy
- * food =&gt; food
- * foxy =&gt; foxy
- * foo =&gt; food
- * </pre>
  */
 
 string[string] abbrev(string[] values) @safe pure
@@ -6302,6 +6278,18 @@ string[string] abbrev(string[] values) @safe pure
 
     return result;
 }
+
+///
+unittest
+{
+    import std.string;
+
+    static string[] list = [ "food", "foxy" ];
+    auto abbrevs = std.string.abbrev(list);
+    assert(abbrevs == ["fox": "foxy", "food": "food",
+                       "foxy": "foxy", "foo": "food"]);
+}
+
 
 @trusted pure unittest
 {

--- a/std/uuid.d
+++ b/std/uuid.d
@@ -75,27 +75,6 @@ $(TR $(TDNW UUID namespaces)
  * boost._uuid) from the Boost project with some minor additions and API
  * changes for a more D-like API.
  *
- * Example:
- * ------------------------
- * UUID[] ids;
- * ids ~= randomUUID();
- * ids ~= md5UUID("test.name.123");
- * ids ~= sha1UUID("test.name.123");
- *
- * foreach(entry; ids)
- * {
- *     assert(entry.variant == UUID.Variant.rfc4122);
- * }
- *
- * assert(ids[0].uuidVersion == UUID.Version.randomNumberBased);
- * assert(ids[1].toString() == "22390768-cced-325f-8f0f-cfeaa19d0ccd");
- * assert(ids[1].data == [34, 57, 7, 104, 204, 237, 50, 95, 143, 15, 207,
- *     234, 161, 157, 12, 205]);
- *
- * UUID id;
- * assert(id.empty);
- *
- * ------------------------
  * Standards:
  * $(LINK2 http://www.ietf.org/rfc/rfc4122.txt, RFC 4122)
  *
@@ -117,6 +96,28 @@ $(TR $(TDNW UUID namespaces)
  *          http://www.boost.org/LICENSE_1_0.txt)
  */
 module std.uuid;
+
+///
+unittest
+{
+    import std.uuid;
+
+    UUID[] ids;
+    ids ~= randomUUID();
+    ids ~= md5UUID("test.name.123");
+    ids ~= sha1UUID("test.name.123");
+
+    foreach(entry; ids)
+    {
+        assert(entry.variant == UUID.Variant.rfc4122);
+    }
+    assert(ids[0].uuidVersion == UUID.Version.randomNumberBased);
+    assert(ids[1].toString() == "22390768-cced-325f-8f0f-cfeaa19d0ccd");
+    assert(ids[1].data == [34, 57, 7, 104, 204, 237, 50, 95, 143, 15, 207,
+        234, 161, 157, 12, 205]);
+    UUID id;
+    assert(id.empty);
+}
 
 import std.range.primitives;
 import std.traits;
@@ -329,18 +330,6 @@ public struct UUID
          * hyphens exactly like above.
          *
          * For a less strict parser, see $(LREF parseUUID)
-         *
-         * Example:
-         * -------------------------
-         * id = UUID("8AB3060E-2cba-4f23-b74c-b52db3bdfb46");
-         * assert(id.data == [138, 179, 6, 14, 44, 186, 79, 35, 183, 76,
-         *    181, 45, 179, 189, 251, 70]);
-         * assert(id.toString() == "8ab3060e-2cba-4f23-b74c-b52db3bdfb46");
-         *
-         * //Can also be used in CTFE, for example as UUID literals:
-         * enum ctfeID = UUID("8ab3060e-2cba-4f23-b74c-b52db3bdfb46");
-         * //here parsing is done at compile time, no runtime overhead!
-         * -------------------------
          */
         this(T)(in T[] uuid) if(isSomeChar!(Unqual!T))
         {
@@ -396,6 +385,19 @@ public struct UUID
 
         Lerr: throw new UUIDParsingException(to!string(uuid), pos,
                 UUIDParsingException.Reason.invalidChar, "Couldn't parse ubyte");
+        }
+
+        ///
+        @safe pure unittest
+        {
+            auto id = UUID("8AB3060E-2cba-4f23-b74c-b52db3bdfb46");
+            assert(id.data == [138, 179, 6, 14, 44, 186, 79, 35, 183, 76,
+               181, 45, 179, 189, 251, 70]);
+            assert(id.toString() == "8ab3060e-2cba-4f23-b74c-b52db3bdfb46");
+
+            //Can also be used in CTFE, for example as UUID literals:
+            enum ctfeID = UUID("8ab3060e-2cba-4f23-b74c-b52db3bdfb46");
+            //here parsing is done at compile time, no runtime overhead!
         }
 
         @safe pure unittest


### PR DESCRIPTION
Inspired by #4039 I propose to go through all old modules and replace the examples in docstring with checked unittests.
The advantage is quite clear - it is possible to verify that the documentation is correct and up-to-date.

A quick regex yielded that there a 55 files affected:

```
107 ./datetime.d
45 ./xml.d
40 ./net/curl.d
25 ./experimental/logger/core.d
16 ./stdio.d
11 ./file.d
10 ./socket.d
10 ./parallelism.d
9 ./exception.d
7 ./regex/package.d
7 ./range/package.d
7 ./process.d
6 ./net/isemail.d
6 ./base64.d
5 ./uni.d
5 ./random.d
5 ./functional.d
5 ./concurrency.d
4 ./windows/registry.d
4 ./traits.d
4 ./conv.d
3 ./typecons.d
3 ./path.d
3 ./internal/scopebuffer.d
3 ./experimental/allocator/typed.d
3 ./encoding.d
3 ./digest/ripemd.d
3 ./digest/digest.d
2 ./zip.d
2 ./format.d
2 ./experimental/ndslice/slice.d
2 ./experimental/logger/filelogger.d
2 ./experimental/allocator/building_blocks/stats_collector.d
2 ./digest/md.d
2 ./bitmanip.d
2 ./algorithm/setops.d
1 ./windows/syserror.d
1 ./uuid.d
1 ./string.d
1 ./socketstream.d
1 ./signals.d
1 ./math.d
1 ./internal/cstring.d
1 ./experimental/ndslice/package.d
1 ./experimental/logger/multilogger.d
1 ./experimental/allocator/building_blocks/segregator.d
1 ./digest/sha.d
1 ./demangle.d
1 ./csv.d
1 ./container/slist.d
1 ./container/rbtree.d
1 ./array.d
1 ./algorithm/sorting.d
1 ./algorithm/searching.d
1 ./algorithm/package.d
```

I used this command - in case you want to reproduce it:

```
for f in $(find . -name '*.d'); do echo $(grep "Example:" $f | wc -l) "$f"; done | grep -v "^0" | sort -nr
```

Questions
--------------

I would be happy to start with this task and go through the modules - maybe I can even automate it.
So there are only two questions

1) If there is a global module example (like in this PR for uuid), currently the best thing is to add the unittest below the class and add the magic `\\\`. However this means that the example will be added to the class and not the module. How about using `\\\\` for module unittest examples?
Compare http://dlang.org/phobos/std_uuid.html and the [generated documentation](http://dtest.thecybershadow.net/artifact/website-66547297e837f5ceb74cec2700feb085437474fc-b760af82a03a2448dd4c56878a5a42fc/web/phobos-prerelease/std_uuid.html) for this PR.

2) How "okay" are you with this proposal?
It's a bit of work and it would feel like wasted time if this ends up non-merged.

I would split the PR in multiple parts, so that it's easier to review ;-)

PS/off-topic: Is anyone taking bets how many docstring examples don't work anymore? 