### PR TITLE
Fix Issue 15773 - D's treatment of whitespace in character classes in free-from regexes is not the same as Perl's

### DIFF
--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -179,6 +179,7 @@
        as well as start and end of input.)
     $(REG_ROW s, Single-line mode, makes . match '\n' and '\r' as well. )
     $(REG_ROW x, Free-form syntax, ignores whitespace in pattern,
+      including inside character classes:
       useful for formatting complex regular expressions. )
   )
 


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=15773

Documents the fact that free-form mode ignores whitespace inside character classes; this behaviour differs from Perl's, and will trip up people coming to D from Perl.