### PR TITLE
Fix big endian version of std.digest.md and std.digest.ripemd.

### DIFF
--- a/std/digest/md.d
+++ b/std/digest/md.d
@@ -192,6 +192,8 @@ struct MD5
 
             version(BigEndian)
             {
+                import std.bitmanip : nativeToLittleEndian;
+
                 for(size_t i = 0; i < 16; i++)
                 {
                     x[i] = littleEndianToNative!uint(*cast(ubyte[4]*)&(*block)[i*4]);

--- a/std/digest/ripemd.d
+++ b/std/digest/ripemd.d
@@ -237,6 +237,8 @@ struct RIPEMD160
 
             version(BigEndian)
             {
+                import std.bitmanip : nativeToLittleEndian;
+
                 for(size_t i = 0; i < 16; i++)
                 {
                     x[i] = littleEndianToNative!uint(*cast(ubyte[4]*)&(*block)[i*4]);


### PR DESCRIPTION
An import is missing.