### PR TITLE
fix redundant static checking, keep the deeper one from 15772

### DIFF
--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -453,11 +453,7 @@ auto make(T, Allocator, A...)(auto ref Allocator alloc, auto ref A args)
     if (!m.ptr) return null;
     scope(failure) alloc.deallocate(m);
     static if (is(T == class))
-    {
-        static assert(!isAbstractClass!T, "class " ~ T.stringof ~
-            " is abstract and can't be created with make()");
         return emplace!T(m, args);
-    }
     else return emplace(cast(T*) m.ptr, args);
 }
 
@@ -495,7 +491,7 @@ unittest
     assert(cust.id == 42);
 }
 
-unittest // bugzilla 15639
+unittest // bugzilla 15639 & 15772
 {
     abstract class Foo {}
     class Bar: Foo {}


### PR DESCRIPTION
revert the changes made in #4023 because they are more deeply fixed in #4057. However keep unittest to verify that 15639 is still well fixed.