### PR TITLE
std.file: Clarify documentation of mkdirRecurse when target exists

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -2096,6 +2096,9 @@ private bool ensureDirExists(in char[] pathname)
 /****************************************************
  * Make directory and all parent directories as needed.
  *
+ * Does nothing if the directory specified by
+ * $(D pathname) already exists.
+ *
  * Throws: $(D FileException) on error.
  */
 


### PR DESCRIPTION
As verified by the unittest below.