### PR TITLE
fix issue 15658 - UFCS used in isFile caused a conflict with a DirEntry member

### DIFF
--- a/std/file.d
+++ b/std/file.d
@@ -1741,7 +1741,13 @@ assert(!"/usr/share/include".isFile);
 @property bool isFile(R)(auto ref R name)
     if (isConvertibleToString!R)
 {
-    return name.isFile!(StringTypeOf!R);
+    return isFile!(StringTypeOf!R)(name);
+}
+
+unittest // bugzilla 15658
+{
+    DirEntry e = DirEntry(".");
+    static assert(is(typeof(isFile(e))));
 }
 
 unittest


### PR DESCRIPTION
`DirEntry` got a member function named `isFile`. So the function tried to call this one instead of the other global `isFile()` overload.