### PR TITLE
 use timelimit to kill deadlocked tests

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -120,6 +120,9 @@ endif
 
 LINKDL:=$(if $(findstring $(OS),linux),-L-ldl,)
 
+# use timelimit to avoid deadlocks if available
+TIMELIMIT:=$(if $(shell which timelimit 2>/dev/null || true),timelimit -t 60 ,)
+
 # Set VERSION, where the file is that contains the version string
 VERSION=../dmd/VERSION
 
@@ -344,7 +347,7 @@ moduleName=$(subst /,.,$(1))
 
 # target for batch unittests (using shared phobos library and test_runner)
 unittest/%.run : $(ROOT)/unittest/test_runner
-	$(QUIET)$(RUN) $< $(call moduleName,$*)
+	$(QUIET)$(TIMELIMIT)$(RUN) $< $(call moduleName,$*)
 
 # Target for quickly running a single unittest (using static phobos library).
 # For example: "make std/algorithm/mutation.test"

--- a/posix.mak
+++ b/posix.mak
@@ -26,7 +26,7 @@
 # OS can be linux, win32, win32wine, osx, or freebsd. The system will be
 # determined by using uname
 
-QUIET:=@
+QUIET:=
 
 include osmodel.mak
 


### PR DESCRIPTION
- restrict any test to 60s
- don't trigger the 1h timeout for the auto-tester
- get a make error message w/ a specific test on timeout failure
- the timelimit program is used b/c the auto-tester already relies on it

See also https://github.com/D-Programming-Language/druntime/pull/1503