### PR TITLE
Use proper right parenthesis in example's comment: "$(RPAREN)" -> ")".

### DIFF
--- a/std/random.d
+++ b/std/random.d
@@ -20,7 +20,7 @@ Example:
 ----
 // Generate a uniformly-distributed integer in the range [0, 14]
 auto i = uniform(0, 15);
-// Generate a uniformly-distributed real in the range [0, 100$(RPAREN)
+// Generate a uniformly-distributed real in the range [0, 100)
 // using a specific random generator
 Random gen;
 auto r = uniform(0.0L, 100.0L, gen);


### PR DESCRIPTION
See first example in the docs for the std.random [1]. Ordinary parenthesis character should be used, not $(RPAREN).

[1] http://dlang.org/phobos-prerelease/std_random.html