### PR TITLE
Linux/PPC: Really fix the import for md.d/ripemd.d.

### DIFF
--- a/std/digest/md.d
+++ b/std/digest/md.d
@@ -192,7 +192,7 @@ struct MD5
 
             version(BigEndian)
             {
-                import std.bitmanip : nativeToLittleEndian;
+                import std.bitmanip : littleEndianToNative;
 
                 for(size_t i = 0; i < 16; i++)
                 {

--- a/std/digest/ripemd.d
+++ b/std/digest/ripemd.d
@@ -237,7 +237,7 @@ struct RIPEMD160
 
             version(BigEndian)
             {
-                import std.bitmanip : nativeToLittleEndian;
+                import std.bitmanip : littleEndianToNative;
 
                 for(size_t i = 0; i < 16; i++)
                 {


### PR DESCRIPTION
The current import for version(BigEndian) is still wrong.
This finally fixes the import.