### PR TITLE
Using `ref` instead of `out` for std.json.parseJSON

### DIFF
--- a/std/json.d
+++ b/std/json.d
@@ -808,7 +808,7 @@ if(isInputRange!T)
         }
     }
 
-    void parseValue(out JSONValue value)
+    void parseValue(ref JSONValue value)
     {
         depth++;
 


### PR DESCRIPTION
As shown in the discussion in [Issue 4037](https://github.com/D-Programming-Language/phobos/pull/4037), the combination of `ref` parameter and void initializer is potentially fragile for future changes in `JSONValue` in the sense of memory `safe`-ty.

This request replaces `out` parameter with `ref` parameter of the nested function in `parseJSON`.
It will not change the behavior of the function and CTFEability.