### PR TITLE
Avoid brute force fd close() on Linux

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -23,6 +23,8 @@ $(BUGSTITLE Library Changes,
         $(XREF algorithm_searching, maxPos) were added.))
     $(LI Range support for the convenience wrapper $(XREF container_rbtree, redBlackTree)
         was added.)
+    $(LI $(RELATIVE_LINK2 process, Process creation in
+        $(STDMODREF process, std.process) was sped up on Posix.))
 )
 
 $(BUGSTITLE Library Changes,
@@ -63,6 +65,15 @@ $(LI $(LNAME2 maxPos, $(XREF algorithm_searching, maxCount) and
 $(P Previous to this addition, in order to get the number of the greatest
     elements, you had to use `minCount!"a > b"`, which was very confusing.
     This change adds convenience functions to fix this issue.)
+)
+
+$(LI $(RELATIVE_LINK2 process, Process creation in
+    $(STDMODREF process, std.process) was sped up on Posix.)
+Previously, Posix systems would attempt to close every file descriptor from 3
+    to the maximum file descriptor number if `inheritFDs` was not specified
+    with `spawnProcess`, `pipeProcess`, etc.
+    $(STDMODREF process, std.process) now uses `poll()` to determine which
+    descriptors need closing.
 )
 
 )


### PR DESCRIPTION
The current Posix implementation of spawnProcess calls close on every fd from 3 to the max fd count (as gathered by `rlimit()`). Given that the process doesn't have that many descriptors open
in the *vast* majority of cases, this is quite pessimal.

Instead, check `/proc/self/fd` to see which descriptors are actually open, and close those.
A similar solution is probably possible for BSD and friends.