### PR TITLE
2 minor tweaks to std.regex default engine

### DIFF
--- a/std/regex/internal/thompson.d
+++ b/std/regex/internal/thompson.d
@@ -563,14 +563,8 @@ struct ThreadList(DataIndex)
                 }
                 static if(withInput)
                 {
-                    int test = quickTestFwd(pc1, front, re);
-                    if(test >= 0)
-                    {
-                        worklist.insertFront(fork(t, pc2, t.counter));
-                        t.pc = pc1;
-                    }
-                    else
-                        t.pc = pc2;
+                    worklist.insertFront(fork(t, pc2, t.counter));
+                    t.pc = pc1;
                 }
                 else
                 {
@@ -914,14 +908,13 @@ struct ThreadList(DataIndex)
     //dispose list of threads
     void recycle(ref ThreadList!DataIndex list)
     {
-        auto t = list.tip;
-        while(t)
+        if(list.tip)
         {
-            auto next = t.next;
-            recycle(t);
-            t = next;
+            // just put this head-tail list in front of freelist
+            list.toe.next = freelist;
+            freelist = list.tip;
+            list = list.init;
         }
-        list = list.init;
     }
 
     //creates a copy of master thread with given pc


### PR DESCRIPTION
Roughly 10-15% faster on a few common patterns.

15 minutes with profiler are worth few days of puzzling.

In short - quickTest scans bytecode forward to see if there is something matching current symbol ahead. This trades extra switching on bytecode for avoding to create a new state. It makes sense in backtracking engine to avoid pushing too much on stack. For thompson VM this just adds a extra work since we are going to recheck that same bytecode anyway. 


