### PR TITLE
faster pairwise summation

### DIFF
--- a/std/range/package.d
+++ b/std/range/package.d
@@ -1841,9 +1841,9 @@ if (isInputRange!(Unqual!Range) &&
         if (hasSlicing!R)
         {
             assert(i <= j, "Invalid slice bounds");
-            assert(j - i <= length, "Attempting to slice past the end of a "
+            assert(j <= length, "Attempting to slice past the end of a "
                 ~ Take.stringof);
-            return source[i .. j - i];
+            return source[i .. j];
         }
     }
     else static if (hasLength!R)
@@ -2052,6 +2052,16 @@ if (isInputRange!(Unqual!R) && (isInfinite!(Unqual!R) || !hasSlicing!(Unqual!R) 
 
     immutable myRepeat = repeat(1);
     static assert(is(Take!(typeof(myRepeat))));
+}
+
+@safe nothrow @nogc unittest
+{
+    //check for correct slicing of Take on an infinite range
+    import std.algorithm : equal;
+    foreach (start; 0 .. 4)
+        foreach (stop; start .. 4)
+            assert(iota(4).cycle.take(4)[start .. stop]
+                .equal(iota(start, stop)));
 }
 
 @safe unittest


### PR DESCRIPTION
Using an iterative approach instead of recursive. When I originally wrote this I recorded an order-of-magnitude speedup on arrays and approx. 2x on more complicated ranges.