### PR TITLE
Examples to unittest [part 5]

### DIFF
--- a/std/uni.d
+++ b/std/uni.d
@@ -2094,20 +2094,21 @@ public:
 
     /**
         Get range that spans all of the $(CODEPOINT) intervals in this $(LREF InversionList).
+    */
+    @property auto byInterval()
+    {
+        return Intervals!(typeof(data))(data);
+    }
 
-        Example:
-        -----------
+    ///
+    unittest
+    {
         import std.algorithm.comparison : equal;
         import std.typecons : tuple;
 
         auto set = CodepointSet('A', 'D'+1, 'a', 'd'+1);
 
         assert(set.byInterval.equal([tuple('A','E'), tuple('a','e')]));
-        -----------
-    */
-    @property auto byInterval()
-    {
-        return Intervals!(typeof(data))(data);
     }
 
     /**


### PR DESCRIPTION
Last part of my sweep throught `std` for replaceable docstring unittests.

There is still one pattern that might be incorporated in the future - multiple examples with text between them, e.g.

-----------------------------------------------------

Some intro ....
.... Amazing module ....

```
assert(a == 1)
```

.... another use case ....

```
assert(a == 1)
```