### PR TITLE
std.range.chunks for InputRanges (buffered)

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -6449,6 +6449,97 @@ if (isForwardRange!Source)
     return typeof(return)(source, chunkSize);
 }
 
+// allows chunks to be used with InputRanges by buffering them
+private struct ChunksBuffered(bool withCopies = true, Source)
+{
+    private Source _source;
+    private size_t _chunkSize;
+    private ElementType!(Source)[] _els;
+    private bool _isBuffered;
+
+    this (Source source, size_t chunkSize)
+    {
+        this._source = source;
+        this._chunkSize = chunkSize;
+        this._els  = new ElementType!(Source)[](_chunkSize);
+    }
+
+    private void _pop()
+    {
+        // create new array -> make other mutable
+        if(_source.empty)
+        {
+            // soft catch in case we reached the end
+            _els = null;
+        }
+        else
+        {
+            if (!_isBuffered)
+                _isBuffered = true;
+
+            // sometime the user does want to store the output
+            if (withCopies)
+                this._els  = new ElementType!(Source)[](_chunkSize);
+
+            for (int i = 0; i < _chunkSize; i++)
+            {
+                if(_source.empty)
+                {
+                    _els.length = i;
+                    break;
+                }
+                ElementType!Source el = _source.front;
+                _els[i] = el;
+                _source.popFront();
+            }
+        }
+    }
+
+    void popFront(){
+        assert(!empty, "empty array");
+        if (!_isBuffered){
+            // call twice if not called before
+            _pop();
+        }
+        _pop();
+    }
+
+    @property bool empty(){
+        return _source.empty && _els is null;
+    }
+
+    @property auto ref front(){
+        assert(!empty, "r is already empty");
+        if (!_isBuffered){
+            // load buffer if called for the first time
+            _pop();
+        }
+        return _els;
+    }
+
+    static if (hasLength!Source)
+    {
+        @property size_t length()
+        {
+            // see overflow warning from chunks
+            return cast(size_t)((cast(ulong)(_source.length) + _chunkSize - 1) / _chunkSize);
+        }
+    }
+
+}
+
+/// Ditto
+ChunksBuffered!(withCopies, Source) chunkss(bool withCopies = false, Source)(Source source, size_t chunkSize)
+if ((!isForwardRange!Source) && isInputRange!Source)
+in
+{
+    assert(chunkSize >= 1, "Invalid chunkSize");
+}
+body
+{
+    return ChunksBuffered!(withCopies, Source)(source, chunkSize);
+}
+
 ///
 @safe unittest
 {
@@ -6537,7 +6628,40 @@ unittest
     assert(equal!`equal(a, b)`(oddsByPairs[3 .. $].take(2), [[13, 15], [17, 19]]));
 }
 
+unittest
+{
+    // test chunks with only input ranges
+    import std.algorithm : equal;
 
+    // this might conflict with std.stdio.chunks
+    // this import checks that!
+    import std.stdio;
+
+    int i = 0;
+    auto r = generate!(() => i++)().take(6);
+    assert(isInputRange!(typeof(r)) && !isForwardRange!(typeof(r)));
+
+    // if the underlying source buffer has a length, so do we
+    assert(r.chunkss(2).length == 3);
+
+    // by default it will override its buffer
+    assert(r.chunkss(2).array == [[4, 5], [4, 5], [4, 5]]);
+
+    // it is intended for one-time consuming ranges
+    i = 0;
+    auto r2 = generate!(() => i++)().take(6);
+    assert(r2.chunkss(2).equal([[0, 1], [2, 3], [4, 5]]));
+
+    // however just in case there is flag to make copies
+    i = 0;
+    //auto r3 = generate!(() => i++)().take(6);
+    //assert(r3.chunkss!true(2).array == [[0, 1], [2, 3], [4, 5]]);
+
+    // non-equal sized ranges are supported too
+    i = 0;
+    auto r4 = generate!(() => i++)().take(4);
+    assert(r4.chunkss(3).equal([[0, 1, 2], [3]]));
+}
 
 /**
 This range splits a $(D source) range into $(D chunkCount) chunks of


### PR DESCRIPTION
Hey all,

this is very vague proposal to allow `chunks` to be used on transient InputRanges that can't be saved (e.g. byLine). The current implementation has (at least) one major flaw, but I wanted to put this initial version up so we can start a discussion. Therefore I would like to know where you stand on such addition (if properly done)?

Moreover there a couple of things that I would like your feedback on:

- proper by reference buffering (maybe there is a better way to have such a buffering - AFAIK currently primitive values and structs are copied)
- conflicts with `chunks` from `std.stdio` (that's why it is named `chunkss` - for some reason the overloading doesn't work so nicely as for the normal `chunks` in Range)
- is it recommended to put the struct into a function or not (I have seen both styles in Phobos)
- I have added a template flag that users can use if they want to obtain a non-transient buffer - is such a flag common in phobos and do you also regard it as useful?

Thanks for your input,

--------------------------------------------------------
Here's a copy of the post from the forum, to give you the motivation
http://forum.dlang.org/post/oidujhauyroygigrqddx@forum.dlang.org

tl;dr: It would be nice if `chunks` would accept only an InputRange too.

Let me show you a common pattern that I often use:

We want to iterate over two lines in a pair and compute the difference between them, e.g.

```
1 2
2 3
```
=> 2

stdin.byLine.map!(x => x.split(' ').map!(to!int)).chunks(2)).map(x =>
  abs(x.front.sum - x.dropOne.front.sum);
);

This currently doesn't compile, because `chunks` doesn't buffer, it saves the state of the forward range. However adding support for normal Input Ranges  can easily done using a buffer - it will of course require more memory as the .save implementation, however handling of ForwardRanges won't be affected.

I have seen this has been discussed more often [2,3]. The only argument against it was in [3] the missing manpower.
However I have already written such a simple buffering [4] in the past and would be happy to wrap this up nicely and (hopefully) bring it into a "phobos" shape - any thoughts/concerns?

[1] https://issues.dlang.org/show_bug.cgi?id=15759
[2] https://issues.dlang.org/show_bug.cgi?id=6621
[3] http://forum.dlang.org/post/omkpvigktgrgbzemhhuc@forum.dlang.org
[4] https://github.com/greenify/d-itertools/blob/4afbc804e8b50c797fa206969dc3b4934911a0b9/source/splitwise.d