### PR TITLE
std.stdio: Fix documentation of File.error

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -618,7 +618,7 @@ it has no name.*/
     }
 
 /**
-If the file is not opened, returns $(D false). Otherwise, returns
+If the file is not opened, returns $(D true). Otherwise, returns
 $(WEB cplusplus.com/reference/clibrary/cstdio/ferror.html, ferror) for
 the file handle.
  */


### PR DESCRIPTION
Fixes doc to match code and test.