### PR TITLE
[std.regex] Introduce filtered loops with bloom filters

### DIFF
--- a/std/regex/internal/backtracking.d
+++ b/std/regex/internal/backtracking.d
@@ -386,21 +386,15 @@ template BacktrackingMatcher(bool CTregex)
                         int test;
                         if(re.ir[pc].code == IR.InfiniteEnd)
                         {
-                            test = quickTestFwd(pc+IRL!(IR.InfiniteEnd), front, re);
-                            if(test >= 0)
-                                pushState(pc+IRL!(IR.InfiniteEnd), counter);
+                            pushState(pc+IRL!(IR.InfiniteEnd), counter);
                             infiniteNesting++;
                             pc -= len;
                         }
                         else
                         {
-                            test = quickTestFwd(pc - len, front, re);
-                            if(test >= 0)
-                            {
-                                infiniteNesting++;
-                                pushState(pc - len, counter);
-                                infiniteNesting--;
-                            }
+                            infiniteNesting++;
+                            pushState(pc - len, counter);
+                            infiniteNesting--;
                             pc += IRL!(IR.InfiniteEnd);
                         }
                         break;
@@ -468,20 +462,14 @@ template BacktrackingMatcher(bool CTregex)
                         int test;
                         if(re.ir[pc].code == IR.InfiniteEnd)
                         {
-                            test = quickTestFwd(pc+IRL!(IR.InfiniteEnd), front, re);
-                            if(test >= 0)
-                            {
-                                infiniteNesting--;
-                                pushState(pc + IRL!(IR.InfiniteEnd), counter);
-                                infiniteNesting++;
-                            }
+                            infiniteNesting--;
+                            pushState(pc + IRL!(IR.InfiniteEnd), counter);
+                            infiniteNesting++;
                             pc -= len;
                         }
                         else
                         {
-                            test = quickTestFwd(pc-len, front, re);
-                            if(test >= 0)
-                                pushState(pc-len, counter);
+                            pushState(pc-len, counter);
                             pc += IRL!(IR.InfiniteEnd);
                             infiniteNesting--;
                         }
@@ -897,7 +885,7 @@ struct CtContext
         {
         case IR.InfiniteStart,  IR.InfiniteBloomStart,IR.InfiniteQStart, IR.RepeatStart, IR.RepeatQStart:
             bool infLoop =
-                ir[0].code == IR.InfiniteStart || ir[0].code == IR.InfiniteQStart || 
+                ir[0].code == IR.InfiniteStart || ir[0].code == IR.InfiniteQStart ||
                 ir[0].code == IR.InfiniteBloomStart;
             infNesting = infNesting || infLoop;
             if(infLoop)

--- a/std/regex/internal/generator.d
+++ b/std/regex/internal/generator.d
@@ -131,11 +131,10 @@ module std.regex.internal.generator;
                         pc += IRL!(IR.RepeatEnd);
                     }
                     break;
-                case IR.InfiniteStart, IR.InfiniteQStart:
+                case IR.InfiniteStart, IR.InfiniteBloomStart, IR.InfiniteQStart:
                     pc += re.ir[pc].data + IRL!(IR.InfiniteStart);
                     goto case IR.InfiniteEnd; //both Q and non-Q
-                case IR.InfiniteEnd:
-                case IR.InfiniteQEnd:
+                case IR.InfiniteEnd, IR.InfiniteBloomEnd, IR.InfiniteQEnd:
                     uint len = re.ir[pc].data;
                     if(app.data.length == dataLenOld)
                     {
@@ -146,7 +145,7 @@ module std.regex.internal.generator;
                     if(app.data.length < limit && rand(3) > 0)
                         pc = pc - len;
                     else
-                        pc = pc + IRL!(IR.InfiniteEnd);
+                        pc = pc + re.ir[pc].length;
                     break;
                 case IR.GroupStart, IR.GroupEnd:
                     pc += IRL!(IR.GroupStart);

--- a/std/regex/internal/ir.d
+++ b/std/regex/internal/ir.d
@@ -11,6 +11,7 @@ package(std.regex):
 
 import std.exception, std.uni, std.meta, std.traits, std.range;
 
+debug(std_regex_parser) import std.stdio;
 // just a common trait, may be moved elsewhere
 alias BasicElementOf(Range) = Unqual!(ElementEncodingType!Range);
 
@@ -116,41 +117,44 @@ enum IR:uint {
     //OrChar holds in upper two bits of data total number of OrChars in this _sequence_
     //the drawback of this representation is that it is difficult
     // to detect a jump in the middle of it
-    OrChar            = 0b1_00100_00,
-    Nop               = 0b1_00101_00, //no operation (padding)
-    End               = 0b1_00110_00, //end of program
-    Bol               = 0b1_00111_00, //beginning of a string ^
-    Eol               = 0b1_01000_00, //end of a string $
-    Wordboundary      = 0b1_01001_00, //boundary of a word
-    Notwordboundary   = 0b1_01010_00, //not a word boundary
-    Backref           = 0b1_01011_00, //backreference to a group (that has to be pinned, i.e. locally unique) (group index)
-    GroupStart        = 0b1_01100_00, //start of a group (x) (groupIndex+groupPinning(1bit))
-    GroupEnd          = 0b1_01101_00, //end of a group (x) (groupIndex+groupPinning(1bit))
-    Option            = 0b1_01110_00, //start of an option within an alternation x | y (length)
-    GotoEndOr         = 0b1_01111_00, //end of an option (length of the rest)
+    OrChar             = 0b1_00100_00,
+    Nop                = 0b1_00101_00, //no operation (padding)
+    End                = 0b1_00110_00, //end of program
+    Bol                = 0b1_00111_00, //beginning of a string ^
+    Eol                = 0b1_01000_00, //end of a string $
+    Wordboundary       = 0b1_01001_00, //boundary of a word
+    Notwordboundary    = 0b1_01010_00, //not a word boundary
+    Backref            = 0b1_01011_00, //backreference to a group (that has to be pinned, i.e. locally unique) (group index)
+    GroupStart         = 0b1_01100_00, //start of a group (x) (groupIndex+groupPinning(1bit))
+    GroupEnd           = 0b1_01101_00, //end of a group (x) (groupIndex+groupPinning(1bit))
+    Option             = 0b1_01110_00, //start of an option within an alternation x | y (length)
+    GotoEndOr          = 0b1_01111_00, //end of an option (length of the rest)
     //... any additional atoms here
 
-    OrStart           = 0b1_00000_01, //start of alternation group  (length)
-    OrEnd             = 0b1_00000_10, //end of the or group (length,mergeIndex)
+    OrStart            = 0b1_00000_01, //start of alternation group  (length)
+    OrEnd              = 0b1_00000_10, //end of the or group (length,mergeIndex)
     //with this instruction order
     //bit mask 0b1_00001_00 could be used to test/set greediness
-    InfiniteStart     = 0b1_00001_01, //start of an infinite repetition x* (length)
-    InfiniteEnd       = 0b1_00001_10, //end of infinite repetition x* (length,mergeIndex)
-    InfiniteQStart    = 0b1_00010_01, //start of a non eager infinite repetition x*? (length)
-    InfiniteQEnd      = 0b1_00010_10, //end of non eager infinite repetition x*? (length,mergeIndex)
-    RepeatStart       = 0b1_00011_01, //start of a {n,m} repetition (length)
-    RepeatEnd         = 0b1_00011_10, //end of x{n,m} repetition (length,step,minRep,maxRep)
-    RepeatQStart      = 0b1_00100_01, //start of a non eager x{n,m}? repetition (length)
-    RepeatQEnd        = 0b1_00100_10, //end of non eager x{n,m}? repetition (length,step,minRep,maxRep)
+    InfiniteStart      = 0b1_00001_01, //start of an infinite repetition x* (length)
+    InfiniteEnd        = 0b1_00001_10, //end of infinite repetition x* (length,mergeIndex)
+    InfiniteQStart     = 0b1_00010_01, //start of a non eager infinite repetition x*? (length)
+    InfiniteQEnd       = 0b1_00010_10, //end of non eager infinite repetition x*? (length,mergeIndex)
+    InfiniteBloomStart = 0b1_00011_01, //start of an filtered infinite repetition x* (length)
+    InfiniteBloomEnd   = 0b1_00011_10, //end of filtered infinite repetition x* (length,mergeIndex)
+    RepeatStart        = 0b1_00100_01, //start of a {n,m} repetition (length)
+    RepeatEnd          = 0b1_00100_10, //end of x{n,m} repetition (length,step,minRep,maxRep)
+    RepeatQStart       = 0b1_00101_01, //start of a non eager x{n,m}? repetition (length)
+    RepeatQEnd         = 0b1_00101_10, //end of non eager x{n,m}? repetition (length,step,minRep,maxRep)
+    
     //
-    LookaheadStart    = 0b1_00101_01, //begin of the lookahead group (length)
-    LookaheadEnd      = 0b1_00101_10, //end of a lookahead group (length)
-    NeglookaheadStart = 0b1_00110_01, //start of a negative lookahead (length)
-    NeglookaheadEnd   = 0b1_00110_10, //end of a negative lookahead (length)
-    LookbehindStart   = 0b1_00111_01, //start of a lookbehind (length)
-    LookbehindEnd     = 0b1_00111_10, //end of a lookbehind (length)
-    NeglookbehindStart= 0b1_01000_01, //start of a negative lookbehind (length)
-    NeglookbehindEnd  = 0b1_01000_10, //end of negative lookbehind (length)
+    LookaheadStart     = 0b1_00110_01, //begin of the lookahead group (length)
+    LookaheadEnd       = 0b1_00110_10, //end of a lookahead group (length)
+    NeglookaheadStart  = 0b1_00111_01, //start of a negative lookahead (length)
+    NeglookaheadEnd    = 0b1_00111_10, //end of a negative lookahead (length)
+    LookbehindStart    = 0b1_01000_01, //start of a lookbehind (length)
+    LookbehindEnd      = 0b1_01000_10, //end of a lookbehind (length)
+    NeglookbehindStart = 0b1_01001_01, //start of a negative lookbehind (length)
+    NeglookbehindEnd   = 0b1_01001_10, //end of negative lookbehind (length)
 }
 
 //a shorthand for IR length - full length of specific opcode evaluated at compile time
@@ -164,11 +168,13 @@ static assert (IRL!(IR.LookaheadStart) == 3);
 int immediateParamsIR(IR i){
     switch (i){
     case IR.OrEnd,IR.InfiniteEnd,IR.InfiniteQEnd:
-        return 1;
+        return 1;  // merge table index
+    case IR.InfiniteBloomEnd:
+        return 2;  // bloom filter index + merge table index 
     case IR.RepeatEnd, IR.RepeatQEnd:
         return 4;
     case IR.LookaheadStart, IR.NeglookaheadStart, IR.LookbehindStart, IR.NeglookbehindStart:
-        return 2;
+        return 2;  // start-end of captures used
     default:
         return 0;
     }
@@ -250,6 +256,11 @@ struct Bytecode
     //bit twiddling helpers
     //0-arg template due to @@@BUG@@@ 10985
     @property uint data()() const { return raw & 0x003f_ffff; }
+
+    @property void data()(uint val)
+    {
+        raw = (raw & ~0x003f_ffff) | (val & 0x003f_ffff);
+    }
 
     //ditto
     //0-arg template due to @@@BUG@@@ 10985
@@ -373,7 +384,8 @@ struct Group(DataIndex)
     case IR.OrChar:
         formattedWrite(output, " %s (0x%x) seq=%d", cast(dchar)irb[pc].data, irb[pc].data, irb[pc].sequence);
         break;
-    case IR.RepeatStart, IR.InfiniteStart, IR.Option, IR.GotoEndOr, IR.OrStart:
+    case IR.RepeatStart, IR.InfiniteStart, IR.InfiniteBloomStart, 
+    IR.Option, IR.GotoEndOr, IR.OrStart:
         //forward-jump instructions
         uint len = irb[pc].data;
         formattedWrite(output, " pc=>%u", pc+len+IRL!(IR.RepeatStart));
@@ -383,7 +395,7 @@ struct Group(DataIndex)
         formattedWrite(output, " pc=>%u min=%u max=%u step=%u",
             pc - len, irb[pc + 3].raw, irb[pc + 4].raw, irb[pc + 2].raw);
         break;
-    case IR.InfiniteEnd, IR.InfiniteQEnd, IR.OrEnd: //ditto
+    case IR.InfiniteEnd, IR.InfiniteQEnd, IR.InfiniteBloomEnd, IR.OrEnd: //ditto
         uint len = irb[pc].data;
         formattedWrite(output, " pc=>%u", pc-len);
         break;
@@ -498,6 +510,7 @@ package(std.regex):
     uint threadCount;
     uint flags;         //global regex flags
     public const(Trie)[]  tries; //
+    public const(BloomFilter)[] filters; // bloom filters for conditional loops
     uint[] backrefed; //bit array of backreferenced submatches
     Kickstart!Char kickstart;
 
@@ -742,4 +755,30 @@ int quickTestFwd(RegEx)(uint pc, dchar front, const ref RegEx re)
 public class RegexException : Exception
 {
     mixin basicExceptionCtors;
+}
+
+
+struct BloomFilter {
+    uint[4] filter;
+
+    this(CodepointSet set){
+        foreach(iv; set.byInterval){
+            foreach(v; iv.a..iv.b)
+                add(v);
+        }
+    }
+
+    void add()(dchar ch){
+        immutable i = index(ch);
+        filter[i >> 5]  |=  1<<(i & 31);
+    }
+    // non-zero -> might be present, 0 -> absent
+    uint opIndex()(dchar ch) const{
+        immutable i = index(ch);
+        return filter[i >> 5] & (1<<(i & 31));
+    }
+
+    static uint index()(dchar ch){
+        return ((ch >> 7) ^ ch) & 0x7F;
+    }
 }

--- a/std/regex/internal/parser.d
+++ b/std/regex/internal/parser.d
@@ -1476,7 +1476,7 @@ struct Parser(R)
 void fixupBytecode()(Bytecode[] ir)
 {
     Stack!uint fixups;
-   
+
     with(IR) for(uint i=0; i<ir.length; i+= ir[i].length)
     {
         if(ir[i].isStart || ir[i].code == Option)
@@ -1523,10 +1523,10 @@ void optimize(Char)(ref Regex!Char zis)
     {
         CodepointSet set;
         with(zis) with(IR)
-    Outer: 
+    Outer:
         for(uint i = idx; i < ir.length; i += ir[i].length)
         {
-            switch(ir[i].code) 
+            switch(ir[i].code)
             {
                 case Char:
                     set.add(ir[i].data, ir[i].data+1);
@@ -1543,7 +1543,7 @@ void optimize(Char)(ref Regex!Char zis)
         }
         return set;
     }
-   
+
     with(zis) with(IR) for(uint i = 0; i < ir.length; i += ir[i].length)
     {
         if(ir[i].code == InfiniteEnd)

--- a/std/regex/internal/parser.d
+++ b/std/regex/internal/parser.d
@@ -449,7 +449,7 @@ struct Parser(R)
         while(!empty)
         {
             debug(std_regex_parser)
-                writeln("*LR*\nSource: ", pat, "\nStack: ",fixupStack.stack.data);
+                writeln("*LR*\nSource: ", pat, "\nStack: ",fixupStack.data);
             switch(current)
             {
             case '(':
@@ -1469,7 +1469,98 @@ struct Parser(R)
         if(!(flags & RegexInfo.oneShot))
             kickstart = Kickstart!Char(zis, new uint[](256));
         debug(std_regex_allocation) writefln("IR processed, max threads: %d", threadCount);
+        optimize(zis);
     }
+}
+
+void fixupBytecode()(Bytecode[] ir)
+{
+    Stack!uint fixups;
+   
+    with(IR) for(uint i=0; i<ir.length; i+= ir[i].length)
+    {
+        if(ir[i].isStart || ir[i].code == Option)
+            fixups.push(i);
+        else if(ir[i].code == OrEnd)
+        {
+            // Alternatives need more care
+            auto j = fixups.pop(); // last Option
+            ir[j].data = i -  j - ir[j].length;
+            j = fixups.pop(); // OrStart
+            ir[j].data = i - j - ir[j].length;
+            ir[i].data = ir[j].data;
+
+            // fixup all GotoEndOrs
+            j = j + IRL!(OrStart);
+            assert(ir[j].code == Option);
+            for(;;)
+            {
+                auto next = j + ir[j].data + IRL!(Option);
+                if(ir[next].code == IR.OrEnd)
+                    break;
+                ir[next - IRL!(GotoEndOr)].data = i - next;
+                j = next;
+            }
+        }
+        else if(ir[i].code == GotoEndOr)
+        {
+            auto j = fixups.pop(); // Option
+            ir[j].data = i - j + IRL!(GotoEndOr)- IRL!(Option); // to the next option
+        }
+        else if(ir[i].isEnd)
+        {
+            auto j = fixups.pop();
+            ir[i].data = i - j - ir[j].length;
+            ir[j].data = ir[i].data;
+        }
+    }
+    assert(fixups.empty);
+}
+
+void optimize(Char)(ref Regex!Char zis)
+{
+    CodepointSet nextSet(uint idx)
+    {
+        CodepointSet set;
+        with(zis) with(IR)
+    Outer: 
+        for(uint i = idx; i < ir.length; i += ir[i].length)
+        {
+            switch(ir[i].code) 
+            {
+                case Char:
+                    set.add(ir[i].data, ir[i].data+1);
+                    goto default;
+                //TODO: OrChar
+                case Trie, CodepointSet:
+                    set = zis.charsets[ir[i].data];
+                    goto default;
+                case GroupStart,GroupEnd:
+                    break;
+                default:
+                    break Outer;
+            }
+        }
+        return set;
+    }
+   
+    with(zis) with(IR) for(uint i = 0; i < ir.length; i += ir[i].length)
+    {
+        if(ir[i].code == InfiniteEnd)
+        {
+            auto set = nextSet(i+IRL!(InfiniteEnd));
+            if(!set.empty && set.length < 10_000)
+            {
+                ir[i] = Bytecode(InfiniteBloomEnd, ir[i].data);
+                ir[i - ir[i].data - IRL!(InfiniteStart)] =
+                    Bytecode(InfiniteBloomStart, ir[i].data);
+                ir.insertInPlace(i+IRL!(InfiniteEnd),
+                    Bytecode.fromRaw(cast(uint)zis.filters.length));
+                zis.filters ~= BloomFilter(set);
+            }
+        }
+    }
+    fixupBytecode(zis.ir);
 }
 
 //IR code validator - proper nesting, illegal instructions, etc.


### PR DESCRIPTION
Make use of bloom filter on dchar to predict if we should take the
out of loop branch. Fairly unique trick for regexes far as I know.

This greatly helps backtracking engine that relied on dubious concept of
"quick test" which is scanning bytecode to see if lookahead will match it.
It was a poor trade-off between spending time executing that bytecode 
essentially twice and pushing/poping extra state on the stack.