### PR TITLE
Make std.json @safe.

### DIFF
--- a/std/json.d
+++ b/std/json.d
@@ -265,6 +265,15 @@ struct JSONValue
 
     /// Value getter for $(D JSON_TYPE.OBJECT).
     /// Unlike $(D object), this retrieves the object by value and can be used in @safe code.
+    ///
+    /// A caveat is that, if the returned value is null, modifications will not be visible:
+    /// ---
+    /// JSONValue json;
+    /// json.object = null;
+    /// json.objectNoRef["hello"] = JSONValue("world");
+    /// assert("hello" !in json.object);
+    /// ---
+    ///
     /// Throws: $(D JSONException) for read access if $(D type) is not
     /// $(D JSON_TYPE.OBJECT).
     @property inout(JSONValue[string]) objectNoRef() inout pure @trusted
@@ -299,6 +308,16 @@ struct JSONValue
 
     /// Value getter for $(D JSON_TYPE.ARRAY).
     /// Unlike $(D array), this retrieves the array by value and can be used in @safe code.
+    ///
+    /// A caveat is that, if you append to the returned array, the new values aren't visible in the
+    /// JSONValue:
+    /// ---
+    /// JSONValue json;
+    /// json.array = [JSONValue("hello")];
+    /// json.arrayNoRef ~= JSONValue("world");
+    /// assert(json.array.length == 1);
+    /// ---
+    ///
     /// Throws: $(D JSONException) for read access if $(D type) is not
     /// $(D JSON_TYPE.ARRAY).
     @property inout(JSONValue[]) arrayNoRef() inout pure @trusted
@@ -621,8 +640,6 @@ struct JSONValue
     /// Implements the foreach $(D opApply) interface for json arrays.
     int opApply(int delegate(size_t index, ref JSONValue) dg) @system
     {
-        enforce!JSONException(type == JSON_TYPE.ARRAY,
-                                "JSONValue is not an array");
         int result;
 
         foreach(size_t index, ref value; array)

--- a/std/json.d
+++ b/std/json.d
@@ -695,7 +695,7 @@ Params:
     maxDepth = maximum depth of nesting allowed, -1 disables depth checking
     options = enable decoding string representations of NaN/Inf as float values
 */
-JSONValue parseJSON(T)(T json, int maxDepth = -1, JSONOptions options = JSONOptions.none) @safe
+JSONValue parseJSON(T)(T json, int maxDepth = -1, JSONOptions options = JSONOptions.none)
 if(isInputRange!T)
 {
     import std.ascii : isWhite, isDigit, isHexDigit, toUpper, toLower;

--- a/std/json.d
+++ b/std/json.d
@@ -786,7 +786,7 @@ if(isInputRange!T)
         return true;
     }
 
-    string parseString() @safe
+    string parseString()
     {
         auto str = appender!string();
 
@@ -852,7 +852,7 @@ if(isInputRange!T)
         }
     }
 
-    void parseValue(out JSONValue value) @safe
+    void parseValue(out JSONValue value)
     {
         depth++;
 
@@ -1030,10 +1030,28 @@ unittest
 @safe unittest
 {
     // Ensure we can parse and use JSON from @safe code
-    enum randomJSON = `{ "key1": { "key2": 1 }}`;
     auto a = `{ "key1": { "key2": 1 }}`.parseJSON;
     assert(a["key1"]["key2"].integer == 1);
     assert(a.toString == `{"key1":{"key2":1}}`);
+}
+
+unittest
+{
+    // Ensure we can parse JSON from a @system range.
+    struct Range
+    {
+        string s;
+        size_t index;
+        @system
+        {
+            bool empty() { return index >= s.length; }
+            void popFront() { index++; }
+            char front() { return s[index]; }
+        }
+    }
+    auto s = Range(`{ "key1": { "key2": 1 }}`);
+    auto json = parseJSON(s);
+    assert(json["key1"]["key2"].integer == 1);
 }
 
 /**

--- a/std/json.d
+++ b/std/json.d
@@ -509,7 +509,7 @@ struct JSONValue
     ///
     /// Throws: $(D JSONException) if $(D type) is not $(D JSON_TYPE.OBJECT)
     /// or $(D JSON_TYPE.NULL).
-    void opIndexAssign(T)(auto ref T value, string key) pure @safe
+    void opIndexAssign(T)(auto ref T value, string key) pure
     {
         enforceEx!JSONException(type == JSON_TYPE.OBJECT || type == JSON_TYPE.NULL,
                                 "JSONValue must be object or null");
@@ -530,7 +530,7 @@ struct JSONValue
             assert( j["language"].str == "Perl" );
     }
 
-    void opIndexAssign(T)(T arg, size_t i) pure @safe
+    void opIndexAssign(T)(T arg, size_t i) pure
     {
         auto a = this.arrayNoRef;
         enforceEx!JSONException(i < a.length,

--- a/std/json.d
+++ b/std/json.d
@@ -167,7 +167,7 @@ struct JSONValue
     /// Value getter/setter for $(D JSON_TYPE.STRING).
     /// Throws: $(D JSONException) for read access if $(D type) is not
     /// $(D JSON_TYPE.STRING).
-    @property inout(string) str() inout pure @trusted
+    @property string str() const pure @trusted
     {
         enforce!JSONException(type == JSON_TYPE.STRING,
                                 "JSONValue is not a string");

--- a/std/json.d
+++ b/std/json.d
@@ -674,7 +674,7 @@ struct JSONValue
     /// $(I options) can be used to tweak the conversion behavior.
     string toString(in JSONOptions options = JSONOptions.none) const @safe
     {
-        return toJSON(&this, false, options);
+        return toJSON(this, false, options);
     }
 
     /// Implicitly calls $(D toJSON) on this JSONValue, like $(D toString), but
@@ -683,7 +683,7 @@ struct JSONValue
     /// $(I options) can be used to tweak the conversion behavior
     string toPrettyString(in JSONOptions options = JSONOptions.none) const @safe
     {
-        return toJSON(&this, true, options);
+        return toJSON(this, true, options);
     }
 }
 
@@ -1049,6 +1049,14 @@ if(isInputRange!T)
     return parseJSON!T(json, -1, options);
 }
 
+deprecated(
+    "Please use the overload that takes a ref JSONValue rather than a pointer. This overload will "
+    ~ "be removed in November 2017.")
+string toJSON(in JSONValue* root, in bool pretty = false, in JSONOptions options = JSONOptions.none) @safe
+{
+    return toJSON(*root, pretty, options);
+}
+
 /**
 Takes a tree of JSON values and returns the serialized string.
 
@@ -1058,7 +1066,7 @@ If $(D pretty) is false no whitespaces are generated.
 If $(D pretty) is true serialized string is formatted to be human-readable.
 Set the $(specialFloatLiterals) flag is set in $(D options) to encode NaN/Infinity as strings.
 */
-string toJSON(in JSONValue* root, in bool pretty = false, in JSONOptions options = JSONOptions.none) @safe
+string toJSON(const ref JSONValue root, in bool pretty = false, in JSONOptions options = JSONOptions.none) @safe
 {
     auto json = appender!string();
 
@@ -1232,7 +1240,7 @@ string toJSON(in JSONValue* root, in bool pretty = false, in JSONOptions options
         }
     }
 
-    toValue(*root, 0);
+    toValue(root, 0);
     return json.data;
 }
 
@@ -1471,7 +1479,7 @@ unittest
         {
             val = parseJSON(json);
             enum pretty = false;
-            result = toJSON(&val, pretty);
+            result = toJSON(val, pretty);
             assert(result == json, text(result, " should be ", json));
         }
         catch (JSONException e)
@@ -1483,18 +1491,18 @@ unittest
 
     // Should be able to correctly interpret unicode entities
     val = parseJSON(`"\u003C\u003E"`);
-    assert(toJSON(&val) == "\"\&lt;\&gt;\"");
+    assert(toJSON(val) == "\"\&lt;\&gt;\"");
     assert(val.to!string() == "\"\&lt;\&gt;\"");
     val = parseJSON(`"\u0391\u0392\u0393"`);
-    assert(toJSON(&val) == "\"\&Alpha;\&Beta;\&Gamma;\"");
+    assert(toJSON(val) == "\"\&Alpha;\&Beta;\&Gamma;\"");
     assert(val.to!string() == "\"\&Alpha;\&Beta;\&Gamma;\"");
     val = parseJSON(`"\u2660\u2666"`);
-    assert(toJSON(&val) == "\"\&spades;\&diams;\"");
+    assert(toJSON(val) == "\"\&spades;\&diams;\"");
     assert(val.to!string() == "\"\&spades;\&diams;\"");
 
     //0x7F is a control character (see Unicode spec)
     val = parseJSON(`"\u007F"`);
-    assert(toJSON(&val) == "\"\\u007F\"");
+    assert(toJSON(val) == "\"\\u007F\"");
     assert(val.to!string() == "\"\\u007F\"");
 
     with(parseJSON(`""`))
@@ -1504,7 +1512,7 @@ unittest
 
     // Formatting
     val = parseJSON(`{"a":[null,{"x":1},{},[]]}`);
-    assert(toJSON(&val, true) == `{
+    assert(toJSON(val, true) == `{
     "a": [
         null,
         {


### PR DESCRIPTION
A number of methods are marked @safe because they do not do anything in themselves that could pose memory issues, but they affect internal state that could, if incorrectly set, cause the @trusted methods to produce memory errors. I'm not sure if it's best to make those @trusted as well to indicate to future programmers that caution is required to avoid memory errors.

The general strategy was to make the basic accessors @safe or @trusted and refactor everything to use those rather than to access the `Store` union directly. This works pretty well but occasionally can cause extra validation. For the most part, I removed that by removing extra validation that most public methods perform. For `opEquals`, I made the method @trusted instead. In some places, I used a temporary variable instead.

The `object` and `array` getters cannot be made @safe. Consider:

```D
JSONValue  v;
v.object = ["hello": JSONValue("world")];
auto obj = &(v.object);  // pointer to v.storage.object
v.uinteger = 1;  // overwrites v.storage.object with invalid pointer
(*obj)["goodbye"] = JSONValue("cruel world");  // segfault
```

For those, I had to offer @trusted getters, `arrayNoRef` and `objectNoRef`. This is awkward and I solicit better names. (I can't just switch to a non-ref return because @system code can still use a pointer to the array or object, or stuff like `jsonvalue.object["foo"] = JSONValue("bar")` without ensuring that `jsonvalue.object` is non-null. Breaking change without proper deprecation and all that.)

`opApply` is another spot of bother. It *should* be possible to define both

```D
int opApply(int delegate(size_t, ref JSONValue) @safe dg) @safe
```

and

```D
int opApply(int delegate(size_t, ref JSONValue) @system dg) @system
```

but DMD is not currently smart enough to do the right thing and will always complain about ambiguous overload resolution. (Making it a template doesn't help.)

I could create a JSONArrayRange, make an accessor to create that range, and then use `alias this` to make iteration transparent and friendly to both @safe and @system code, but we have two things to iterate through: the object key/values and the array index/values.

So I've left `opApply` @system, which shouldn't break anything, and @safe code can use the `objectNoRef` and `arrayNoRef` accessors for iteration.