### PR TITLE
fix issue #4763 File.open() implementation that re-uses the File struct

### DIFF
--- a/std/stdio.d
+++ b/std/stdio.d
@@ -363,11 +363,15 @@ struct File
 
     package this(FILE* handle, string name, uint refs = 1, bool isPopened = false) @trusted
     {
+        initMembers(handle, name, refs, isPopened);
+    }
+
+    private void initMembers(FILE* handle, string name, uint refs = 1, bool isPopened = false) @trusted
+    {
         import core.stdc.stdlib : malloc;
         import std.exception : enforce;
 
-        assert(!_p);
-        _p = cast(Impl*) enforce(malloc(Impl.sizeof), "Out of memory");
+        if (!_p) _p = cast(Impl*) enforce(malloc(Impl.sizeof), "Out of memory");
         _p.handle = handle;
         _p.refs = refs;
         _p.isPopened = isPopened;
@@ -395,13 +399,18 @@ Throws: $(D ErrnoException) if the file could not be opened.
  */
     this(string name, in char[] stdioOpenmode = "rb") @safe
     {
+        initMembers(name, stdioOpenmode);
+    }
+
+    private void initMembers(string name, in char[] stdioOpenmode = "rb") @safe
+    {
         import std.conv : text;
         import std.exception : errnoEnforce;
 
-        this(errnoEnforce(.fopen(name, stdioOpenmode),
-                        text("Cannot open file `", name, "' in mode `",
-                                stdioOpenmode, "'")),
-                name);
+        initMembers(errnoEnforce(.fopen(name, stdioOpenmode),
+                text("Cannot open file `", name, "' in mode `",
+                    stdioOpenmode, "'")),
+            name);
 
         // MSVCRT workaround (issue 14422)
         version (MICROSOFT_STDIO)
@@ -458,18 +467,6 @@ Throws: $(D ErrnoException) if the file could not be opened.
     }
 
 /**
-Assigns a file to another. The target of the assignment gets detached
-from whatever file it was attached to, and attaches itself to the new
-file.
- */
-    void opAssign(File rhs) @safe
-    {
-        import std.algorithm : swap;
-
-        swap(this, rhs);
-    }
-
-/**
 First calls $(D detach) (throwing on failure), and then attempts to
 _open file $(D name) with mode $(D stdioOpenmode). The mode has the
 same semantics as in the C standard library $(WEB
@@ -479,8 +476,19 @@ Throws: $(D ErrnoException) in case of error.
  */
     void open(string name, in char[] stdioOpenmode = "rb") @safe
     {
-        detach();
-        this = File(name, stdioOpenmode);
+        if (_p)
+        {
+            if (_p.refs == 1)
+                closeWithoutFree();
+            else
+            {
+                assert(_p.refs);
+                --_p.refs;
+                _p = null;
+            }
+
+        }
+        initMembers(name, stdioOpenmode);
     }
 
 /**
@@ -694,18 +702,23 @@ Throws: $(D ErrnoException) on error.
     void close() @trusted
     {
         import core.stdc.stdlib : free;
-        import std.exception : errnoEnforce;
 
         if (!_p) return; // succeed vacuously
-        scope(exit)
-        {
-            assert(_p.refs);
-            if(!--_p.refs)
-                free(_p);
-            _p = null; // start a new life
-        }
-        if (!_p.handle) return; // Impl is closed by another File
 
+        closeWithoutFree();
+
+        if(!--_p.refs) {
+            free(_p);
+        }
+        _p = null; // start a new life
+    }
+
+    private void closeWithoutFree() @trusted
+    {
+        import std.exception : errnoEnforce;
+
+        if (!_p.handle) return; // Impl is closed by another File
+        
         scope(exit) _p.handle = null; // nullify the handle anyway
         version (Posix)
         {


### PR DESCRIPTION
fix issue #4763

Implementation of a more efficient File.open() that re-uses the File struct state, avoiding the destructor/free + constructor/malloc pattern.

Be aware that this is my first PR and contribution to phobos. I'm still learning git/hub and new to the D community and this contribution process.
