### PR TITLE
Added Runtime Field Getting and Setting

### DIFF
--- a/std/typecons.d
+++ b/std/typecons.d
@@ -7143,3 +7143,194 @@ unittest
         ubyte, ubyte, T3, T3,
     );
 }
+
+/**
+ * Get a field or property member function by `ref`. Allows getting fields
+ * via runtime information rather than requiring it at compile-time.
+ *
+ * Params:
+ *     obj = the struct or class to access
+ *     name = the name of the field or property method
+ * Returns:
+ *     The value of the field
+ */
+auto getFeild(Field, Obj)(auto ref Obj obj, string name)
+{
+    enum refObj = !is(Obj == class) && (Obj.sizeof > 16);
+    return rtPropDispatch!(false, Field, false, Obj, refObj)(obj, name);
+}
+
+///
+@safe @nogc nothrow pure unittest
+{
+    struct Foo
+    {
+        int bar = 42;
+    }
+
+    Foo foo;
+    int val = foo.getFeild!int("bar");
+    assert(val == 42);
+}
+
+@safe nothrow pure unittest
+{
+    class A
+    {
+        int bar = 42;
+    }
+
+    auto a = new A();
+    int val = a.getFeild!int("bar");
+    assert(val == 42);
+
+    struct B
+    {
+        auto bar() @property { return 42; }
+    }
+
+    B b;
+    int val2 = b.getFeild!int("bar");
+    assert(val == 42);
+}
+
+/**
+ * Get a field or property member function. Allows getting fields
+ * via runtime information rather than requiring it at compile-time.
+ *
+ * Params:
+ *     obj = the struct or class to access
+ *     name = the name of the field or property method
+ * Returns:
+ *     The value of the field or property method by reference
+ */
+ref Field refGetFeild(Field, Obj)(Obj obj, string name) if (is(Obj == class))
+{
+    return rtPropDispatch!(false, Field, true, Obj, false)(obj, name);
+}
+
+/// ditto
+ref Field refGetFeild(Field, Obj)(return ref Obj obj, string name) if (!is(Obj == class))
+{
+    return rtPropDispatch!(false, Field, true, Obj, true)(obj, name);
+}
+
+///
+@safe @nogc nothrow pure unittest
+{
+    struct Foo
+    {
+        int bar = 42;
+    }
+
+    Foo foo;
+    int val = foo.refGetFeild!int("bar");
+    assert(val == 42);
+}
+
+@safe nothrow pure unittest
+{
+    class A
+    {
+        int bar = 42;
+    }
+
+    auto a = new A();
+    int val = a.refGetFeild!int("bar");
+    assert(val == 42);
+
+    struct B
+    {
+        private int b = 42;
+        ref auto bar() @property { return b; }
+    }
+
+    B b;
+    int val2 = b.refGetFeild!int("bar");
+    assert(val == 42);
+}
+
+/**
+ * Set a field or property member function. Allows setting fields
+ * via runtime information rather than requiring it at compile-time.
+ *
+ * Params:
+ *     obj = the struct or class to access
+ *     name = the name of the field or property method
+ */
+void setFeild(Field, Obj)(auto ref Obj obj, string name, auto ref Field value)
+{
+    enum refProp = !is(Field == class) || (Field.sizeof > 16);
+    enum refObj = !is(Obj == class) || (Obj.sizeof > 16);
+    rtPropDispatch!(true, Field, refProp, Obj, refObj)(obj, name, value);
+}
+
+///
+@safe @nogc nothrow pure unittest
+{
+    struct Foo
+    {
+        int bar = 42;
+    }
+
+    Foo foo;
+    foo.setFeild("bar", 24);
+    assert(foo.bar == 24);
+}
+
+@safe nothrow pure unittest
+{
+    class A
+    {
+        int bar = 42;
+    }
+
+    auto a = new A();
+    a.setFeild("bar", 24);
+    assert(a.bar == 24);
+
+    struct B
+    {
+        private int b = 42;
+        auto bar() @property { return b; }
+        auto bar(int val) @property { b = val; }
+    }
+
+    B b;
+    b.setFeild("bar", 24);
+    assert(b.getFeild!int("bar") == 24);
+}
+
+// mixin template for the get/setField functions
+private template rtFieldDispatch(bool set, Field, bool refProp, Obj, bool refObj)
+{
+    private enum propMix = (set ? `` : `return `) ~ `mixin("obj." ~ mName)` ~ (
+        set ? ` = value; return;` : `;`);
+    private enum errorMessage = Obj.stringof ~ " has no " ~
+        (set ? "assignable" : (refProp ? "lvalue " : "")) ~ "property matching " ~ Field.stringof;
+    private enum dispMix = (set ? `void` : (refProp ? `ref Field` : `Field`)) ~ ` rtPropDispatch(` ~ (
+            refObj ? (!set && refProp ? `return ` : ``) ~ `ref ` : ``) ~ `Obj obj, string name` ~ (
+            set ? `, ` ~ (refProp ? `ref ` : ``) ~ `Field value` : ``) ~ `)
+    {
+        ` ~ (
+            set ? `void` : (refProp ? `ref ` : ``) ~ `Field`) ~ ` checkType(string mName)()
+        {
+            if (!__ctfe) assert (0);
+            ` ~ propMix ~ `
+        }
+
+        foreach (mName; __traits (allMembers, Obj))
+        {
+            static if (__traits(compiles, checkType!mName()))
+            {
+                if (mName == name)
+                {
+                    ` ~ propMix ~ `
+                }
+            }
+        }
+
+        assert (0, "`~ errorMessage ~`");
+    } `;
+    mixin(dispMix);
+}


### PR DESCRIPTION
Added a new function `setAttribute`, which allows someone to set an attribute of a type based by accessing the member with a string at runtime.

This is useful when the member being changed can change due to some external factors. For example, I have a library that parses strings for timezone info. The string can contain information for regular UTC offsets or DST offsets, which are both attributes of an internal result type. The info on which to set is only available at runtime. A possible way to refactor such an example is to have a general offset variable and hold some state in the type as to which type of offset the value is referring to, but IMO this is much cleaner.