### PR TITLE
std.algorithm.sorting: fix save reference in isSorted

### DIFF
--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -161,7 +161,7 @@ bool isSorted(alias less = "a < b", Range)(Range r) if (isForwardRange!(Range))
     }
     else
     {
-        auto ahead = r;
+        auto ahead = r.save;
         ahead.popFront();
         size_t i;
 


### PR DESCRIPTION
in reference to the reverted #4025, here the two small bug fixes

- fix for zero length random access ranges
- `save` the forward range before iterating through it