### PR TITLE
update changelog: range support for the convenience wrapper redBlackTree

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -22,6 +22,8 @@ $(LI $(RELATIVE_LINK2 unary, Unary overloads of $(REF startsWith std,algorithm,s
 $(REF endsWith std,algorithm,searching) were added.))
 $(LI $(RELATIVE_LINK2 maxCount, $(REF maxCount std,algorithm,searching) and
 $(REF maxPos std,algorithm,searching) were added.))
+$(LI $(LNAME2 range support for the convenience wrapper $(REF redBlackTree std,container,rbtree)
+was added))
 )
 
 $(BUGSTITLE Library Changes,


### PR DESCRIPTION
follow-up to #4041 - maybe it's a good idea to document the addition?
ping @schveiguy 

Btw I don't know why there are two "Library changes" sections - is this by design or a bug?