### PR TITLE
std.math.pow: change type from `double` to `real` for internal variable.

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -6248,7 +6248,7 @@ Unqual!(Largest!(F, G)) pow(F, G)(F x, G y) @nogc @trusted pure nothrow
         if (iy == y && fabs(y) < 32768.0)
             return pow(x, iy);
 
-        double sign = 1.0;
+        real sign = 1.0;
         if (x < 0)
         {
             // Result is real only if y is an integer


### PR DESCRIPTION
This change "fixes"/works-around a unittest failure with LDC with optimizations on. Note that the return type of `impl` is `real` (not `Float`) and thus changing the type of `sign` to `real` should not matter / be more correct?
