### PR TITLE
convert docstring examples to unittests [datetime]

### DIFF
--- a/std/datetime.d
+++ b/std/datetime.d
@@ -17917,12 +17917,6 @@ Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1));
         Throws:
             $(LREF DateTimeException) if the resulting $(D end) is before
             $(D begin).
-
-        Example:
---------------------
-assert(Interval!Date(Date(1996, 1, 2), dur!"years"(3)) ==
-       Interval!Date(Date(1996, 1, 2), Date(1999, 1, 2)));
---------------------
       +/
     this(D)(in TP begin, in D duration) pure
         if(__traits(compiles, begin + duration))
@@ -17934,6 +17928,12 @@ assert(Interval!Date(Date(1996, 1, 2), dur!"years"(3)) ==
             throw new DateTimeException("Arguments would result in an invalid Interval.");
     }
 
+    ///
+    unittest
+    {
+        assert(Interval!Date(Date(1996, 1, 2), dur!"years"(3)) ==
+               Interval!Date(Date(1996, 1, 2), Date(1999, 1, 2)));
+    }
 
     /++
         Params:
@@ -17961,16 +17961,17 @@ assert(Interval!Date(Date(1996, 1, 2), dur!"years"(3)) ==
 
     /++
         The starting point of the interval. It is included in the interval.
-
-        Example:
---------------------
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).begin ==
-       Date(1996, 1, 2));
---------------------
       +/
     @property TP begin() const pure nothrow
     {
         return cast(TP)_begin;
+    }
+
+    ///
+    unittest
+    {
+    assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).begin ==
+           Date(1996, 1, 2));
     }
 
 
@@ -17994,16 +17995,17 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).begin ==
 
     /++
         The end point of the interval. It is excluded from the interval.
-
-        Example:
---------------------
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).end ==
-       Date(2012, 3, 1));
---------------------
       +/
     @property TP end() const pure nothrow
     {
         return cast(TP)_end;
+    }
+
+    ///
+    unittest
+    {
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).end ==
+               Date(2012, 3, 1));
     }
 
 
@@ -18027,33 +18029,34 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).end ==
 
     /++
         Returns the duration between $(D begin) and $(D end).
-
-        Example:
---------------------
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).length ==
-       dur!"days"(5903));
---------------------
       +/
     @property auto length() const pure nothrow
     {
         return _end - _begin;
     }
 
+    ///
+    unittest
+    {
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).length ==
+               dur!"days"(5903));
+    }
+
 
     /++
         Whether the interval's length is 0, that is, whether $(D begin == end).
-
-        Example:
---------------------
-assert(Interval!Date(Date(1996, 1, 2), Date(1996, 1, 2)).empty);
-assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).empty);
---------------------
       +/
     @property bool empty() const pure nothrow
     {
         return _begin == _end;
     }
 
+    ///
+    unittest
+    {
+        assert(Interval!Date(Date(1996, 1, 2), Date(1996, 1, 2)).empty);
+        assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).empty);
+    }
 
     /++
         Whether the given time point is within this interval.
@@ -18063,23 +18066,24 @@ assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).empty);
 
         Throws:
             $(LREF DateTimeException) if this interval is empty.
-
-        Example:
---------------------
-assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).contains(
-            Date(1994, 12, 24)));
-
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).contains(
-            Date(2000, 1, 5)));
-assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).contains(
-            Date(2012, 3, 1)));
---------------------
       +/
     bool contains(in TP timePoint) const pure
     {
         _enforceNotEmpty();
 
         return timePoint >= _begin && timePoint < _end;
+    }
+
+    ///
+    unittest
+    {
+        assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).contains(
+                    Date(1994, 12, 24)));
+
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).contains(
+                    Date(2000, 1, 5)));
+        assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).contains(
+                    Date(2012, 3, 1)));
     }
 
 
@@ -18091,18 +18095,6 @@ assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).contains(
 
         Throws:
             $(LREF DateTimeException) if either interval is empty.
-
-        Example:
---------------------
-assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).contains(
-            Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
-
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).contains(
-            Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))));
-
-assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).contains(
-            Interval!Date(Date(1998, 2, 28), Date(2013, 5, 1))));
---------------------
       +/
     bool contains(in Interval interval) const pure
     {
@@ -18114,6 +18106,18 @@ assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).contains(
                interval._end <= _end;
     }
 
+    ///
+    unittest
+    {
+        assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).contains(
+                    Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
+
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).contains(
+                    Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))));
+
+        assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).contains(
+                    Interval!Date(Date(1998, 2, 28), Date(2013, 5, 1))));
+    }
 
     /++
         Whether the given interval is completely within this interval.
@@ -18127,12 +18131,6 @@ assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).contains(
 
         Throws:
             $(LREF DateTimeException) if this interval is empty.
-
-        Example:
---------------------
-assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).contains(
-            PosInfInterval!Date(Date(1999, 5, 4))));
---------------------
       +/
     bool contains(in PosInfInterval!TP interval) const pure
     {
@@ -18141,6 +18139,12 @@ assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).contains(
         return false;
     }
 
+    ///
+    unittest
+    {
+        assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).contains(
+                    PosInfInterval!Date(Date(1999, 5, 4))));
+    }
 
     /++
         Whether the given interval is completely within this interval.
@@ -18154,12 +18158,6 @@ assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).contains(
 
         Throws:
             $(LREF DateTimeException) if this interval is empty.
-
-        Example:
---------------------
-assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).contains(
-            NegInfInterval!Date(Date(1996, 5, 4))));
---------------------
       +/
     bool contains(in NegInfInterval!TP interval) const pure
     {
@@ -18168,6 +18166,12 @@ assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).contains(
         return false;
     }
 
+    ///
+    unittest
+    {
+        assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).contains(
+                    NegInfInterval!Date(Date(1996, 5, 4))));
+    }
 
     /++
         Whether this interval is before the given time point.
@@ -18178,24 +18182,25 @@ assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).contains(
 
         Throws:
             $(LREF DateTimeException) if this interval is empty.
-
-        Example:
---------------------
-assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isBefore(
-            Date(1994, 12, 24)));
-
-assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isBefore(
-            Date(2000, 1, 5)));
-
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isBefore(
-            Date(2012, 3, 1)));
---------------------
       +/
     bool isBefore(in TP timePoint) const pure
     {
         _enforceNotEmpty();
 
         return _end <= timePoint;
+    }
+
+    ///
+    unittest
+    {
+        assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isBefore(
+                    Date(1994, 12, 24)));
+
+        assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isBefore(
+                    Date(2000, 1, 5)));
+
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isBefore(
+                    Date(2012, 3, 1)));
     }
 
 
@@ -18208,18 +18213,6 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isBefore(
 
         Throws:
             $(LREF DateTimeException) if either interval is empty.
-
-        Example:
---------------------
-assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isBefore(
-            Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
-
-assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isBefore(
-            Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))));
-
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isBefore(
-            Interval!Date(Date(2012, 3, 1), Date(2013, 5, 1))));
---------------------
       +/
     bool isBefore(in Interval interval) const pure
     {
@@ -18229,6 +18222,18 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isBefore(
         return _end <= interval._begin;
     }
 
+    ///
+    unittest
+    {
+        assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isBefore(
+                    Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
+
+        assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isBefore(
+                    Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))));
+
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isBefore(
+                    Interval!Date(Date(2012, 3, 1), Date(2013, 5, 1))));
+    }
 
     /++
         Whether this interval is before the given interval and does not
@@ -18239,15 +18244,6 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isBefore(
 
         Throws:
             $(LREF DateTimeException) if this interval is empty.
-
-        Example:
---------------------
-assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isBefore(
-            PosInfInterval!Date(Date(1999, 5, 4))));
-
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isBefore(
-            PosInfInterval!Date(Date(2013, 3, 7))));
---------------------
       +/
     bool isBefore(in PosInfInterval!TP interval) const pure
     {
@@ -18256,6 +18252,16 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isBefore(
         return _end <= interval._begin;
     }
 
+
+    ///
+    unittest
+    {
+        assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isBefore(
+                    PosInfInterval!Date(Date(1999, 5, 4))));
+
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isBefore(
+                    PosInfInterval!Date(Date(2013, 3, 7))));
+    }
 
     /++
         Whether this interval is before the given interval and does not
@@ -18269,12 +18275,6 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isBefore(
 
         Throws:
             $(LREF DateTimeException) if this interval is empty.
-
-        Example:
---------------------
-assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isBefore(
-            NegInfInterval!Date(Date(1996, 5, 4))));
---------------------
       +/
     bool isBefore(in NegInfInterval!TP interval) const pure
     {
@@ -18283,6 +18283,12 @@ assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isBefore(
         return false;
     }
 
+    ///
+    unittest
+    {
+        assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isBefore(
+                    NegInfInterval!Date(Date(1996, 5, 4))));
+    }
 
     /++
         Whether this interval is after the given time point.
@@ -18293,18 +18299,6 @@ assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isBefore(
 
         Throws:
             $(LREF DateTimeException) if this interval is empty.
-
-        Example:
---------------------
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAfter(
-            Date(1994, 12, 24)));
-
-assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAfter(
-            Date(2000, 1, 5)));
-
-assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAfter(
-            Date(2012, 3, 1)));
---------------------
       +/
     bool isAfter(in TP timePoint) const pure
     {
@@ -18313,6 +18307,18 @@ assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAfter(
         return timePoint < _begin;
     }
 
+    ///
+    unittest
+    {
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAfter(
+                    Date(1994, 12, 24)));
+
+        assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAfter(
+                    Date(2000, 1, 5)));
+
+        assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAfter(
+                    Date(2012, 3, 1)));
+    }
 
     /++
         Whether this interval is after the given interval and does not intersect
@@ -18323,18 +18329,6 @@ assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAfter(
 
         Throws:
             $(LREF DateTimeException) if either interval is empty.
-
-        Example:
---------------------
-assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAfter(
-            Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
-
-assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAfter(
-            Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))));
-
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAfter(
-            Interval!Date(Date(1989, 3, 1), Date(1996, 1, 2))));
---------------------
       +/
     bool isAfter(in Interval interval) const pure
     {
@@ -18344,6 +18338,18 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAfter(
         return _begin >= interval._end;
     }
 
+    ///
+    unittest
+    {
+        assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAfter(
+                    Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
+
+        assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAfter(
+                    Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))));
+
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAfter(
+                    Interval!Date(Date(1989, 3, 1), Date(1996, 1, 2))));
+    }
 
     /++
         Whether this interval is after the given interval and does not intersect
@@ -18357,12 +18363,6 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAfter(
 
         Throws:
             $(LREF DateTimeException) if this interval is empty.
-
-        Example:
---------------------
-assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAfter(
-            PosInfInterval!Date(Date(1999, 5, 4))));
---------------------
       +/
     bool isAfter(in PosInfInterval!TP interval) const pure
     {
@@ -18371,6 +18371,13 @@ assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAfter(
         return false;
     }
 
+
+    ///
+    unittest
+    {
+        assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAfter(
+                    PosInfInterval!Date(Date(1999, 5, 4))));
+    }
 
     /++
         Whether this interval is after the given interval and does not intersect
@@ -18381,12 +18388,6 @@ assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAfter(
 
         Throws:
             $(LREF DateTimeException) if this interval is empty.
-
-        Example:
---------------------
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAfter(
-            NegInfInterval!Date(Date(1996, 1, 2))));
---------------------
       +/
     bool isAfter(in NegInfInterval!TP interval) const pure
     {
@@ -18395,6 +18396,12 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAfter(
         return _begin >= interval._end;
     }
 
+    ///
+    unittest
+    {
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAfter(
+                    NegInfInterval!Date(Date(1996, 1, 2))));
+    }
 
     /++
         Whether the given interval overlaps this interval.
@@ -18404,18 +18411,6 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAfter(
 
         Throws:
             $(LREF DateTimeException) if either interval is empty.
-
-        Example:
---------------------
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersects(
-            Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
-
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersects(
-            Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))));
-
-assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersects(
-            Interval!Date(Date(1989, 3, 1), Date(1996, 1, 2))));
---------------------
       +/
     bool intersects(in Interval interval) const pure
     {
@@ -18425,6 +18420,19 @@ assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersects(
         return interval._begin < _end && interval._end > _begin;
     }
 
+    ///
+    unittest
+    {
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersects(
+                    Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
+
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersects(
+                    Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))));
+
+        assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersects(
+                    Interval!Date(Date(1989, 3, 1), Date(1996, 1, 2))));
+    }
+
 
     /++
         Whether the given interval overlaps this interval.
@@ -18434,15 +18442,6 @@ assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersects(
 
         Throws:
             $(LREF DateTimeException) if this interval is empty.
-
-        Example:
---------------------
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersects(
-            PosInfInterval!Date(Date(1999, 5, 4))));
-
-assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersects(
-            PosInfInterval!Date(Date(2012, 3, 1))));
---------------------
       +/
     bool intersects(in PosInfInterval!TP interval) const pure
     {
@@ -18451,6 +18450,15 @@ assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersects(
         return _end > interval._begin;
     }
 
+    ///
+    unittest
+    {
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersects(
+                    PosInfInterval!Date(Date(1999, 5, 4))));
+
+        assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersects(
+                    PosInfInterval!Date(Date(2012, 3, 1))));
+    }
 
     /++
         Whether the given interval overlaps this interval.
@@ -18460,15 +18468,6 @@ assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersects(
 
         Throws:
             $(LREF DateTimeException) if this interval is empty.
-
-        Example:
---------------------
-assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersects(
-            NegInfInterval!Date(Date(1996, 1, 2))));
-
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersects(
-            NegInfInterval!Date(Date(2000, 1, 2))));
---------------------
       +/
     bool intersects(in NegInfInterval!TP interval) const pure
     {
@@ -18477,6 +18476,15 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersects(
         return _begin < interval._end;
     }
 
+    ///
+    unittest
+    {
+        assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersects(
+                    NegInfInterval!Date(Date(1996, 1, 2))));
+
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersects(
+                    NegInfInterval!Date(Date(2000, 1, 2))));
+    }
 
     /++
         Returns the intersection of two intervals
@@ -18487,17 +18495,6 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersects(
         Throws:
             $(LREF DateTimeException) if the two intervals do not intersect or if
             either interval is empty.
-
-        Example:
---------------------
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersection(
-            Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))) ==
-       Interval!Date(Date(1996, 1 , 2), Date(2000, 8, 2)));
-
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersection(
-            Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))) ==
-       Interval!Date(Date(1999, 1 , 12), Date(2011, 9, 17)));
---------------------
       +/
     Interval intersection(in Interval interval) const
     {
@@ -18511,6 +18508,17 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersection(
         return Interval(begin, end);
     }
 
+    ///
+    unittest
+    {
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersection(
+                    Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))) ==
+               Interval!Date(Date(1996, 1 , 2), Date(2000, 8, 2)));
+
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersection(
+                    Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))) ==
+               Interval!Date(Date(1999, 1 , 12), Date(2011, 9, 17)));
+    }
 
     /++
         Returns the intersection of two intervals
@@ -18521,17 +18529,6 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersection(
         Throws:
             $(LREF DateTimeException) if the two intervals do not intersect or if
             this interval is empty.
-
-        Example:
---------------------
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersection(
-            PosInfInterval!Date(Date(1990, 7, 6))) ==
-       Interval!Date(Date(1996, 1 , 2), Date(2012, 3, 1)));
-
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersection(
-            PosInfInterval!Date(Date(1999, 1, 12))) ==
-       Interval!Date(Date(1999, 1 , 12), Date(2012, 3, 1)));
---------------------
       +/
     Interval intersection(in PosInfInterval!TP interval) const
     {
@@ -18542,6 +18539,17 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersection(
         return Interval(_begin > interval._begin ? _begin : interval._begin, _end);
     }
 
+    ///
+    unittest
+    {
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersection(
+                    PosInfInterval!Date(Date(1990, 7, 6))) ==
+               Interval!Date(Date(1996, 1 , 2), Date(2012, 3, 1)));
+
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersection(
+                    PosInfInterval!Date(Date(1999, 1, 12))) ==
+               Interval!Date(Date(1999, 1 , 12), Date(2012, 3, 1)));
+    }
 
     /++
         Returns the intersection of two intervals
@@ -18552,17 +18560,6 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersection(
         Throws:
             $(LREF DateTimeException) if the two intervals do not intersect or if
             this interval is empty.
-
-        Example:
---------------------
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersection(
-            NegInfInterval!Date(Date(1999, 7, 6))) ==
-       Interval!Date(Date(1996, 1 , 2), Date(1999, 7, 6)));
-
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersection(
-            NegInfInterval!Date(Date(2013, 1, 12))) ==
-       Interval!Date(Date(1996, 1 , 2), Date(2012, 3, 1)));
---------------------
       +/
     Interval intersection(in NegInfInterval!TP interval) const
     {
@@ -18573,6 +18570,17 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersection(
         return Interval(_begin, _end < interval._end ? _end : interval._end);
     }
 
+    ///
+    unittest
+    {
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersection(
+                    NegInfInterval!Date(Date(1999, 7, 6))) ==
+               Interval!Date(Date(1996, 1 , 2), Date(1999, 7, 6)));
+
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersection(
+                    NegInfInterval!Date(Date(2013, 1, 12))) ==
+               Interval!Date(Date(1996, 1 , 2), Date(2012, 3, 1)));
+    }
 
     /++
         Whether the given interval is adjacent to this interval.
@@ -18583,18 +18591,6 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersection(
 
         Throws:
             $(LREF DateTimeException) if either interval is empty.
-
-        Example:
---------------------
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAdjacent(
-            Interval!Date(Date(1990, 7, 6), Date(1996, 1, 2))));
-
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAdjacent(
-            Interval!Date(Date(2012, 3, 1), Date(2013, 9, 17))));
-
-assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAdjacent(
-            Interval!Date(Date(1989, 3, 1), Date(2012, 3, 1))));
---------------------
       +/
     bool isAdjacent(in Interval interval) const pure
     {
@@ -18604,6 +18600,18 @@ assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAdjacent(
         return _begin == interval._end || _end == interval._begin;
     }
 
+    ///
+    unittest
+    {
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAdjacent(
+                    Interval!Date(Date(1990, 7, 6), Date(1996, 1, 2))));
+
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAdjacent(
+                    Interval!Date(Date(2012, 3, 1), Date(2013, 9, 17))));
+
+        assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAdjacent(
+                    Interval!Date(Date(1989, 3, 1), Date(2012, 3, 1))));
+    }
 
     /++
         Whether the given interval is adjacent to this interval.
@@ -18614,15 +18622,6 @@ assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAdjacent(
 
         Throws:
             $(LREF DateTimeException) if this interval is empty.
-
-        Example:
---------------------
-assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAdjacent(
-            PosInfInterval!Date(Date(1999, 5, 4))));
-
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAdjacent(
-            PosInfInterval!Date(Date(2012, 3, 1))));
---------------------
       +/
     bool isAdjacent(in PosInfInterval!TP interval) const pure
     {
@@ -18631,6 +18630,15 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAdjacent(
         return _end == interval._begin;
     }
 
+    ///
+    unittest
+    {
+        assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAdjacent(
+                    PosInfInterval!Date(Date(1999, 5, 4))));
+
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAdjacent(
+                    PosInfInterval!Date(Date(2012, 3, 1))));
+    }
 
     /++
         Whether the given interval is adjacent to this interval.
@@ -18641,15 +18649,6 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAdjacent(
 
         Throws:
             $(LREF DateTimeException) if this interval is empty.
-
-        Example:
---------------------
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAdjacent(
-            NegInfInterval!Date(Date(1996, 1, 2))));
-
-assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAdjacent(
-            NegInfInterval!Date(Date(2000, 1, 2))));
---------------------
       +/
     bool isAdjacent(in NegInfInterval!TP interval) const pure
     {
@@ -18658,6 +18657,15 @@ assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAdjacent(
         return _begin == interval._end;
     }
 
+    ///
+    unittest
+    {
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAdjacent(
+                    NegInfInterval!Date(Date(1996, 1, 2))));
+
+        assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAdjacent(
+                    NegInfInterval!Date(Date(2000, 1, 2))));
+    }
 
     /++
         Returns the union of two intervals
@@ -18668,17 +18676,6 @@ assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).isAdjacent(
         Throws:
             $(LREF DateTimeException) if the two intervals do not intersect and are
             not adjacent or if either interval is empty.
-
-        Example:
---------------------
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).merge(
-            Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))) ==
-       Interval!Date(Date(1990, 7 , 6), Date(2012, 3, 1)));
-
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).merge(
-            Interval!Date(Date(2012, 3, 1), Date(2013, 5, 7))) ==
-       Interval!Date(Date(1996, 1 , 2), Date(2013, 5, 7)));
---------------------
       +/
     Interval merge(in Interval interval) const
     {
@@ -18693,6 +18690,17 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).merge(
         return Interval(begin, end);
     }
 
+    ///
+    unittest
+    {
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).merge(
+                    Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))) ==
+               Interval!Date(Date(1990, 7 , 6), Date(2012, 3, 1)));
+
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).merge(
+                    Interval!Date(Date(2012, 3, 1), Date(2013, 5, 7))) ==
+               Interval!Date(Date(1996, 1 , 2), Date(2013, 5, 7)));
+    }
 
     /++
         Returns the union of two intervals
@@ -18703,17 +18711,6 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).merge(
         Throws:
             $(LREF DateTimeException) if the two intervals do not intersect and are
             not adjacent or if this interval is empty.
-
-        Example:
---------------------
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).merge(
-            PosInfInterval!Date(Date(1990, 7, 6))) ==
-       PosInfInterval!Date(Date(1990, 7 , 6)));
-
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).merge(
-            PosInfInterval!Date(Date(2012, 3, 1))) ==
-       PosInfInterval!Date(Date(1996, 1 , 2)));
---------------------
       +/
     PosInfInterval!TP merge(in PosInfInterval!TP interval) const
     {
@@ -18725,6 +18722,17 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).merge(
         return PosInfInterval!TP(_begin < interval._begin ? _begin : interval._begin);
     }
 
+    ///
+    unittest
+    {
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).merge(
+                    PosInfInterval!Date(Date(1990, 7, 6))) ==
+               PosInfInterval!Date(Date(1990, 7 , 6)));
+
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).merge(
+                    PosInfInterval!Date(Date(2012, 3, 1))) ==
+               PosInfInterval!Date(Date(1996, 1 , 2)));
+    }
 
     /++
         Returns the union of two intervals
@@ -18735,17 +18743,6 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).merge(
         Throws:
             $(LREF DateTimeException) if the two intervals do not intersect and are not
             adjacent or if this interval is empty.
-
-        Example:
---------------------
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).merge(
-            NegInfInterval!Date(Date(1996, 1, 2))) ==
-       NegInfInterval!Date(Date(2012, 3 , 1)));
-
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).merge(
-            NegInfInterval!Date(Date(2013, 1, 12))) ==
-       NegInfInterval!Date(Date(2013, 1 , 12)));
---------------------
       +/
     NegInfInterval!TP merge(in NegInfInterval!TP interval) const
     {
@@ -18757,6 +18754,17 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).merge(
         return NegInfInterval!TP(_end > interval._end ? _end : interval._end);
     }
 
+    ///
+    unittest
+    {
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).merge(
+                    NegInfInterval!Date(Date(1996, 1, 2))) ==
+               NegInfInterval!Date(Date(2012, 3 , 1)));
+
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).merge(
+                    NegInfInterval!Date(Date(2013, 1, 12))) ==
+               NegInfInterval!Date(Date(2013, 1 , 12)));
+    }
 
     /++
         Returns an interval that covers from the earliest time point of two
@@ -18768,17 +18776,6 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).merge(
 
         Throws:
             $(LREF DateTimeException) if either interval is empty.
-
-        Example:
---------------------
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).span(
-            Interval!Date(Date(1990, 7, 6), Date(1991, 1, 8))) ==
-       Interval!Date(Date(1990, 7 , 6), Date(2012, 3, 1)));
-
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).span(
-            Interval!Date(Date(2012, 3, 1), Date(2013, 5, 7))) ==
-       Interval!Date(Date(1996, 1 , 2), Date(2013, 5, 7)));
---------------------
       +/
     Interval span(in Interval interval) const pure
     {
@@ -18791,6 +18788,18 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).span(
         return Interval(begin, end);
     }
 
+    ///
+    unittest
+    {
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).span(
+                    Interval!Date(Date(1990, 7, 6), Date(1991, 1, 8))) ==
+               Interval!Date(Date(1990, 7 , 6), Date(2012, 3, 1)));
+
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).span(
+                    Interval!Date(Date(2012, 3, 1), Date(2013, 5, 7))) ==
+               Interval!Date(Date(1996, 1 , 2), Date(2013, 5, 7)));
+    }
+
 
     /++
         Returns an interval that covers from the earliest time point of two
@@ -18802,17 +18811,6 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).span(
 
         Throws:
             $(LREF DateTimeException) if this interval is empty.
-
-        Example:
---------------------
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).span(
-            PosInfInterval!Date(Date(1990, 7, 6))) ==
-       PosInfInterval!Date(Date(1990, 7 , 6)));
-
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).span(
-            PosInfInterval!Date(Date(2050, 1, 1))) ==
-       PosInfInterval!Date(Date(1996, 1 , 2)));
---------------------
       +/
     PosInfInterval!TP span(in PosInfInterval!TP interval) const pure
     {
@@ -18821,6 +18819,17 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).span(
         return PosInfInterval!TP(_begin < interval._begin ? _begin : interval._begin);
     }
 
+    ///
+    unittest
+    {
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).span(
+                    PosInfInterval!Date(Date(1990, 7, 6))) ==
+               PosInfInterval!Date(Date(1990, 7 , 6)));
+
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).span(
+                    PosInfInterval!Date(Date(2050, 1, 1))) ==
+               PosInfInterval!Date(Date(1996, 1 , 2)));
+    }
 
     /++
         Returns an interval that covers from the earliest time point of two
@@ -18832,17 +18841,6 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).span(
 
         Throws:
             $(LREF DateTimeException) if this interval is empty.
-
-        Example:
---------------------
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).span(
-            NegInfInterval!Date(Date(1602, 5, 21))) ==
-       NegInfInterval!Date(Date(2012, 3 , 1)));
-
-assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).span(
-            NegInfInterval!Date(Date(2013, 1, 12))) ==
-       NegInfInterval!Date(Date(2013, 1 , 12)));
---------------------
       +/
     NegInfInterval!TP span(in NegInfInterval!TP interval) const pure
     {
@@ -18851,6 +18849,17 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).span(
         return NegInfInterval!TP(_end > interval._end ? _end : interval._end);
     }
 
+    ///
+    unittest
+    {
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).span(
+                    NegInfInterval!Date(Date(1602, 5, 21))) ==
+               NegInfInterval!Date(Date(2012, 3 , 1)));
+
+        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).span(
+                    NegInfInterval!Date(Date(2013, 1, 12))) ==
+               NegInfInterval!Date(Date(2013, 1 , 12)));
+    }
 
     /++
         Shifts the interval forward or backwards in time by the given duration
@@ -18864,18 +18873,6 @@ assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).span(
         Throws:
             $(LREF DateTimeException) this interval is empty or if the resulting
             interval would be invalid.
-
-        Example:
---------------------
-auto interval1 = Interval!Date(Date(1996, 1, 2), Date(2012, 4, 5));
-auto interval2 = Interval!Date(Date(1996, 1, 2), Date(2012, 4, 5));
-
-interval1.shift(dur!"days"(50));
-assert(interval1 == Interval!Date(Date(1996, 2, 21), Date(2012, 5, 25)));
-
-interval2.shift(dur!"days"(-50));
-assert(interval2 == Interval!Date(Date(1995, 11, 13), Date(2012, 2, 15)));
---------------------
       +/
     void shift(D)(D duration) pure
         if(__traits(compiles, begin + duration))
@@ -18892,6 +18889,18 @@ assert(interval2 == Interval!Date(Date(1995, 11, 13), Date(2012, 2, 15)));
         _end = end;
     }
 
+    ///
+    unittest
+    {
+        auto interval1 = Interval!Date(Date(1996, 1, 2), Date(2012, 4, 5));
+        auto interval2 = Interval!Date(Date(1996, 1, 2), Date(2012, 4, 5));
+
+        interval1.shift(dur!"days"(50));
+        assert(interval1 == Interval!Date(Date(1996, 2, 21), Date(2012, 5, 25)));
+
+        interval2.shift(dur!"days"(-50));
+        assert(interval2 == Interval!Date(Date(1995, 11, 13), Date(2012, 2, 15)));
+    }
 
     static if(__traits(compiles, begin.add!"months"(1)) &&
               __traits(compiles, begin.add!"years"(1)))
@@ -18914,18 +18923,6 @@ assert(interval2 == Interval!Date(Date(1995, 11, 13), Date(2012, 2, 15)));
             Throws:
                 $(LREF DateTimeException) if this interval is empty or if the
                 resulting interval would be invalid.
-
-            Example:
---------------------
-auto interval1 = Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1));
-auto interval2 = Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1));
-
-interval1.shift(2);
-assert(interval1 == Interval!Date(Date(1998, 1, 2), Date(2014, 3, 1)));
-
-interval2.shift(-2);
-assert(interval2 == Interval!Date(Date(1994, 1, 2), Date(2010, 3, 1)));
---------------------
           +/
         void shift(T)(T years, T months = 0, AllowDayOverflow allowOverflow = AllowDayOverflow.yes)
             if(isIntegral!T)
@@ -18945,6 +18942,20 @@ assert(interval2 == Interval!Date(Date(1994, 1, 2), Date(2010, 3, 1)));
             _begin = begin;
             _end = end;
         }
+
+        ///
+        unittest
+        {
+            auto interval1 = Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1));
+            auto interval2 = Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1));
+
+            interval1.shift(2);
+            assert(interval1 == Interval!Date(Date(1998, 1, 2), Date(2014, 3, 1)));
+
+            interval2.shift(-2);
+            assert(interval2 == Interval!Date(Date(1994, 1, 2), Date(2010, 3, 1)));
+        }
+
     }
 
 
@@ -18961,18 +18972,6 @@ assert(interval2 == Interval!Date(Date(1994, 1, 2), Date(2010, 3, 1)));
         Throws:
             $(LREF DateTimeException) this interval is empty or if the resulting
             interval would be invalid.
-
-        Example:
---------------------
-auto interval1 = Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1));
-auto interval2 = Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1));
-
-interval1.expand(2);
-assert(interval1 == Interval!Date(Date(1994, 1, 2), Date(2014, 3, 1)));
-
-interval2.expand(-2);
-assert(interval2 == Interval!Date(Date(1998, 1, 2), Date(2010, 3, 1)));
---------------------
       +/
     void expand(D)(D duration, Direction dir = Direction.both) pure
         if(__traits(compiles, begin + duration))
@@ -19019,6 +19018,20 @@ assert(interval2 == Interval!Date(Date(1998, 1, 2), Date(2010, 3, 1)));
         }
     }
 
+    ///
+    unittest
+    {
+        auto interval1 = Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1));
+        auto interval2 = Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1));
+
+        interval1.expand(2);
+        assert(interval1 == Interval!Date(Date(1994, 1, 2), Date(2014, 3, 1)));
+
+        interval2.expand(-2);
+        assert(interval2 == Interval!Date(Date(1998, 1, 2), Date(2010, 3, 1)));
+    }
+
+
     static if(__traits(compiles, begin.add!"months"(1)) &&
               __traits(compiles, begin.add!"years"(1)))
     {
@@ -19039,18 +19052,6 @@ assert(interval2 == Interval!Date(Date(1998, 1, 2), Date(2010, 3, 1)));
             Throws:
                 $(LREF DateTimeException) if this interval is empty or if the
                 resulting interval would be invalid.
-
-            Example:
---------------------
-auto interval1 = Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1));
-auto interval2 = Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1));
-
-interval1.expand(2);
-assert(interval1 == Interval!Date(Date(1994, 1, 2), Date(2014, 3, 1)));
-
-interval2.expand(-2);
-assert(interval2 == Interval!Date(Date(1998, 1, 2), Date(2010, 3, 1)));
---------------------
           +/
         void expand(T)(T years, T months = 0, AllowDayOverflow allowOverflow = AllowDayOverflow.yes, Direction dir = Direction.both)
             if(isIntegral!T)
@@ -19103,6 +19104,19 @@ assert(interval2 == Interval!Date(Date(1998, 1, 2), Date(2010, 3, 1)));
                     assert(0, "Invalid Direction.");
             }
         }
+
+        ///
+        unittest
+        {
+            auto interval1 = Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1));
+            auto interval2 = Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1));
+
+            interval1.expand(2);
+            assert(interval1 == Interval!Date(Date(1994, 1, 2), Date(2014, 3, 1)));
+
+            interval2.expand(-2);
+            assert(interval2 == Interval!Date(Date(1998, 1, 2), Date(2010, 3, 1)));
+        }
     }
 
 
@@ -19154,37 +19168,6 @@ assert(interval2 == Interval!Date(Date(1998, 1, 2), Date(2010, 3, 1)));
 
             Of course, none of the functions in this module have this problem,
             so it's only relevant if when creating a custom delegate.
-
-        Example:
---------------------
-auto interval = Interval!Date(Date(2010, 9, 1), Date(2010, 9, 9));
-auto func = (in Date date) //For iterating over even-numbered days.
-            {
-                if((date.day & 1) == 0)
-                    return date + dur!"days"(2);
-
-                return date + dur!"days"(1);
-            };
-auto range = interval.fwdRange(func);
-
- //An odd day. Using PopFirst.yes would have made this Date(2010, 9, 2).
-assert(range.front == Date(2010, 9, 1));
-
-range.popFront();
-assert(range.front == Date(2010, 9, 2));
-
-range.popFront();
-assert(range.front == Date(2010, 9, 4));
-
-range.popFront();
-assert(range.front == Date(2010, 9, 6));
-
-range.popFront();
-assert(range.front == Date(2010, 9, 8));
-
-range.popFront();
-assert(range.empty);
---------------------
       +/
     IntervalRange!(TP, Direction.fwd) fwdRange(TP delegate(in TP) func, PopFirst popFirst = PopFirst.no) const
     {
@@ -19198,6 +19181,37 @@ assert(range.empty);
         return range;
     }
 
+    ///
+    unittest
+    {
+        auto interval = Interval!Date(Date(2010, 9, 1), Date(2010, 9, 9));
+        auto func = (in Date date) //For iterating over even-numbered days.
+                    {
+                        if((date.day & 1) == 0)
+                            return date + dur!"days"(2);
+
+                        return date + dur!"days"(1);
+                    };
+        auto range = interval.fwdRange(func);
+
+         //An odd day. Using PopFirst.yes would have made this Date(2010, 9, 2).
+        assert(range.front == Date(2010, 9, 1));
+
+        range.popFront();
+        assert(range.front == Date(2010, 9, 2));
+
+        range.popFront();
+        assert(range.front == Date(2010, 9, 4));
+
+        range.popFront();
+        assert(range.front == Date(2010, 9, 6));
+
+        range.popFront();
+        assert(range.front == Date(2010, 9, 8));
+
+        range.popFront();
+        assert(range.empty);
+    }
 
     /++
         Returns a range which iterates backwards over the interval, starting
@@ -19247,37 +19261,6 @@ assert(range.empty);
 
             Of course, none of the functions in this module have this problem,
             so it's only relevant for custom delegates.
-
-        Example:
---------------------
-auto interval = Interval!Date(Date(2010, 9, 1), Date(2010, 9, 9));
-auto func = (in Date date) //For iterating over even-numbered days.
-            {
-                if((date.day & 1) == 0)
-                    return date - dur!"days"(2);
-
-                return date - dur!"days"(1);
-            };
-auto range = interval.bwdRange(func);
-
-//An odd day. Using PopFirst.yes would have made this Date(2010, 9, 8).
-assert(range.front == Date(2010, 9, 9));
-
-range.popFront();
-assert(range.front == Date(2010, 9, 8));
-
-range.popFront();
-assert(range.front == Date(2010, 9, 6));
-
-range.popFront();
-assert(range.front == Date(2010, 9, 4));
-
-range.popFront();
-assert(range.front == Date(2010, 9, 2));
-
-range.popFront();
-assert(range.empty);
---------------------
       +/
     IntervalRange!(TP, Direction.bwd) bwdRange(TP delegate(in TP) func, PopFirst popFirst = PopFirst.no) const
     {
@@ -19291,6 +19274,37 @@ assert(range.empty);
         return range;
     }
 
+    ///
+    unittest
+    {
+        auto interval = Interval!Date(Date(2010, 9, 1), Date(2010, 9, 9));
+        auto func = (in Date date) //For iterating over even-numbered days.
+                    {
+                        if((date.day & 1) == 0)
+                            return date - dur!"days"(2);
+
+                        return date - dur!"days"(1);
+                    };
+        auto range = interval.bwdRange(func);
+
+        //An odd day. Using PopFirst.yes would have made this Date(2010, 9, 8).
+        assert(range.front == Date(2010, 9, 9));
+
+        range.popFront();
+        assert(range.front == Date(2010, 9, 8));
+
+        range.popFront();
+        assert(range.front == Date(2010, 9, 6));
+
+        range.popFront();
+        assert(range.front == Date(2010, 9, 4));
+
+        range.popFront();
+        assert(range.front == Date(2010, 9, 2));
+
+        range.popFront();
+        assert(range.empty);
+    }
 
     /+
         Converts this interval to a string.
@@ -20834,15 +20848,16 @@ auto interval = PosInfInterval!Date(Date(1996, 1, 2));
 
     /++
         The starting point of the interval. It is included in the interval.
-
-        Example:
---------------------
-assert(PosInfInterval!Date(Date(1996, 1, 2)).begin == Date(1996, 1, 2));
---------------------
       +/
     @property TP begin() const pure nothrow
     {
         return cast(TP)_begin;
+    }
+
+    ///
+    unittest
+    {
+        assert(PosInfInterval!Date(Date(1996, 1, 2)).begin == Date(1996, 1, 2));
     }
 
 
@@ -20860,35 +20875,35 @@ assert(PosInfInterval!Date(Date(1996, 1, 2)).begin == Date(1996, 1, 2));
 
     /++
         Whether the interval's length is 0. Always returns false.
-
-        Example:
---------------------
-assert(!PosInfInterval!Date(Date(1996, 1, 2)).empty);
---------------------
       +/
     @property bool empty() const pure nothrow
     {
         return false;
     }
 
+    ///
+    unittest
+    {
+        assert(!PosInfInterval!Date(Date(1996, 1, 2)).empty);
+    }
 
     /++
         Whether the given time point is within this interval.
 
         Params:
             timePoint = The time point to check for inclusion in this interval.
-
-        Example:
---------------------
-assert(!PosInfInterval!Date(Date(1996, 1, 2)).contains(Date(1994, 12, 24)));
-assert(PosInfInterval!Date(Date(1996, 1, 2)).contains(Date(2000, 1, 5)));
---------------------
       +/
     bool contains(TP timePoint) const pure nothrow
     {
         return timePoint >= _begin;
     }
 
+    ///
+    unittest
+    {
+        assert(!PosInfInterval!Date(Date(1996, 1, 2)).contains(Date(1994, 12, 24)));
+        assert(PosInfInterval!Date(Date(1996, 1, 2)).contains(Date(2000, 1, 5)));
+    }
 
     /++
         Whether the given interval is completely within this interval.
@@ -20898,18 +20913,6 @@ assert(PosInfInterval!Date(Date(1996, 1, 2)).contains(Date(2000, 1, 5)));
 
         Throws:
             $(LREF DateTimeException) if the given interval is empty.
-
-        Example:
---------------------
-assert(!PosInfInterval!Date(Date(1996, 1, 2)).contains(
-            Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
-
-assert(PosInfInterval!Date(Date(1996, 1, 2)).contains(
-            Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))));
-
-assert(PosInfInterval!Date(Date(1996, 1, 2)).contains(
-            Interval!Date(Date(1998, 2, 28), Date(2013, 5, 1))));
---------------------
       +/
     bool contains(in Interval!TP interval) const pure
     {
@@ -20918,27 +20921,39 @@ assert(PosInfInterval!Date(Date(1996, 1, 2)).contains(
         return interval._begin >= _begin;
     }
 
+    ///
+    unittest
+    {
+        assert(!PosInfInterval!Date(Date(1996, 1, 2)).contains(
+                    Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
+
+        assert(PosInfInterval!Date(Date(1996, 1, 2)).contains(
+                    Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))));
+
+        assert(PosInfInterval!Date(Date(1996, 1, 2)).contains(
+                    Interval!Date(Date(1998, 2, 28), Date(2013, 5, 1))));
+    }
 
     /++
         Whether the given interval is completely within this interval.
 
         Params:
             interval = The interval to check for inclusion in this interval.
-
-        Example:
---------------------
-assert(PosInfInterval!Date(Date(1996, 1, 2)).contains(
-            PosInfInterval!Date(Date(1999, 5, 4))));
-
-assert(!PosInfInterval!Date(Date(1996, 1, 2)).contains(
-            PosInfInterval!Date(Date(1995, 7, 2))));
---------------------
       +/
     bool contains(in PosInfInterval interval) const pure nothrow
     {
         return interval._begin >= _begin;
     }
 
+    ///
+    unittest
+    {
+        assert(PosInfInterval!Date(Date(1996, 1, 2)).contains(
+                    PosInfInterval!Date(Date(1999, 5, 4))));
+
+        assert(!PosInfInterval!Date(Date(1996, 1, 2)).contains(
+                    PosInfInterval!Date(Date(1995, 7, 2))));
+    }
 
     /++
         Whether the given interval is completely within this interval.
@@ -20948,18 +20963,18 @@ assert(!PosInfInterval!Date(Date(1996, 1, 2)).contains(
 
         Params:
             interval = The interval to check for inclusion in this interval.
-
-        Example:
---------------------
-assert(!PosInfInterval!Date(Date(1996, 1, 2)).contains(
-            NegInfInterval!Date(Date(1996, 5, 4))));
---------------------
       +/
     bool contains(in NegInfInterval!TP interval) const pure nothrow
     {
         return false;
     }
 
+    ///
+    unittest
+    {
+        assert(!PosInfInterval!Date(Date(1996, 1, 2)).contains(
+                    NegInfInterval!Date(Date(1996, 5, 4))));
+    }
 
     /++
         Whether this interval is before the given time point.
@@ -20970,18 +20985,18 @@ assert(!PosInfInterval!Date(Date(1996, 1, 2)).contains(
         Params:
             timePoint = The time point to check whether this interval is before
                         it.
-
-        Example:
---------------------
-assert(!PosInfInterval!Date(Date(1996, 1, 2)).isBefore(Date(1994, 12, 24)));
-assert(!PosInfInterval!Date(Date(1996, 1, 2)).isBefore(Date(2000, 1, 5)));
---------------------
       +/
     bool isBefore(in TP timePoint) const pure nothrow
     {
         return false;
     }
 
+    ///
+    unittest
+    {
+        assert(!PosInfInterval!Date(Date(1996, 1, 2)).isBefore(Date(1994, 12, 24)));
+        assert(!PosInfInterval!Date(Date(1996, 1, 2)).isBefore(Date(2000, 1, 5)));
+    }
 
     /++
         Whether this interval is before the given interval and does not
@@ -20996,15 +21011,6 @@ assert(!PosInfInterval!Date(Date(1996, 1, 2)).isBefore(Date(2000, 1, 5)));
 
         Throws:
             $(LREF DateTimeException) if the given interval is empty.
-
-        Example:
---------------------
-assert(!PosInfInterval!Date(Date(1996, 1, 2)).isBefore(
-            Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
-
-assert(!PosInfInterval!Date(Date(1996, 1, 2)).isBefore(
-            Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))));
---------------------
       +/
     bool isBefore(in Interval!TP interval) const pure
     {
@@ -21013,6 +21019,15 @@ assert(!PosInfInterval!Date(Date(1996, 1, 2)).isBefore(
         return false;
     }
 
+    ///
+    unittest
+    {
+        assert(!PosInfInterval!Date(Date(1996, 1, 2)).isBefore(
+                    Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
+
+        assert(!PosInfInterval!Date(Date(1996, 1, 2)).isBefore(
+                    Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))));
+    }
 
     /++
         Whether this interval is before the given interval and does not
@@ -21023,21 +21038,21 @@ assert(!PosInfInterval!Date(Date(1996, 1, 2)).isBefore(
 
         Params:
             interval = The interval to check for against this interval.
-
-        Example:
---------------------
-assert(!PosInfInterval!Date(Date(1996, 1, 2)).isBefore(
-            PosInfInterval!Date(Date(1992, 5, 4))));
-
-assert(!PosInfInterval!Date(Date(1996, 1, 2)).isBefore(
-            PosInfInterval!Date(Date(2013, 3, 7))));
---------------------
       +/
     bool isBefore(in PosInfInterval interval) const pure nothrow
     {
         return false;
     }
 
+    ///
+    unittest
+    {
+        assert(!PosInfInterval!Date(Date(1996, 1, 2)).isBefore(
+                    PosInfInterval!Date(Date(1992, 5, 4))));
+
+        assert(!PosInfInterval!Date(Date(1996, 1, 2)).isBefore(
+                    PosInfInterval!Date(Date(2013, 3, 7))));
+    }
 
     /++
         Whether this interval is before the given interval and does not
@@ -21048,18 +21063,18 @@ assert(!PosInfInterval!Date(Date(1996, 1, 2)).isBefore(
 
         Params:
             interval = The interval to check for against this interval.
-
-        Example:
---------------------
-assert(!PosInfInterval!Date(Date(1996, 1, 2)).isBefore(
-            NegInfInterval!Date(Date(1996, 5, 4))));
---------------------
       +/
     bool isBefore(in NegInfInterval!TP interval) const pure nothrow
     {
         return false;
     }
 
+    ///
+    unittest
+    {
+        assert(!PosInfInterval!Date(Date(1996, 1, 2)).isBefore(
+                    NegInfInterval!Date(Date(1996, 5, 4))));
+    }
 
     /++
         Whether this interval is after the given time point.
@@ -21067,18 +21082,18 @@ assert(!PosInfInterval!Date(Date(1996, 1, 2)).isBefore(
         Params:
             timePoint = The time point to check whether this interval is after
                         it.
-
-        Example:
---------------------
-assert(PosInfInterval!Date(Date(1996, 1, 2)).isAfter(Date(1994, 12, 24)));
-assert(!PosInfInterval!Date(Date(1996, 1, 2)).isAfter(Date(2000, 1, 5)));
---------------------
       +/
     bool isAfter(in TP timePoint) const pure nothrow
     {
         return timePoint < _begin;
     }
 
+    ///
+    unittest
+    {
+        assert(PosInfInterval!Date(Date(1996, 1, 2)).isAfter(Date(1994, 12, 24)));
+        assert(!PosInfInterval!Date(Date(1996, 1, 2)).isAfter(Date(2000, 1, 5)));
+    }
 
     /++
         Whether this interval is after the given interval and does not intersect
@@ -21089,18 +21104,6 @@ assert(!PosInfInterval!Date(Date(1996, 1, 2)).isAfter(Date(2000, 1, 5)));
 
         Throws:
             $(LREF DateTimeException) if the given interval is empty.
-
-        Example:
---------------------
-assert(!PosInfInterval!Date(Date(1996, 1, 2)).isAfter(
-            Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
-
-assert(!PosInfInterval!Date(Date(1996, 1, 2)).isAfter(
-            Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))));
-
-assert(PosInfInterval!Date(Date(1996, 1, 2)).isAfter(
-            Interval!Date(Date(1989, 3, 1), Date(1996, 1, 2))));
---------------------
       +/
     bool isAfter(in Interval!TP interval) const pure
     {
@@ -21109,6 +21112,18 @@ assert(PosInfInterval!Date(Date(1996, 1, 2)).isAfter(
         return _begin >= interval._end;
     }
 
+    ///
+    unittest
+    {
+        assert(!PosInfInterval!Date(Date(1996, 1, 2)).isAfter(
+                    Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
+
+        assert(!PosInfInterval!Date(Date(1996, 1, 2)).isAfter(
+                    Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))));
+
+        assert(PosInfInterval!Date(Date(1996, 1, 2)).isAfter(
+                    Interval!Date(Date(1989, 3, 1), Date(1996, 1, 2))));
+    }
 
     /++
         Whether this interval is after the given interval and does not intersect
@@ -21119,21 +21134,21 @@ assert(PosInfInterval!Date(Date(1996, 1, 2)).isAfter(
 
         Params:
             interval = The interval to check against this interval.
-
-        Example:
---------------------
-assert(!PosInfInterval!Date(Date(1996, 1, 2)).isAfter(
-            PosInfInterval!Date(Date(1990, 1, 7))));
-
-assert(!PosInfInterval!Date(Date(1996, 1, 2)).isAfter(
-            PosInfInterval!Date(Date(1999, 5, 4))));
---------------------
       +/
     bool isAfter(in PosInfInterval interval) const pure nothrow
     {
         return false;
     }
 
+    ///
+    unittest
+    {
+        assert(!PosInfInterval!Date(Date(1996, 1, 2)).isAfter(
+                    PosInfInterval!Date(Date(1990, 1, 7))));
+
+        assert(!PosInfInterval!Date(Date(1996, 1, 2)).isAfter(
+                    PosInfInterval!Date(Date(1999, 5, 4))));
+    }
 
     /++
         Whether this interval is after the given interval and does not intersect
@@ -21141,21 +21156,21 @@ assert(!PosInfInterval!Date(Date(1996, 1, 2)).isAfter(
 
         Params:
             interval = The interval to check against this interval.
-
-        Example:
---------------------
-assert(PosInfInterval!Date(Date(1996, 1, 2)).isAfter(
-            NegInfInterval!Date(Date(1996, 1, 2))));
-
-assert(!PosInfInterval!Date(Date(1996, 1, 2)).isAfter(
-            NegInfInterval!Date(Date(2000, 7, 1))));
---------------------
       +/
     bool isAfter(in NegInfInterval!TP interval) const pure nothrow
     {
         return _begin >= interval._end;
     }
 
+    ///
+    unittest
+    {
+        assert(PosInfInterval!Date(Date(1996, 1, 2)).isAfter(
+                    NegInfInterval!Date(Date(1996, 1, 2))));
+
+        assert(!PosInfInterval!Date(Date(1996, 1, 2)).isAfter(
+                    NegInfInterval!Date(Date(2000, 7, 1))));
+    }
 
     /++
         Whether the given interval overlaps this interval.
@@ -21165,18 +21180,6 @@ assert(!PosInfInterval!Date(Date(1996, 1, 2)).isAfter(
 
         Throws:
             $(LREF DateTimeException) if the given interval is empty.
-
-        Example:
---------------------
-assert(PosInfInterval!Date(Date(1996, 1, 2)).intersects(
-            Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
-
-assert(PosInfInterval!Date(Date(1996, 1, 2)).intersects(
-            Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))));
-
-assert(!PosInfInterval!Date(Date(1996, 1, 2)).intersects(
-            Interval!Date(Date(1989, 3, 1), Date(1996, 1, 2))));
---------------------
       +/
     bool intersects(in Interval!TP interval) const pure
     {
@@ -21185,6 +21188,18 @@ assert(!PosInfInterval!Date(Date(1996, 1, 2)).intersects(
         return interval._end > _begin;
     }
 
+    ///
+    unittest
+    {
+        assert(PosInfInterval!Date(Date(1996, 1, 2)).intersects(
+                    Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
+
+        assert(PosInfInterval!Date(Date(1996, 1, 2)).intersects(
+                    Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))));
+
+        assert(!PosInfInterval!Date(Date(1996, 1, 2)).intersects(
+                    Interval!Date(Date(1989, 3, 1), Date(1996, 1, 2))));
+    }
 
     /++
         Whether the given interval overlaps this interval.
@@ -21195,21 +21210,21 @@ assert(!PosInfInterval!Date(Date(1996, 1, 2)).intersects(
         Params:
             interval = The interval to check for intersection with this
                        interval.
-
-        Example:
---------------------
-assert(PosInfInterval!Date(Date(1996, 1, 2)).intersects(
-            PosInfInterval!Date(Date(1990, 1, 7))));
-
-assert(PosInfInterval!Date(Date(1996, 1, 2)).intersects(
-            PosInfInterval!Date(Date(1999, 5, 4))));
---------------------
       +/
     bool intersects(in PosInfInterval interval) const pure nothrow
     {
         return true;
     }
 
+    ///
+    unittest
+    {
+        assert(PosInfInterval!Date(Date(1996, 1, 2)).intersects(
+                    PosInfInterval!Date(Date(1990, 1, 7))));
+
+        assert(PosInfInterval!Date(Date(1996, 1, 2)).intersects(
+                    PosInfInterval!Date(Date(1999, 5, 4))));
+    }
 
     /++
         Whether the given interval overlaps this interval.
@@ -21217,21 +21232,21 @@ assert(PosInfInterval!Date(Date(1996, 1, 2)).intersects(
         Params:
             interval = The interval to check for intersection with this
                        interval.
-
-        Example:
---------------------
-assert(!PosInfInterval!Date(Date(1996, 1, 2)).intersects(
-            NegInfInterval!Date(Date(1996, 1, 2))));
-
-assert(PosInfInterval!Date(Date(1996, 1, 2)).intersects(
-            NegInfInterval!Date(Date(2000, 7, 1))));
---------------------
       +/
     bool intersects(in NegInfInterval!TP interval) const pure nothrow
     {
         return _begin < interval._end;
     }
 
+    ///
+    unittest
+    {
+        assert(!PosInfInterval!Date(Date(1996, 1, 2)).intersects(
+                    NegInfInterval!Date(Date(1996, 1, 2))));
+
+        assert(PosInfInterval!Date(Date(1996, 1, 2)).intersects(
+                    NegInfInterval!Date(Date(2000, 7, 1))));
+    }
 
     /++
         Returns the intersection of two intervals
@@ -21242,17 +21257,6 @@ assert(PosInfInterval!Date(Date(1996, 1, 2)).intersects(
         Throws:
             $(LREF DateTimeException) if the two intervals do not intersect or if
             the given interval is empty.
-
-        Example:
---------------------
-assert(PosInfInterval!Date(Date(1996, 1, 2)).intersection(
-            Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))) ==
-       Interval!Date(Date(1996, 1 , 2), Date(2000, 8, 2)));
-
-assert(PosInfInterval!Date(Date(1996, 1, 2)).intersection(
-            Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))) ==
-       Interval!Date(Date(1999, 1 , 12), Date(2011, 9, 17)));
---------------------
       +/
     Interval!TP intersection(in Interval!TP interval) const
     {
@@ -21265,29 +21269,40 @@ assert(PosInfInterval!Date(Date(1996, 1, 2)).intersection(
         return Interval!TP(begin, interval._end);
     }
 
+    ///
+    unittest
+    {
+        assert(PosInfInterval!Date(Date(1996, 1, 2)).intersection(
+                    Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))) ==
+               Interval!Date(Date(1996, 1 , 2), Date(2000, 8, 2)));
+
+        assert(PosInfInterval!Date(Date(1996, 1, 2)).intersection(
+                    Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))) ==
+               Interval!Date(Date(1999, 1 , 12), Date(2011, 9, 17)));
+    }
 
     /++
         Returns the intersection of two intervals
 
         Params:
             interval = The interval to intersect with this interval.
-
-        Example:
---------------------
-assert(PosInfInterval!Date(Date(1996, 1, 2)).intersection(
-            PosInfInterval!Date(Date(1990, 7, 6))) ==
-       PosInfInterval!Date(Date(1996, 1 , 2)));
-
-assert(PosInfInterval!Date(Date(1996, 1, 2)).intersection(
-            PosInfInterval!Date(Date(1999, 1, 12))) ==
-       PosInfInterval!Date(Date(1999, 1 , 12)));
---------------------
       +/
     PosInfInterval intersection(in PosInfInterval interval) const pure nothrow
     {
         return PosInfInterval(_begin < interval._begin ? interval._begin : _begin);
     }
 
+    ///
+    unittest
+    {
+        assert(PosInfInterval!Date(Date(1996, 1, 2)).intersection(
+                    PosInfInterval!Date(Date(1990, 7, 6))) ==
+               PosInfInterval!Date(Date(1996, 1 , 2)));
+
+        assert(PosInfInterval!Date(Date(1996, 1, 2)).intersection(
+                    PosInfInterval!Date(Date(1999, 1, 12))) ==
+               PosInfInterval!Date(Date(1999, 1 , 12)));
+    }
 
     /++
         Returns the intersection of two intervals
@@ -21297,17 +21312,6 @@ assert(PosInfInterval!Date(Date(1996, 1, 2)).intersection(
 
         Throws:
             $(LREF DateTimeException) if the two intervals do not intersect.
-
-        Example:
---------------------
-assert(PosInfInterval!Date(Date(1996, 1, 2)).intersection(
-            NegInfInterval!Date(Date(1999, 7, 6))) ==
-       Interval!Date(Date(1996, 1 , 2), Date(1999, 7, 6)));
-
-assert(PosInfInterval!Date(Date(1996, 1, 2)).intersection(
-            NegInfInterval!Date(Date(2013, 1, 12))) ==
-       Interval!Date(Date(1996, 1 , 2), Date(2013, 1, 12)));
---------------------
       +/
     Interval!TP intersection(in NegInfInterval!TP interval) const
     {
@@ -21318,6 +21322,17 @@ assert(PosInfInterval!Date(Date(1996, 1, 2)).intersection(
         return Interval!TP(_begin, interval._end);
     }
 
+    ///
+    unittest
+    {
+        assert(PosInfInterval!Date(Date(1996, 1, 2)).intersection(
+                    NegInfInterval!Date(Date(1999, 7, 6))) ==
+               Interval!Date(Date(1996, 1 , 2), Date(1999, 7, 6)));
+
+        assert(PosInfInterval!Date(Date(1996, 1, 2)).intersection(
+                    NegInfInterval!Date(Date(2013, 1, 12))) ==
+               Interval!Date(Date(1996, 1 , 2), Date(2013, 1, 12)));
+    }
 
     /++
         Whether the given interval is adjacent to this interval.
@@ -21328,15 +21343,6 @@ assert(PosInfInterval!Date(Date(1996, 1, 2)).intersection(
 
         Throws:
             $(LREF DateTimeException) if the given interval is empty.
-
-        Example:
---------------------
-assert(PosInfInterval!Date(Date(1996, 1, 2)).isAdjacent(
-            Interval!Date(Date(1989, 3, 1), Date(1996, 1, 2))));
-
-assert(!PosInfInterval!Date(Date(1999, 1, 12)).isAdjacent(
-            Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))));
---------------------
       +/
     bool isAdjacent(in Interval!TP interval) const pure
     {
@@ -21345,6 +21351,15 @@ assert(!PosInfInterval!Date(Date(1999, 1, 12)).isAdjacent(
         return _begin == interval._end;
     }
 
+    ///
+    unittest
+    {
+        assert(PosInfInterval!Date(Date(1996, 1, 2)).isAdjacent(
+                    Interval!Date(Date(1989, 3, 1), Date(1996, 1, 2))));
+
+        assert(!PosInfInterval!Date(Date(1999, 1, 12)).isAdjacent(
+                    Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))));
+    }
 
     /++
         Whether the given interval is adjacent to this interval.
@@ -21355,21 +21370,21 @@ assert(!PosInfInterval!Date(Date(1999, 1, 12)).isAdjacent(
         Params:
             interval = The interval to check whether its adjecent to this
                        interval.
-
-        Example:
---------------------
-assert(!PosInfInterval!Date(Date(1996, 1, 2)).isAdjacent(
-            PosInfInterval!Date(Date(1990, 1, 7))));
-
-assert(!PosInfInterval!Date(Date(1996, 1, 2)).isAdjacent(
-            PosInfInterval!Date(Date(1996, 1, 2))));
---------------------
       +/
     bool isAdjacent(in PosInfInterval interval) const pure nothrow
     {
         return false;
     }
 
+    ///
+    unittest
+    {
+        assert(!PosInfInterval!Date(Date(1996, 1, 2)).isAdjacent(
+                    PosInfInterval!Date(Date(1990, 1, 7))));
+
+        assert(!PosInfInterval!Date(Date(1996, 1, 2)).isAdjacent(
+                    PosInfInterval!Date(Date(1996, 1, 2))));
+    }
 
     /++
         Whether the given interval is adjacent to this interval.
@@ -21377,21 +21392,21 @@ assert(!PosInfInterval!Date(Date(1996, 1, 2)).isAdjacent(
         Params:
             interval = The interval to check whether its adjecent to this
                        interval.
-
-        Example:
---------------------
-assert(PosInfInterval!Date(Date(1996, 1, 2)).isAdjacent(
-            NegInfInterval!Date(Date(1996, 1, 2))));
-
-assert(!PosInfInterval!Date(Date(1996, 1, 2)).isAdjacent(
-            NegInfInterval!Date(Date(2000, 7, 1))));
---------------------
       +/
     bool isAdjacent(in NegInfInterval!TP interval) const pure nothrow
     {
         return _begin == interval._end;
     }
 
+    ///
+    unittest
+    {
+        assert(PosInfInterval!Date(Date(1996, 1, 2)).isAdjacent(
+                    NegInfInterval!Date(Date(1996, 1, 2))));
+
+        assert(!PosInfInterval!Date(Date(1996, 1, 2)).isAdjacent(
+                    NegInfInterval!Date(Date(2000, 7, 1))));
+    }
 
     /++
         Returns the union of two intervals
@@ -21408,17 +21423,6 @@ assert(!PosInfInterval!Date(Date(1996, 1, 2)).isAdjacent(
             $(D NegInfInterval), because an interval
             going from negative infinity to positive infinity
             is not possible.
-
-        Example:
---------------------
-assert(PosInfInterval!Date(Date(1996, 1, 2)).merge(
-            Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))) ==
-       PosInfInterval!Date(Date(1990, 7 , 6)));
-
-assert(PosInfInterval!Date(Date(1996, 1, 2)).merge(
-            Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))) ==
-       PosInfInterval!Date(Date(1996, 1 , 2)));
---------------------
       +/
     PosInfInterval merge(in Interval!TP interval) const
     {
@@ -21430,6 +21434,17 @@ assert(PosInfInterval!Date(Date(1996, 1, 2)).merge(
         return PosInfInterval(_begin < interval._begin ? _begin : interval._begin);
     }
 
+    ///
+    unittest
+    {
+        assert(PosInfInterval!Date(Date(1996, 1, 2)).merge(
+                    Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))) ==
+               PosInfInterval!Date(Date(1990, 7 , 6)));
+
+        assert(PosInfInterval!Date(Date(1996, 1, 2)).merge(
+                    Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))) ==
+               PosInfInterval!Date(Date(1996, 1 , 2)));
+    }
 
     /++
         Returns the union of two intervals
@@ -21442,23 +21457,23 @@ assert(PosInfInterval!Date(Date(1996, 1, 2)).merge(
             $(D NegInfInterval), because an interval
             going from negative infinity to positive infinity
             is not possible.
-
-        Example:
---------------------
-assert(PosInfInterval!Date(Date(1996, 1, 2)).merge(
-            PosInfInterval!Date(Date(1990, 7, 6))) ==
-       PosInfInterval!Date(Date(1990, 7 , 6)));
-
-assert(PosInfInterval!Date(Date(1996, 1, 2)).merge(
-            PosInfInterval!Date(Date(1999, 1, 12))) ==
-       PosInfInterval!Date(Date(1996, 1 , 2)));
---------------------
       +/
     PosInfInterval merge(in PosInfInterval interval) const pure nothrow
     {
         return PosInfInterval(_begin < interval._begin ? _begin : interval._begin);
     }
 
+    ///
+    unittest
+    {
+        assert(PosInfInterval!Date(Date(1996, 1, 2)).merge(
+                    PosInfInterval!Date(Date(1990, 7, 6))) ==
+               PosInfInterval!Date(Date(1990, 7 , 6)));
+
+        assert(PosInfInterval!Date(Date(1996, 1, 2)).merge(
+                    PosInfInterval!Date(Date(1999, 1, 12))) ==
+               PosInfInterval!Date(Date(1996, 1 , 2)));
+    }
 
     /++
         Returns an interval that covers from the earliest time point of two
@@ -21477,21 +21492,6 @@ assert(PosInfInterval!Date(Date(1996, 1, 2)).merge(
             $(D NegInfInterval), because an interval
             going from negative infinity to positive infinity
             is not possible.
-
-        Example:
---------------------
-assert(PosInfInterval!Date(Date(1996, 1, 2)).span(
-            Interval!Date(Date(500, 8, 9), Date(1602, 1, 31))) ==
-       PosInfInterval!Date(Date(500, 8, 9)));
-
-assert(PosInfInterval!Date(Date(1996, 1, 2)).span(
-            Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))) ==
-       PosInfInterval!Date(Date(1990, 7 , 6)));
-
-assert(PosInfInterval!Date(Date(1996, 1, 2)).span(
-            Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))) ==
-       PosInfInterval!Date(Date(1996, 1 , 2)));
---------------------
       +/
     PosInfInterval span(in Interval!TP interval) const pure
     {
@@ -21500,6 +21500,21 @@ assert(PosInfInterval!Date(Date(1996, 1, 2)).span(
         return PosInfInterval(_begin < interval._begin ? _begin : interval._begin);
     }
 
+    ///
+    unittest
+    {
+        assert(PosInfInterval!Date(Date(1996, 1, 2)).span(
+                    Interval!Date(Date(500, 8, 9), Date(1602, 1, 31))) ==
+               PosInfInterval!Date(Date(500, 8, 9)));
+
+        assert(PosInfInterval!Date(Date(1996, 1, 2)).span(
+                    Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))) ==
+               PosInfInterval!Date(Date(1990, 7 , 6)));
+
+        assert(PosInfInterval!Date(Date(1996, 1, 2)).span(
+                    Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))) ==
+               PosInfInterval!Date(Date(1996, 1 , 2)));
+    }
 
     /++
         Returns an interval that covers from the earliest time point of two
@@ -21515,23 +21530,23 @@ assert(PosInfInterval!Date(Date(1996, 1, 2)).span(
             $(D NegInfInterval), because an interval
             going from negative infinity to positive infinity
             is not possible.
-
-        Example:
---------------------
-assert(PosInfInterval!Date(Date(1996, 1, 2)).span(
-            PosInfInterval!Date(Date(1990, 7, 6))) ==
-       PosInfInterval!Date(Date(1990, 7 , 6)));
-
-assert(PosInfInterval!Date(Date(1996, 1, 2)).span(
-            PosInfInterval!Date(Date(1999, 1, 12))) ==
-       PosInfInterval!Date(Date(1996, 1 , 2)));
---------------------
       +/
     PosInfInterval span(in PosInfInterval interval) const pure nothrow
     {
         return PosInfInterval(_begin < interval._begin ? _begin : interval._begin);
     }
 
+    ///
+    unittest
+    {
+        assert(PosInfInterval!Date(Date(1996, 1, 2)).span(
+                    PosInfInterval!Date(Date(1990, 7, 6))) ==
+               PosInfInterval!Date(Date(1990, 7 , 6)));
+
+        assert(PosInfInterval!Date(Date(1996, 1, 2)).span(
+                    PosInfInterval!Date(Date(1999, 1, 12))) ==
+               PosInfInterval!Date(Date(1996, 1 , 2)));
+    }
 
     /++
         Shifts the $(D begin) of this interval forward or backwards in time by
@@ -21541,18 +21556,6 @@ assert(PosInfInterval!Date(Date(1996, 1, 2)).span(
 
         Params:
             duration = The duration to shift the interval by.
-
-        Example:
---------------------
-auto interval1 = PosInfInterval!Date(Date(1996, 1, 2));
-auto interval2 = PosInfInterval!Date(Date(1996, 1, 2));
-
-interval1.shift(dur!"days"(50));
-assert(interval1 == PosInfInterval!Date(Date(1996, 2, 21)));
-
-interval2.shift(dur!"days"(-50));
-assert(interval2 == PosInfInterval!Date(Date(1995, 11, 13)));
---------------------
       +/
     void shift(D)(D duration) pure nothrow
         if(__traits(compiles, begin + duration))
@@ -21560,6 +21563,18 @@ assert(interval2 == PosInfInterval!Date(Date(1995, 11, 13)));
         _begin += duration;
     }
 
+    ///
+    unittest
+    {
+        auto interval1 = PosInfInterval!Date(Date(1996, 1, 2));
+        auto interval2 = PosInfInterval!Date(Date(1996, 1, 2));
+
+        interval1.shift(dur!"days"(50));
+        assert(interval1 == PosInfInterval!Date(Date(1996, 2, 21)));
+
+        interval2.shift(dur!"days"(-50));
+        assert(interval2 == PosInfInterval!Date(Date(1995, 11, 13)));
+    }
 
     static if(__traits(compiles, begin.add!"months"(1)) &&
               __traits(compiles, begin.add!"years"(1)))
@@ -21582,18 +21597,6 @@ assert(interval2 == PosInfInterval!Date(Date(1995, 11, 13)));
             Throws:
                 $(LREF DateTimeException) if this interval is empty or if the
                 resulting interval would be invalid.
-
-            Example:
---------------------
-auto interval1 = PosInfInterval!Date(Date(1996, 1, 2));
-auto interval2 = PosInfInterval!Date(Date(1996, 1, 2));
-
-interval1.shift(dur!"days"(50));
-assert(interval1 == PosInfInterval!Date(Date(1996, 2, 21)));
-
-interval2.shift(dur!"days"(-50));
-assert(interval2 == PosInfInterval!Date(Date(1995, 11, 13)));
---------------------
           +/
         void shift(T)(T years, T months = 0, AllowDayOverflow allowOverflow = AllowDayOverflow.yes)
             if(isIntegral!T)
@@ -21605,6 +21608,19 @@ assert(interval2 == PosInfInterval!Date(Date(1995, 11, 13)));
 
             _begin = begin;
         }
+
+        ///
+        unittest
+        {
+            auto interval1 = PosInfInterval!Date(Date(1996, 1, 2));
+            auto interval2 = PosInfInterval!Date(Date(1996, 1, 2));
+
+            interval1.shift(dur!"days"(50));
+            assert(interval1 == PosInfInterval!Date(Date(1996, 2, 21)));
+
+            interval2.shift(dur!"days"(-50));
+            assert(interval2 == PosInfInterval!Date(Date(1995, 11, 13)));
+        }
     }
 
 
@@ -21614,18 +21630,6 @@ assert(interval2 == PosInfInterval!Date(Date(1995, 11, 13)));
 
         Params:
             duration = The duration to expand the interval by.
-
-        Example:
---------------------
-auto interval1 = PosInfInterval!Date(Date(1996, 1, 2));
-auto interval2 = PosInfInterval!Date(Date(1996, 1, 2));
-
-interval1.expand(dur!"days"(2));
-assert(interval1 == PosInfInterval!Date(Date(1995, 12, 31)));
-
-interval2.expand(dur!"days"(-2));
-assert(interval2 == PosInfInterval!Date(Date(1996, 1, 4)));
---------------------
       +/
     void expand(D)(D duration) pure nothrow
         if(__traits(compiles, begin + duration))
@@ -21633,6 +21637,19 @@ assert(interval2 == PosInfInterval!Date(Date(1996, 1, 4)));
         _begin -= duration;
     }
 
+
+    ///
+    unittest
+    {
+        auto interval1 = PosInfInterval!Date(Date(1996, 1, 2));
+        auto interval2 = PosInfInterval!Date(Date(1996, 1, 2));
+
+        interval1.expand(dur!"days"(2));
+        assert(interval1 == PosInfInterval!Date(Date(1995, 12, 31)));
+
+        interval2.expand(dur!"days"(-2));
+        assert(interval2 == PosInfInterval!Date(Date(1996, 1, 4)));
+    }
 
     static if(__traits(compiles, begin.add!"months"(1)) &&
               __traits(compiles, begin.add!"years"(1)))
@@ -21650,18 +21667,6 @@ assert(interval2 == PosInfInterval!Date(Date(1996, 1, 4)));
             Throws:
                 $(LREF DateTimeException) if this interval is empty or if the
                 resulting interval would be invalid.
-
-            Example:
---------------------
-auto interval1 = PosInfInterval!Date(Date(1996, 1, 2));
-auto interval2 = PosInfInterval!Date(Date(1996, 1, 2));
-
-interval1.expand(2);
-assert(interval1 == PosInfInterval!Date(Date(1994, 1, 2)));
-
-interval2.expand(-2);
-assert(interval2 == PosInfInterval!Date(Date(1998, 1, 2)));
---------------------
           +/
         void expand(T)(T years, T months = 0, AllowDayOverflow allowOverflow = AllowDayOverflow.yes)
             if(isIntegral!T)
@@ -21677,6 +21682,18 @@ assert(interval2 == PosInfInterval!Date(Date(1998, 1, 2)));
         }
     }
 
+    ///
+    unittest
+    {
+        auto interval1 = PosInfInterval!Date(Date(1996, 1, 2));
+        auto interval2 = PosInfInterval!Date(Date(1996, 1, 2));
+
+        interval1.expand(2);
+        assert(interval1 == PosInfInterval!Date(Date(1994, 1, 2)));
+
+        interval2.expand(-2);
+        assert(interval2 == PosInfInterval!Date(Date(1998, 1, 2)));
+    }
 
     /++
         Returns a range which iterates forward over the interval, starting
@@ -21724,37 +21741,6 @@ assert(interval2 == PosInfInterval!Date(Date(1998, 1, 2)));
 
             Of course, none of the functions in this module have this problem,
             so it's only relevant for custom delegates.
-
-        Example:
---------------------
-auto interval = PosInfInterval!Date(Date(2010, 9, 1));
-auto func = (in Date date) //For iterating over even-numbered days.
-            {
-                if((date.day & 1) == 0)
-                    return date + dur!"days"(2);
-
-                return date + dur!"days"(1);
-            };
-auto range = interval.fwdRange(func);
-
-//An odd day. Using PopFirst.yes would have made this Date(2010, 9, 2).
-assert(range.front == Date(2010, 9, 1));
-
-range.popFront();
-assert(range.front == Date(2010, 9, 2));
-
-range.popFront();
-assert(range.front == Date(2010, 9, 4));
-
-range.popFront();
-assert(range.front == Date(2010, 9, 6));
-
-range.popFront();
-assert(range.front == Date(2010, 9, 8));
-
-range.popFront();
-assert(!range.empty);
---------------------
       +/
     PosInfIntervalRange!(TP) fwdRange(TP delegate(in TP) func, PopFirst popFirst = PopFirst.no) const
     {
@@ -21766,6 +21752,37 @@ assert(!range.empty);
         return range;
     }
 
+    ///
+    unittest
+    {
+        auto interval = PosInfInterval!Date(Date(2010, 9, 1));
+        auto func = (in Date date) //For iterating over even-numbered days.
+                    {
+                        if((date.day & 1) == 0)
+                            return date + dur!"days"(2);
+
+                        return date + dur!"days"(1);
+                    };
+        auto range = interval.fwdRange(func);
+
+        //An odd day. Using PopFirst.yes would have made this Date(2010, 9, 2).
+        assert(range.front == Date(2010, 9, 1));
+
+        range.popFront();
+        assert(range.front == Date(2010, 9, 2));
+
+        range.popFront();
+        assert(range.front == Date(2010, 9, 4));
+
+        range.popFront();
+        assert(range.front == Date(2010, 9, 6));
+
+        range.popFront();
+        assert(range.front == Date(2010, 9, 8));
+
+        range.popFront();
+        assert(!range.empty);
+    }
 
     /+
         Converts this interval to a string.
@@ -23026,17 +23043,17 @@ auto interval = PosInfInterval!Date(Date(1996, 1, 2));
 
     /++
         The end point of the interval. It is excluded from the interval.
-
-        Example:
---------------------
-assert(NegInfInterval!Date(Date(2012, 3, 1)).end == Date(2012, 3, 1));
---------------------
       +/
     @property TP end() const pure nothrow
     {
         return cast(TP)_end;
     }
 
+    ///
+    unittest
+    {
+        assert(NegInfInterval!Date(Date(2012, 3, 1)).end == Date(2012, 3, 1));
+    }
 
     /++
         The end point of the interval. It is excluded from the interval.
@@ -23052,36 +23069,36 @@ assert(NegInfInterval!Date(Date(2012, 3, 1)).end == Date(2012, 3, 1));
 
     /++
         Whether the interval's length is 0. Always returns false.
-
-        Example:
---------------------
-assert(!NegInfInterval!Date(Date(1996, 1, 2)).empty);
---------------------
       +/
     @property bool empty() const pure nothrow
     {
         return false;
     }
 
+    ///
+    unittest
+    {
+        assert(!NegInfInterval!Date(Date(1996, 1, 2)).empty);
+    }
 
     /++
         Whether the given time point is within this interval.
 
         Params:
             timePoint = The time point to check for inclusion in this interval.
-
-        Example:
---------------------
-assert(NegInfInterval!Date(Date(2012, 3, 1)).contains(Date(1994, 12, 24)));
-assert(NegInfInterval!Date(Date(2012, 3, 1)).contains(Date(2000, 1, 5)));
-assert(!NegInfInterval!Date(Date(2012, 3, 1)).contains(Date(2012, 3, 1)));
---------------------
       +/
     bool contains(TP timePoint) const pure nothrow
     {
         return timePoint < _end;
     }
 
+    ///
+    unittest
+    {
+        assert(NegInfInterval!Date(Date(2012, 3, 1)).contains(Date(1994, 12, 24)));
+        assert(NegInfInterval!Date(Date(2012, 3, 1)).contains(Date(2000, 1, 5)));
+        assert(!NegInfInterval!Date(Date(2012, 3, 1)).contains(Date(2012, 3, 1)));
+    }
 
     /++
         Whether the given interval is completely within this interval.
@@ -23091,18 +23108,6 @@ assert(!NegInfInterval!Date(Date(2012, 3, 1)).contains(Date(2012, 3, 1)));
 
         Throws:
             $(LREF DateTimeException) if the given interval is empty.
-
-        Example:
---------------------
-assert(NegInfInterval!Date(Date(2012, 3, 1)).contains(
-            Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
-
-assert(NegInfInterval!Date(Date(2012, 3, 1)).contains(
-            Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))));
-
-assert(!NegInfInterval!Date(Date(2012, 3, 1)).contains(
-            Interval!Date(Date(1998, 2, 28), Date(2013, 5, 1))));
---------------------
       +/
     bool contains(in Interval!TP interval) const pure
     {
@@ -23111,6 +23116,18 @@ assert(!NegInfInterval!Date(Date(2012, 3, 1)).contains(
         return interval._end <= _end;
     }
 
+    ///
+    unittest
+    {
+        assert(NegInfInterval!Date(Date(2012, 3, 1)).contains(
+                    Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
+
+        assert(NegInfInterval!Date(Date(2012, 3, 1)).contains(
+                    Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))));
+
+        assert(!NegInfInterval!Date(Date(2012, 3, 1)).contains(
+                    Interval!Date(Date(1998, 2, 28), Date(2013, 5, 1))));
+    }
 
     /++
         Whether the given interval is completely within this interval.
@@ -23120,39 +23137,39 @@ assert(!NegInfInterval!Date(Date(2012, 3, 1)).contains(
 
         Params:
             interval = The interval to check for inclusion in this interval.
-
-        Example:
---------------------
-assert(!NegInfInterval!Date(Date(2012, 3, 1)).contains(
-            PosInfInterval!Date(Date(1999, 5, 4))));
---------------------
       +/
     bool contains(in PosInfInterval!TP interval) const pure nothrow
     {
         return false;
     }
 
+    ///
+    unittest
+    {
+        assert(!NegInfInterval!Date(Date(2012, 3, 1)).contains(
+                    PosInfInterval!Date(Date(1999, 5, 4))));
+    }
 
     /++
         Whether the given interval is completely within this interval.
 
         Params:
             interval = The interval to check for inclusion in this interval.
-
-        Example:
---------------------
-assert(NegInfInterval!Date(Date(2012, 3, 1)).contains(
-            NegInfInterval!Date(Date(1996, 5, 4))));
-
-assert(!NegInfInterval!Date(Date(2012, 3, 1)).contains(
-            NegInfInterval!Date(Date(2013, 7, 9))));
---------------------
       +/
     bool contains(in NegInfInterval interval) const pure nothrow
     {
         return interval._end <= _end;
     }
 
+    ///
+    unittest
+    {
+        assert(NegInfInterval!Date(Date(2012, 3, 1)).contains(
+                    NegInfInterval!Date(Date(1996, 5, 4))));
+
+        assert(!NegInfInterval!Date(Date(2012, 3, 1)).contains(
+                    NegInfInterval!Date(Date(2013, 7, 9))));
+    }
 
     /++
         Whether this interval is before the given time point.
@@ -23160,19 +23177,19 @@ assert(!NegInfInterval!Date(Date(2012, 3, 1)).contains(
         Params:
             timePoint = The time point to check whether this interval is
                         before it.
-
-        Example:
---------------------
-assert(!NegInfInterval!Date(Date(2012, 3, 1)).isBefore(Date(1994, 12, 24)));
-assert(!NegInfInterval!Date(Date(2012, 3, 1)).isBefore(Date(2000, 1, 5)));
-assert(NegInfInterval!Date(Date(2012, 3, 1)).isBefore(Date(2012, 3, 1)));
---------------------
       +/
     bool isBefore(in TP timePoint) const pure nothrow
     {
         return timePoint >= _end;
     }
 
+    ///
+    unittest
+    {
+        assert(!NegInfInterval!Date(Date(2012, 3, 1)).isBefore(Date(1994, 12, 24)));
+        assert(!NegInfInterval!Date(Date(2012, 3, 1)).isBefore(Date(2000, 1, 5)));
+        assert(NegInfInterval!Date(Date(2012, 3, 1)).isBefore(Date(2012, 3, 1)));
+    }
 
     /++
         Whether this interval is before the given interval and does not
@@ -23183,18 +23200,6 @@ assert(NegInfInterval!Date(Date(2012, 3, 1)).isBefore(Date(2012, 3, 1)));
 
         Throws:
             $(LREF DateTimeException) if the given interval is empty
-
-        Example:
---------------------
-assert(!NegInfInterval!Date(Date(2012, 3, 1)).isBefore(
-            Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
-
-assert(!NegInfInterval!Date(Date(2012, 3, 1)).isBefore(
-            Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))));
-
-assert(NegInfInterval!Date(Date(2012, 3, 1)).isBefore(
-            Interval!Date(Date(2022, 10, 19), Date(2027, 6, 3))));
---------------------
       +/
     bool isBefore(in Interval!TP interval) const pure
     {
@@ -23203,6 +23208,18 @@ assert(NegInfInterval!Date(Date(2012, 3, 1)).isBefore(
         return _end <= interval._begin;
     }
 
+    ///
+    unittest
+    {
+        assert(!NegInfInterval!Date(Date(2012, 3, 1)).isBefore(
+                    Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
+
+        assert(!NegInfInterval!Date(Date(2012, 3, 1)).isBefore(
+                    Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))));
+
+        assert(NegInfInterval!Date(Date(2012, 3, 1)).isBefore(
+                    Interval!Date(Date(2022, 10, 19), Date(2027, 6, 3))));
+    }
 
     /++
         Whether this interval is before the given interval and does not
@@ -23210,21 +23227,21 @@ assert(NegInfInterval!Date(Date(2012, 3, 1)).isBefore(
 
         Params:
             interval = The interval to check for against this interval.
-
-        Example:
---------------------
-assert(!NegInfInterval!Date(Date(2012, 3, 1)).isBefore(
-            PosInfInterval!Date(Date(1999, 5, 4))));
-
-assert(NegInfInterval!Date(Date(2012, 3, 1)).isBefore(
-            PosInfInterval!Date(Date(2012, 3, 1))));
---------------------
       +/
     bool isBefore(in PosInfInterval!TP interval) const pure nothrow
     {
         return _end <= interval._begin;
     }
 
+    ///
+    unittest
+    {
+        assert(!NegInfInterval!Date(Date(2012, 3, 1)).isBefore(
+                    PosInfInterval!Date(Date(1999, 5, 4))));
+
+        assert(NegInfInterval!Date(Date(2012, 3, 1)).isBefore(
+                    PosInfInterval!Date(Date(2012, 3, 1))));
+    }
 
     /++
         Whether this interval is before the given interval and does not
@@ -23236,21 +23253,21 @@ assert(NegInfInterval!Date(Date(2012, 3, 1)).isBefore(
 
         Params:
             interval = The interval to check for against this interval.
-
-        Example:
---------------------
-assert(!NegInfInterval!Date(Date(2012, 3, 1)).isBefore(
-            NegInfInterval!Date(Date(1996, 5, 4))));
-
-assert(!NegInfInterval!Date(Date(2012, 3, 1)).isBefore(
-            NegInfInterval!Date(Date(2013, 7, 9))));
---------------------
       +/
     bool isBefore(in NegInfInterval interval) const pure nothrow
     {
         return false;
     }
 
+    ///
+    unittest
+    {
+        assert(!NegInfInterval!Date(Date(2012, 3, 1)).isBefore(
+                    NegInfInterval!Date(Date(1996, 5, 4))));
+
+        assert(!NegInfInterval!Date(Date(2012, 3, 1)).isBefore(
+                    NegInfInterval!Date(Date(2013, 7, 9))));
+    }
 
     /++
         Whether this interval is after the given time point.
@@ -23261,19 +23278,19 @@ assert(!NegInfInterval!Date(Date(2012, 3, 1)).isBefore(
         Params:
             timePoint = The time point to check whether this interval is after
                         it.
-
-        Example:
---------------------
-assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAfter(Date(1994, 12, 24)));
-assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAfter(Date(2000, 1, 5)));
-assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAfter(Date(2012, 3, 1)));
---------------------
       +/
     bool isAfter(in TP timePoint) const pure nothrow
     {
         return false;
     }
 
+    ///
+    unittest
+    {
+        assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAfter(Date(1994, 12, 24)));
+        assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAfter(Date(2000, 1, 5)));
+        assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAfter(Date(2012, 3, 1)));
+    }
 
     /++
         Whether this interval is after the given interval and does not
@@ -23288,18 +23305,6 @@ assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAfter(Date(2012, 3, 1)));
 
         Throws:
             $(LREF DateTimeException) if the given interval is empty.
-
-        Example:
---------------------
-assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAfter(
-            Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
-
-assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAfter(
-            Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))));
-
-assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAfter(
-            Interval!Date(Date(2022, 10, 19), Date(2027, 6, 3))));
---------------------
       +/
     bool isAfter(in Interval!TP interval) const pure
     {
@@ -23308,6 +23313,18 @@ assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAfter(
         return false;
     }
 
+    ///
+    unittest
+    {
+        assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAfter(
+                    Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
+
+        assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAfter(
+                    Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))));
+
+        assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAfter(
+                    Interval!Date(Date(2022, 10, 19), Date(2027, 6, 3))));
+    }
 
     /++
         Whether this interval is after the given interval and does not intersect
@@ -23318,21 +23335,21 @@ assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAfter(
 
         Params:
             interval = The interval to check against this interval.
-
-        Example:
---------------------
-assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAfter(
-            PosInfInterval!Date(Date(1999, 5, 4))));
-
-assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAfter(
-            PosInfInterval!Date(Date(2012, 3, 1))));
---------------------
       +/
     bool isAfter(in PosInfInterval!TP interval) const pure nothrow
     {
         return false;
     }
 
+    ///
+    unittest
+    {
+        assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAfter(
+                    PosInfInterval!Date(Date(1999, 5, 4))));
+
+        assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAfter(
+                    PosInfInterval!Date(Date(2012, 3, 1))));
+    }
 
     /++
         Whether this interval is after the given interval and does not intersect
@@ -23343,21 +23360,21 @@ assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAfter(
 
         Params:
             interval = The interval to check against this interval.
-
-        Example:
---------------------
-assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAfter(
-            NegInfInterval!Date(Date(1996, 5, 4))));
-
-assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAfter(
-            NegInfInterval!Date(Date(2013, 7, 9))));
---------------------
       +/
     bool isAfter(in NegInfInterval interval) const pure nothrow
     {
         return false;
     }
 
+    ///
+    unittest
+    {
+        assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAfter(
+                    NegInfInterval!Date(Date(1996, 5, 4))));
+
+        assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAfter(
+                    NegInfInterval!Date(Date(2013, 7, 9))));
+    }
 
     /++
         Whether the given interval overlaps this interval.
@@ -23367,18 +23384,6 @@ assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAfter(
 
         Throws:
             $(LREF DateTimeException) if the given interval is empty.
-
-        Example:
---------------------
-assert(NegInfInterval!Date(Date(2012, 3, 1)).intersects(
-            Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
-
-assert(NegInfInterval!Date(Date(2012, 3, 1)).intersects(
-            Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))));
-
-assert(!NegInfInterval!Date(Date(2012, 3, 1)).intersects(
-            Interval!Date(Date(2022, 10, 19), Date(2027, 6, 3))));
---------------------
       +/
     bool intersects(in Interval!TP interval) const pure
     {
@@ -23387,6 +23392,18 @@ assert(!NegInfInterval!Date(Date(2012, 3, 1)).intersects(
         return interval._begin < _end;
     }
 
+    ///
+    unittest
+    {
+        assert(NegInfInterval!Date(Date(2012, 3, 1)).intersects(
+                    Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
+
+        assert(NegInfInterval!Date(Date(2012, 3, 1)).intersects(
+                    Interval!Date(Date(1999, 1, 12), Date(2011, 9, 17))));
+
+        assert(!NegInfInterval!Date(Date(2012, 3, 1)).intersects(
+                    Interval!Date(Date(2022, 10, 19), Date(2027, 6, 3))));
+    }
 
     /++
         Whether the given interval overlaps this interval.
@@ -23394,21 +23411,21 @@ assert(!NegInfInterval!Date(Date(2012, 3, 1)).intersects(
         Params:
             interval = The interval to check for intersection with this
                        interval.
-
-        Example:
---------------------
-assert(NegInfInterval!Date(Date(2012, 3, 1)).intersects(
-            PosInfInterval!Date(Date(1999, 5, 4))));
-
-assert(!NegInfInterval!Date(Date(2012, 3, 1)).intersects(
-            PosInfInterval!Date(Date(2012, 3, 1))));
---------------------
       +/
     bool intersects(in PosInfInterval!TP interval) const pure nothrow
     {
         return interval._begin < _end;
     }
 
+    ///
+    unittest
+    {
+        assert(NegInfInterval!Date(Date(2012, 3, 1)).intersects(
+                    PosInfInterval!Date(Date(1999, 5, 4))));
+
+        assert(!NegInfInterval!Date(Date(2012, 3, 1)).intersects(
+                    PosInfInterval!Date(Date(2012, 3, 1))));
+    }
 
     /++
         Whether the given interval overlaps this interval.
@@ -23418,21 +23435,21 @@ assert(!NegInfInterval!Date(Date(2012, 3, 1)).intersects(
 
         Params:
             interval = The interval to check for intersection with this interval.
-
-        Example:
---------------------
-assert(NegInfInterval!Date(Date(2012, 3, 1)).intersects(
-            NegInfInterval!Date(Date(1996, 5, 4))));
-
-assert(NegInfInterval!Date(Date(2012, 3, 1)).intersects(
-            NegInfInterval!Date(Date(2013, 7, 9))));
---------------------
       +/
     bool intersects(in NegInfInterval!TP interval) const pure nothrow
     {
         return true;
     }
 
+    ///
+    unittest
+    {
+        assert(NegInfInterval!Date(Date(2012, 3, 1)).intersects(
+                    NegInfInterval!Date(Date(1996, 5, 4))));
+
+        assert(NegInfInterval!Date(Date(2012, 3, 1)).intersects(
+                    NegInfInterval!Date(Date(2013, 7, 9))));
+    }
 
     /++
         Returns the intersection of two intervals
@@ -23443,17 +23460,6 @@ assert(NegInfInterval!Date(Date(2012, 3, 1)).intersects(
         Throws:
             $(LREF DateTimeException) if the two intervals do not intersect or if
             the given interval is empty.
-
-        Example:
---------------------
-assert(NegInfInterval!Date(Date(2012, 3, 1)).intersection(
-            Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))) ==
-       Interval!Date(Date(1990, 7 , 6), Date(2000, 8, 2)));
-
-assert(NegInfInterval!Date(Date(2012, 3, 1)).intersection(
-            Interval!Date(Date(1999, 1, 12), Date(2015, 9, 2))) ==
-       Interval!Date(Date(1999, 1 , 12), Date(2012, 3, 1)));
---------------------
       +/
     Interval!TP intersection(in Interval!TP interval) const
     {
@@ -23466,6 +23472,17 @@ assert(NegInfInterval!Date(Date(2012, 3, 1)).intersection(
         return Interval!TP(interval._begin, end);
     }
 
+    ///
+    unittest
+    {
+        assert(NegInfInterval!Date(Date(2012, 3, 1)).intersection(
+                    Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))) ==
+               Interval!Date(Date(1990, 7 , 6), Date(2000, 8, 2)));
+
+        assert(NegInfInterval!Date(Date(2012, 3, 1)).intersection(
+                    Interval!Date(Date(1999, 1, 12), Date(2015, 9, 2))) ==
+               Interval!Date(Date(1999, 1 , 12), Date(2012, 3, 1)));
+    }
 
     /++
         Returns the intersection of two intervals
@@ -23475,17 +23492,6 @@ assert(NegInfInterval!Date(Date(2012, 3, 1)).intersection(
 
         Throws:
             $(LREF DateTimeException) if the two intervals do not intersect.
-
-        Example:
---------------------
-assert(NegInfInterval!Date(Date(2012, 3, 1)).intersection(
-            PosInfInterval!Date(Date(1990, 7, 6))) ==
-       Interval!Date(Date(1990, 7 , 6), Date(2012, 3, 1)));
-
-assert(NegInfInterval!Date(Date(2012, 3, 1)).intersection(
-            PosInfInterval!Date(Date(1999, 1, 12))) ==
-       Interval!Date(Date(1999, 1 , 12), Date(2012, 3, 1)));
---------------------
       +/
     Interval!TP intersection(in PosInfInterval!TP interval) const
     {
@@ -23496,29 +23502,40 @@ assert(NegInfInterval!Date(Date(2012, 3, 1)).intersection(
         return Interval!TP(interval._begin, _end);
     }
 
+    ///
+    unittest
+    {
+        assert(NegInfInterval!Date(Date(2012, 3, 1)).intersection(
+                    PosInfInterval!Date(Date(1990, 7, 6))) ==
+               Interval!Date(Date(1990, 7 , 6), Date(2012, 3, 1)));
+
+        assert(NegInfInterval!Date(Date(2012, 3, 1)).intersection(
+                    PosInfInterval!Date(Date(1999, 1, 12))) ==
+               Interval!Date(Date(1999, 1 , 12), Date(2012, 3, 1)));
+    }
 
     /++
         Returns the intersection of two intervals
 
         Params:
             interval = The interval to intersect with this interval.
-
-        Example:
---------------------
-assert(NegInfInterval!Date(Date(2012, 3, 1)).intersection(
-            NegInfInterval!Date(Date(1999, 7, 6))) ==
-       NegInfInterval!Date(Date(1999, 7 , 6)));
-
-assert(NegInfInterval!Date(Date(2012, 3, 1)).intersection(
-            NegInfInterval!Date(Date(2013, 1, 12))) ==
-       NegInfInterval!Date(Date(2012, 3 , 1)));
---------------------
       +/
     NegInfInterval intersection(in NegInfInterval interval) const nothrow
     {
         return NegInfInterval(_end < interval._end ? _end : interval._end);
     }
 
+    ///
+    unittest
+    {
+        assert(NegInfInterval!Date(Date(2012, 3, 1)).intersection(
+                    NegInfInterval!Date(Date(1999, 7, 6))) ==
+               NegInfInterval!Date(Date(1999, 7 , 6)));
+
+        assert(NegInfInterval!Date(Date(2012, 3, 1)).intersection(
+                    NegInfInterval!Date(Date(2013, 1, 12))) ==
+               NegInfInterval!Date(Date(2012, 3 , 1)));
+    }
 
     /++
         Whether the given interval is adjacent to this interval.
@@ -23529,21 +23546,6 @@ assert(NegInfInterval!Date(Date(2012, 3, 1)).intersection(
 
         Throws:
             $(LREF DateTimeException) if the given interval is empty.
-
-        Example:
---------------------
-assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAdjacent(
-            Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
-
-assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAdjacent(
-            Interval!Date(Date(1999, 1, 12), Date(2012, 3, 1))));
-
-assert(NegInfInterval!Date(Date(2012, 3, 1)).isAdjacent(
-            Interval!Date(Date(2012, 3, 1), Date(2019, 2, 2))));
-
-assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAdjacent(
-            Interval!Date(Date(2022, 10, 19), Date(2027, 6, 3))));
---------------------
       +/
     bool isAdjacent(in Interval!TP interval) const pure
     {
@@ -23552,6 +23554,21 @@ assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAdjacent(
         return interval._begin == _end;
     }
 
+    ///
+    unittest
+    {
+        assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAdjacent(
+                    Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))));
+
+        assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAdjacent(
+                    Interval!Date(Date(1999, 1, 12), Date(2012, 3, 1))));
+
+        assert(NegInfInterval!Date(Date(2012, 3, 1)).isAdjacent(
+                    Interval!Date(Date(2012, 3, 1), Date(2019, 2, 2))));
+
+        assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAdjacent(
+                    Interval!Date(Date(2022, 10, 19), Date(2027, 6, 3))));
+    }
 
     /++
         Whether the given interval is adjacent to this interval.
@@ -23559,21 +23576,21 @@ assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAdjacent(
         Params:
             interval = The interval to check whether its adjecent to this
                        interval.
-
-        Example:
---------------------
-assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAdjacent(
-            PosInfInterval!Date(Date(1999, 5, 4))));
-
-assert(NegInfInterval!Date(Date(2012, 3, 1)).isAdjacent(
-            PosInfInterval!Date(Date(2012, 3, 1))));
---------------------
       +/
     bool isAdjacent(in PosInfInterval!TP interval) const pure nothrow
     {
         return interval._begin == _end;
     }
 
+    ///
+    unittest
+    {
+        assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAdjacent(
+                    PosInfInterval!Date(Date(1999, 5, 4))));
+
+        assert(NegInfInterval!Date(Date(2012, 3, 1)).isAdjacent(
+                    PosInfInterval!Date(Date(2012, 3, 1))));
+    }
 
     /++
         Whether the given interval is adjacent to this interval.
@@ -23584,21 +23601,21 @@ assert(NegInfInterval!Date(Date(2012, 3, 1)).isAdjacent(
         Params:
             interval = The interval to check whether its adjecent to this
                        interval.
-
-        Example:
---------------------
-assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAdjacent(
-            NegInfInterval!Date(Date(1996, 5, 4))));
-
-assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAdjacent(
-            NegInfInterval!Date(Date(2012, 3, 1))));
---------------------
       +/
     bool isAdjacent(in NegInfInterval interval) const pure nothrow
     {
         return false;
     }
 
+    ///
+    unittest
+    {
+        assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAdjacent(
+                    NegInfInterval!Date(Date(1996, 5, 4))));
+
+        assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAdjacent(
+                    NegInfInterval!Date(Date(2012, 3, 1))));
+    }
 
     /++
         Returns the union of two intervals
@@ -23615,17 +23632,6 @@ assert(!NegInfInterval!Date(Date(2012, 3, 1)).isAdjacent(
             $(D PosInfInterval), because an interval
             going from negative infinity to positive infinity
             is not possible.
-
-        Example:
---------------------
-assert(NegInfInterval!Date(Date(2012, 3, 1)).merge(
-            Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))) ==
-       NegInfInterval!Date(Date(2012, 3 , 1)));
-
-assert(NegInfInterval!Date(Date(2012, 3, 1)).merge(
-            Interval!Date(Date(1999, 1, 12), Date(2015, 9, 2))) ==
-       NegInfInterval!Date(Date(2015, 9 , 2)));
---------------------
       +/
     NegInfInterval merge(in Interval!TP interval) const
     {
@@ -23637,6 +23643,17 @@ assert(NegInfInterval!Date(Date(2012, 3, 1)).merge(
         return NegInfInterval(_end > interval._end ? _end : interval._end);
     }
 
+    ///
+    unittest
+    {
+        assert(NegInfInterval!Date(Date(2012, 3, 1)).merge(
+                    Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))) ==
+               NegInfInterval!Date(Date(2012, 3 , 1)));
+
+        assert(NegInfInterval!Date(Date(2012, 3, 1)).merge(
+                    Interval!Date(Date(1999, 1, 12), Date(2015, 9, 2))) ==
+               NegInfInterval!Date(Date(2015, 9 , 2)));
+    }
 
     /++
         Returns the union of two intervals
@@ -23649,23 +23666,23 @@ assert(NegInfInterval!Date(Date(2012, 3, 1)).merge(
             $(D PosInfInterval), because an interval
             going from negative infinity to positive infinity
             is not possible.
-
-        Example:
---------------------
-assert(NegInfInterval!Date(Date(2012, 3, 1)).merge(
-            NegInfInterval!Date(Date(1999, 7, 6))) ==
-       NegInfInterval!Date(Date(2012, 3 , 1)));
-
-assert(NegInfInterval!Date(Date(2012, 3, 1)).merge(
-            NegInfInterval!Date(Date(2013, 1, 12))) ==
-       NegInfInterval!Date(Date(2013, 1 , 12)));
---------------------
       +/
     NegInfInterval merge(in NegInfInterval interval) const pure nothrow
     {
         return NegInfInterval(_end > interval._end ? _end : interval._end);
     }
 
+    ///
+    unittest
+    {
+        assert(NegInfInterval!Date(Date(2012, 3, 1)).merge(
+                    NegInfInterval!Date(Date(1999, 7, 6))) ==
+               NegInfInterval!Date(Date(2012, 3 , 1)));
+
+        assert(NegInfInterval!Date(Date(2012, 3, 1)).merge(
+                    NegInfInterval!Date(Date(2013, 1, 12))) ==
+               NegInfInterval!Date(Date(2013, 1 , 12)));
+    }
 
     /++
         Returns an interval that covers from the earliest time point of two
@@ -23684,21 +23701,6 @@ assert(NegInfInterval!Date(Date(2012, 3, 1)).merge(
             $(D PosInfInterval), because an interval
             going from negative infinity to positive infinity
             is not possible.
-
-        Example:
---------------------
-assert(NegInfInterval!Date(Date(2012, 3, 1)).span(
-            Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))) ==
-       NegInfInterval!Date(Date(2012, 3 , 1)));
-
-assert(NegInfInterval!Date(Date(2012, 3, 1)).span(
-            Interval!Date(Date(1999, 1, 12), Date(2015, 9, 2))) ==
-       NegInfInterval!Date(Date(2015, 9 , 2)));
-
-assert(NegInfInterval!Date(Date(1600, 1, 7)).span(
-            Interval!Date(Date(2012, 3, 11), Date(2017, 7, 1))) ==
-       NegInfInterval!Date(Date(2017, 7 , 1)));
---------------------
       +/
     NegInfInterval span(in Interval!TP interval) const pure
     {
@@ -23707,6 +23709,21 @@ assert(NegInfInterval!Date(Date(1600, 1, 7)).span(
         return NegInfInterval(_end > interval._end ? _end : interval._end);
     }
 
+    ///
+    unittest
+    {
+        assert(NegInfInterval!Date(Date(2012, 3, 1)).span(
+                    Interval!Date(Date(1990, 7, 6), Date(2000, 8, 2))) ==
+               NegInfInterval!Date(Date(2012, 3 , 1)));
+
+        assert(NegInfInterval!Date(Date(2012, 3, 1)).span(
+                    Interval!Date(Date(1999, 1, 12), Date(2015, 9, 2))) ==
+               NegInfInterval!Date(Date(2015, 9 , 2)));
+
+        assert(NegInfInterval!Date(Date(1600, 1, 7)).span(
+                    Interval!Date(Date(2012, 3, 11), Date(2017, 7, 1))) ==
+               NegInfInterval!Date(Date(2017, 7 , 1)));
+    }
 
     /++
         Returns an interval that covers from the earliest time point of two
@@ -23722,23 +23739,23 @@ assert(NegInfInterval!Date(Date(1600, 1, 7)).span(
             $(D PosInfInterval), because an interval
             going from negative infinity to positive infinity
             is not possible.
-
-        Example:
---------------------
-assert(NegInfInterval!Date(Date(2012, 3, 1)).span(
-            NegInfInterval!Date(Date(1999, 7, 6))) ==
-       NegInfInterval!Date(Date(2012, 3 , 1)));
-
-assert(NegInfInterval!Date(Date(2012, 3, 1)).span(
-            NegInfInterval!Date(Date(2013, 1, 12))) ==
-       NegInfInterval!Date(Date(2013, 1 , 12)));
---------------------
       +/
     NegInfInterval span(in NegInfInterval interval) const pure nothrow
     {
         return NegInfInterval(_end > interval._end ? _end : interval._end);
     }
 
+    ///
+    unittest
+    {
+        assert(NegInfInterval!Date(Date(2012, 3, 1)).span(
+                    NegInfInterval!Date(Date(1999, 7, 6))) ==
+               NegInfInterval!Date(Date(2012, 3 , 1)));
+
+        assert(NegInfInterval!Date(Date(2012, 3, 1)).span(
+                    NegInfInterval!Date(Date(2013, 1, 12))) ==
+               NegInfInterval!Date(Date(2013, 1 , 12)));
+    }
 
     /++
         Shifts the $(D end) of this interval forward or backwards in time by the
@@ -23748,18 +23765,6 @@ assert(NegInfInterval!Date(Date(2012, 3, 1)).span(
 
         Params:
             duration = The duration to shift the interval by.
-
-        Example:
---------------------
-auto interval1 = NegInfInterval!Date(Date(2012, 4, 5));
-auto interval2 = NegInfInterval!Date(Date(2012, 4, 5));
-
-interval1.shift(dur!"days"(50));
-assert(interval1 == NegInfInterval!Date(Date(2012, 5, 25)));
-
-interval2.shift(dur!"days"(-50));
-assert(interval2 == NegInfInterval!Date( Date(2012, 2, 15)));
---------------------
       +/
     void shift(D)(D duration) pure nothrow
         if(__traits(compiles, end + duration))
@@ -23767,6 +23772,18 @@ assert(interval2 == NegInfInterval!Date( Date(2012, 2, 15)));
         _end += duration;
     }
 
+    ///
+    unittest
+    {
+        auto interval1 = NegInfInterval!Date(Date(2012, 4, 5));
+        auto interval2 = NegInfInterval!Date(Date(2012, 4, 5));
+
+        interval1.shift(dur!"days"(50));
+        assert(interval1 == NegInfInterval!Date(Date(2012, 5, 25)));
+
+        interval2.shift(dur!"days"(-50));
+        assert(interval2 == NegInfInterval!Date( Date(2012, 2, 15)));
+    }
 
     static if(__traits(compiles, end.add!"months"(1)) &&
               __traits(compiles, end.add!"years"(1)))
@@ -23788,18 +23805,6 @@ assert(interval2 == NegInfInterval!Date( Date(2012, 2, 15)));
             Throws:
                 $(LREF DateTimeException) if empty is true or if the resulting
                 interval would be invalid.
-
-            Example:
---------------------
-auto interval1 = NegInfInterval!Date(Date(2012, 3, 1));
-auto interval2 = NegInfInterval!Date(Date(2012, 3, 1));
-
-interval1.shift(2);
-assert(interval1 == NegInfInterval!Date(Date(2014, 3, 1)));
-
-interval2.shift(-2);
-assert(interval2 == NegInfInterval!Date(Date(2010, 3, 1)));
---------------------
           +/
         void shift(T)(T years, T months = 0, AllowDayOverflow allowOverflow = AllowDayOverflow.yes)
             if(isIntegral!T)
@@ -23811,6 +23816,19 @@ assert(interval2 == NegInfInterval!Date(Date(2010, 3, 1)));
 
             _end = end;
         }
+
+        ///
+        unittest
+        {
+            auto interval1 = NegInfInterval!Date(Date(2012, 3, 1));
+            auto interval2 = NegInfInterval!Date(Date(2012, 3, 1));
+
+            interval1.shift(2);
+            assert(interval1 == NegInfInterval!Date(Date(2014, 3, 1)));
+
+            interval2.shift(-2);
+            assert(interval2 == NegInfInterval!Date(Date(2010, 3, 1)));
+        }
     }
 
 
@@ -23820,18 +23838,6 @@ assert(interval2 == NegInfInterval!Date(Date(2010, 3, 1)));
 
         Params:
             duration = The duration to expand the interval by.
-
-        Example:
---------------------
-auto interval1 = NegInfInterval!Date(Date(2012, 3, 1));
-auto interval2 = NegInfInterval!Date(Date(2012, 3, 1));
-
-interval1.expand(dur!"days"(2));
-assert(interval1 == NegInfInterval!Date(Date(2012, 3, 3)));
-
-interval2.expand(dur!"days"(-2));
-assert(interval2 == NegInfInterval!Date(Date(2012, 2, 28)));
---------------------
       +/
     void expand(D)(D duration) pure nothrow
         if(__traits(compiles, end + duration))
@@ -23839,6 +23845,19 @@ assert(interval2 == NegInfInterval!Date(Date(2012, 2, 28)));
         _end += duration;
     }
 
+
+    ///
+    unittest
+    {
+        auto interval1 = NegInfInterval!Date(Date(2012, 3, 1));
+        auto interval2 = NegInfInterval!Date(Date(2012, 3, 1));
+
+        interval1.expand(dur!"days"(2));
+        assert(interval1 == NegInfInterval!Date(Date(2012, 3, 3)));
+
+        interval2.expand(dur!"days"(-2));
+        assert(interval2 == NegInfInterval!Date(Date(2012, 2, 28)));
+    }
 
     static if(__traits(compiles, end.add!"months"(1)) &&
               __traits(compiles, end.add!"years"(1)))
@@ -23856,18 +23875,6 @@ assert(interval2 == NegInfInterval!Date(Date(2012, 2, 28)));
             Throws:
                 $(LREF DateTimeException) if empty is true or if the resulting
                 interval would be invalid.
-
-            Example:
---------------------
-auto interval1 = NegInfInterval!Date(Date(2012, 3, 1));
-auto interval2 = NegInfInterval!Date(Date(2012, 3, 1));
-
-interval1.expand(2);
-assert(interval1 == NegInfInterval!Date(Date(2014, 3, 1)));
-
-interval2.expand(-2);
-assert(interval2 == NegInfInterval!Date(Date(2010, 3, 1)));
---------------------
           +/
         void expand(T)(T years, T months = 0, AllowDayOverflow allowOverflow = AllowDayOverflow.yes)
             if(isIntegral!T)
@@ -23880,6 +23887,19 @@ assert(interval2 == NegInfInterval!Date(Date(2010, 3, 1)));
             _end = end;
 
             return;
+        }
+
+        ///
+        unittest
+        {
+            auto interval1 = NegInfInterval!Date(Date(2012, 3, 1));
+            auto interval2 = NegInfInterval!Date(Date(2012, 3, 1));
+
+            interval1.expand(2);
+            assert(interval1 == NegInfInterval!Date(Date(2014, 3, 1)));
+
+            interval2.expand(-2);
+            assert(interval2 == NegInfInterval!Date(Date(2010, 3, 1)));
         }
     }
 
@@ -23930,36 +23950,6 @@ assert(interval2 == NegInfInterval!Date(Date(2010, 3, 1)));
 
             Of course, none of the functions in this module have this problem,
             so it's only relevant for custom delegates.
-
-        Example:
---------------------
-auto interval = NegInfInterval!Date(Date(2010, 9, 9));
-auto func = (in Date date) //For iterating over even-numbered days.
-            {
-                if((date.day & 1) == 0)
-                    return date - dur!"days"(2);
-
-                return date - dur!"days"(1);
-            };
-auto range = interval.bwdRange(func);
-
-assert(range.front == Date(2010, 9, 9)); //An odd day. Using PopFirst.yes would have made this Date(2010, 9, 8).
-
-range.popFront();
-assert(range.front == Date(2010, 9, 8));
-
-range.popFront();
-assert(range.front == Date(2010, 9, 6));
-
-range.popFront();
-assert(range.front == Date(2010, 9, 4));
-
-range.popFront();
-assert(range.front == Date(2010, 9, 2));
-
-range.popFront();
-assert(!range.empty);
---------------------
       +/
     NegInfIntervalRange!(TP) bwdRange(TP delegate(in TP) func, PopFirst popFirst = PopFirst.no) const
     {
@@ -23971,6 +23961,36 @@ assert(!range.empty);
         return range;
     }
 
+    ///
+    unittest
+    {
+        auto interval = NegInfInterval!Date(Date(2010, 9, 9));
+        auto func = (in Date date) //For iterating over even-numbered days.
+                    {
+                        if((date.day & 1) == 0)
+                            return date - dur!"days"(2);
+
+                        return date - dur!"days"(1);
+                    };
+        auto range = interval.bwdRange(func);
+
+        assert(range.front == Date(2010, 9, 9)); //An odd day. Using PopFirst.yes would have made this Date(2010, 9, 8).
+
+        range.popFront();
+        assert(range.front == Date(2010, 9, 8));
+
+        range.popFront();
+        assert(range.front == Date(2010, 9, 6));
+
+        range.popFront();
+        assert(range.front == Date(2010, 9, 4));
+
+        range.popFront();
+        assert(range.front == Date(2010, 9, 2));
+
+        range.popFront();
+        assert(!range.empty);
+    }
 
     /+
         Converts this interval to a string.

--- a/std/datetime.d
+++ b/std/datetime.d
@@ -17931,7 +17931,7 @@ Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1));
     ///
     unittest
     {
-        assert(Interval!Date(Date(1996, 1, 2), dur!"years"(3)) ==
+        assert(Interval!Date(Date(1996, 1, 2), dur!"days"(1096)) ==
                Interval!Date(Date(1996, 1, 2), Date(1999, 1, 2)));
     }
 
@@ -18453,11 +18453,11 @@ Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1));
     ///
     unittest
     {
-        assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersects(
-                    PosInfInterval!Date(Date(1999, 5, 4))));
+assert(Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersects(
+            PosInfInterval!Date(Date(1999, 5, 4))));
 
-        assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersects(
-                    PosInfInterval!Date(Date(2012, 3, 1))));
+assert(!Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1)).intersects(
+            PosInfInterval!Date(Date(2012, 3, 1))));
     }
 
     /++
@@ -19185,7 +19185,7 @@ Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1));
     unittest
     {
         auto interval = Interval!Date(Date(2010, 9, 1), Date(2010, 9, 9));
-        auto func = (in Date date) //For iterating over even-numbered days.
+        auto func = (in Date date) const //For iterating over even-numbered days.
                     {
                         if((date.day & 1) == 0)
                             return date + dur!"days"(2);
@@ -19278,7 +19278,7 @@ Interval!Date(Date(1996, 1, 2), Date(2012, 3, 1));
     unittest
     {
         auto interval = Interval!Date(Date(2010, 9, 1), Date(2010, 9, 9));
-        auto func = (in Date date) //For iterating over even-numbered days.
+        auto func = (in Date date) const //For iterating over even-numbered days.
                     {
                         if((date.day & 1) == 0)
                             return date - dur!"days"(2);
@@ -21756,7 +21756,7 @@ auto interval = PosInfInterval!Date(Date(1996, 1, 2));
     unittest
     {
         auto interval = PosInfInterval!Date(Date(2010, 9, 1));
-        auto func = (in Date date) //For iterating over even-numbered days.
+        auto func = (in Date date) const //For iterating over even-numbered days.
                     {
                         if((date.day & 1) == 0)
                             return date + dur!"days"(2);
@@ -23965,7 +23965,7 @@ auto interval = PosInfInterval!Date(Date(1996, 1, 2));
     unittest
     {
         auto interval = NegInfInterval!Date(Date(2010, 9, 9));
-        auto func = (in Date date) //For iterating over even-numbered days.
+        auto func = (in Date date) const //For iterating over even-numbered days.
                     {
                         if((date.day & 1) == 0)
                             return date - dur!"days"(2);


### PR DESCRIPTION
Hey it seems like the datetime.d module is a bit messy - nevertheless I propose to convert its examples to unittests.

The PR is split in two parts:
a) "dumb" conversion from docstring to unittest (>100 tests, large commit)
b) small fixes to unittests (more interesting)

The unittests are displayed on my local machine, let's see what Doctester says ;-)

(Github did automatically closed #4048 once I rebased - sorry ...)