### PR TITLE
[std.regex] Faster tables for ASCII case

### DIFF
--- a/std/regex/internal/backtracking.d
+++ b/std/regex/internal/backtracking.d
@@ -301,7 +301,7 @@ template BacktrackingMatcher(bool CTregex)
                         pc += IRL!(IR.CodepointSet);
                         break;
                     case IR.Trie:
-                        if(atEnd || !re.tries[re.ir[pc].data][front])
+                        if(atEnd || !re.matchers[re.ir[pc].data][front])
                             goto L_backtrack;
                         next();
                         pc += IRL!(IR.Trie);
@@ -310,21 +310,21 @@ template BacktrackingMatcher(bool CTregex)
                         dchar back;
                         DataIndex bi;
                         //at start & end of input
-                        if(atStart && wordTrie[front])
+                        if(atStart && wordMatcher[front])
                         {
                             pc += IRL!(IR.Wordboundary);
                             break;
                         }
                         else if(atEnd && s.loopBack(index).nextChar(back, bi)
-                                && wordTrie[back])
+                                && wordMatcher[back])
                         {
                             pc += IRL!(IR.Wordboundary);
                             break;
                         }
                         else if(s.loopBack(index).nextChar(back, bi))
                         {
-                            bool af = wordTrie[front];
-                            bool ab = wordTrie[back];
+                            bool af = wordMatcher[front];
+                            bool ab = wordMatcher[back];
                             if(af ^ ab)
                             {
                                 pc += IRL!(IR.Wordboundary);
@@ -336,15 +336,15 @@ template BacktrackingMatcher(bool CTregex)
                         dchar back;
                         DataIndex bi;
                         //at start & end of input
-                        if(atStart && wordTrie[front])
+                        if(atStart && wordMatcher[front])
                             goto L_backtrack;
                         else if(atEnd && s.loopBack(index).nextChar(back, bi)
-                                && wordTrie[back])
+                                && wordMatcher[back])
                             goto L_backtrack;
                         else if(s.loopBack(index).nextChar(back, bi))
                         {
-                            bool af = wordTrie[front];
-                            bool ab = wordTrie[back];
+                            bool af = wordMatcher[front];
+                            bool ab = wordMatcher[back];
                             if(af ^ ab)
                                 goto L_backtrack;
                         }
@@ -1276,7 +1276,7 @@ struct CtContext
             break;
         case IR.Trie:
             code ~= ctSub( `
-                    if(atEnd || !re.tries[$$][front])
+                    if(atEnd || !re.matchers[$$][front])
                         $$
                     $$
                 $$`, ir[0].data, bailOut, addr >= 0 ? "next();" :"", nextInstr);
@@ -1285,19 +1285,19 @@ struct CtContext
             code ~= ctSub( `
                     dchar back;
                     DataIndex bi;
-                    if(atStart && wordTrie[front])
+                    if(atStart && wordMatcher[front])
                     {
                         $$
                     }
                     else if(atEnd && s.loopBack(index).nextChar(back, bi)
-                            && wordTrie[back])
+                            && wordMatcher[back])
                     {
                         $$
                     }
                     else if(s.loopBack(index).nextChar(back, bi))
                     {
-                        bool af = wordTrie[front];
-                        bool ab = wordTrie[back];
+                        bool af = wordMatcher[front];
+                        bool ab = wordMatcher[back];
                         if(af ^ ab)
                         {
                             $$
@@ -1310,15 +1310,15 @@ struct CtContext
                     dchar back;
                     DataIndex bi;
                     //at start & end of input
-                    if(atStart && wordTrie[front])
+                    if(atStart && wordMatcher[front])
                         $$
                     else if(atEnd && s.loopBack(index).nextChar(back, bi)
-                            && wordTrie[back])
+                            && wordMatcher[back])
                         $$
                     else if(s.loopBack(index).nextChar(back, bi))
                     {
-                        bool af = wordTrie[front];
-                        bool ab = wordTrie[back];
+                        bool af = wordMatcher[front];
+                        bool ab = wordMatcher[back];
                         if(af ^ ab)
                             $$
                     }

--- a/std/regex/internal/ir.d
+++ b/std/regex/internal/ir.d
@@ -507,10 +507,10 @@ package(std.regex):
     uint ngroup;                           // number of internal groups
     uint maxCounterDepth;                  // max depth of nested {n,m} repetitions
     uint hotspotTableSize;                 // number of entries in merge table
-    uint threadCount;                      // upper bound on number of Thompson VM threads 
+    uint threadCount;                      // upper bound on number of Thompson VM threads
     uint flags;                            // global regex flags
     public const(CharMatcher)[]  matchers; // tables that represent character sets
-    public const(BitTable)[] filters;   // bloom filters for conditional loops
+    public const(BitTable)[] filters;      // bloom filters for conditional loops
     uint[] backrefed;                      // bit array of backreferenced submatches
     Kickstart!Char kickstart;
 

--- a/std/regex/internal/ir.d
+++ b/std/regex/internal/ir.d
@@ -19,29 +19,29 @@ alias BasicElementOf(Range) = Unqual!(ElementEncodingType!Range);
 enum maxCharsetUsed = 6;
 
 // another variable to tweak behavior of caching generated Tries for character classes
-enum maxCachedTries = 8;
+enum maxCachedMatchers = 8;
 
 alias Trie = CodepointSetTrie!(13, 8);
 alias makeTrie = codepointSetTrie!(13, 8);
 
-Trie[CodepointSet] trieCache;
+CharMatcher[CodepointSet] matcherCache;
 
 //accessor with caching
-@trusted Trie getTrie(CodepointSet set)
+@trusted CharMatcher getMatcher(CodepointSet set)
 {// @@@BUG@@@ 6357 almost all properties of AA are not @safe
-    if(__ctfe || maxCachedTries == 0)
-        return makeTrie(set);
+    if(__ctfe || maxCachedMatchers == 0)
+        return CharMatcher(set);
     else
     {
-        auto p = set in trieCache;
+        auto p = set in matcherCache;
         if(p)
             return *p;
-        if(trieCache.length == maxCachedTries)
+        if(matcherCache.length == maxCachedMatchers)
         {
-            // flush entries in trieCache
-            trieCache = null;
+            // flush enmatchers in trieCache
+            matcherCache = null;
         }
-        return (trieCache[set] = makeTrie(set));
+        return (matcherCache[set] = CharMatcher(set));
     }
 }
 
@@ -67,9 +67,9 @@ Trie[CodepointSet] trieCache;
         | unicode.Me | unicode.Nd | unicode.Pc")();
 }
 
-@property Trie wordTrie()
+@property CharMatcher wordMatcher()
 {
-    return memoizeExpr!("makeTrie(wordCharacter)")();
+    return memoizeExpr!("CharMatcher(wordCharacter)")();
 }
 
 // some special Unicode white space characters
@@ -503,15 +503,15 @@ struct Regex(Char)
 
 package(std.regex):
     import std.regex.internal.kickstart : Kickstart; //TODO: get rid of this dependency
-    NamedGroup[] dict;  //maps name -> user group number
-    uint ngroup;        //number of internal groups
-    uint maxCounterDepth; //max depth of nested {n,m} repetitions
-    uint hotspotTableSize; //number of entries in merge table
-    uint threadCount;
-    uint flags;         //global regex flags
-    public const(Trie)[]  tries; //
-    public const(BloomFilter)[] filters; // bloom filters for conditional loops
-    uint[] backrefed; //bit array of backreferenced submatches
+    NamedGroup[] dict;                     // maps name -> user group number
+    uint ngroup;                           // number of internal groups
+    uint maxCounterDepth;                  // max depth of nested {n,m} repetitions
+    uint hotspotTableSize;                 // number of entries in merge table
+    uint threadCount;                      // upper bound on number of Thompson VM threads 
+    uint flags;                            // global regex flags
+    public const(CharMatcher)[]  matchers; // tables that represent character sets
+    public const(BitTable)[] filters;   // bloom filters for conditional loops
+    uint[] backrefed;                      // bit array of backreferenced submatches
     Kickstart!Char kickstart;
 
     //bit access helper
@@ -728,8 +728,8 @@ public class RegexException : Exception
     mixin basicExceptionCtors;
 }
 
-
-struct BloomFilter {
+// simple 128-entry bit-table used with a hash function
+struct BitTable {
     uint[4] filter;
 
     this(CodepointSet set){
@@ -744,12 +744,32 @@ struct BloomFilter {
         filter[i >> 5]  |=  1<<(i & 31);
     }
     // non-zero -> might be present, 0 -> absent
-    uint opIndex()(dchar ch) const{
+    bool opIndex()(dchar ch) const{
         immutable i = index(ch);
-        return filter[i >> 5] & (1<<(i & 31));
+        return (filter[i >> 5]>>(i & 31)) & 1;
     }
 
     static uint index()(dchar ch){
         return ((ch >> 7) ^ ch) & 0x7F;
+    }
+}
+
+struct CharMatcher {
+    BitTable ascii; // fast path for ASCII
+    Trie trie;      // slow path for Unicode
+
+    this(CodepointSet set)
+    {
+        auto asciiSet = set & unicode.ASCII;
+        ascii = BitTable(asciiSet);
+        trie = makeTrie(set);
+    }
+
+    bool opIndex()(dchar ch) const
+    {
+        if (ch < 0x80)
+            return ascii[ch];
+        else
+            return trie[ch];
     }
 }

--- a/std/regex/internal/thompson.d
+++ b/std/regex/internal/thompson.d
@@ -86,14 +86,575 @@ struct ThreadList(DataIndex)
     }
 }
 
+template ThompsonOps(E, S, bool withInput:true)
+{
+    static bool op(IR code:IR.End)(E* e, S* state)
+    {
+        with(e) with(state)
+        {
+            finish(t, matches);
+            //fix endpoint of the whole match
+            matches[0].end = e.index;
+            recycle(t);
+            //cut off low priority threads
+            recycle(clist);
+            recycle(worklist);
+            debug(std_regex_matcher) writeln("Finished thread ", matches);
+            return false; // no more state to eval
+        }
+    }
+
+    static bool op(IR code:IR.Wordboundary)(E* e, S* state)
+    {
+        with(e) with(state)
+        {
+            dchar back;
+            DataIndex bi;
+            //at start & end of input
+            if(atStart && wordTrie[front])
+            {
+                t.pc += IRL!(IR.Wordboundary);
+                return true;
+            }
+            else if(atEnd && s.loopBack(index).nextChar(back, bi)
+                    && wordTrie[back])
+            {
+                t.pc += IRL!(IR.Wordboundary);
+                return true;
+            }
+            else if(s.loopBack(index).nextChar(back, bi))
+            {
+                bool af = wordTrie[front];
+                bool ab = wordTrie[back];
+                if(af ^ ab)
+                {
+                    t.pc += IRL!(IR.Wordboundary);
+                    return true;
+                }
+            }
+            return popState(e);
+        }
+    }
+
+    static bool op(IR code:IR.Notwordboundary)(E* e, S* state)
+    {
+        with(e) with(state)
+        {
+            dchar back;
+            DataIndex bi;
+            //at start & end of input
+            if(atStart && wordTrie[front])
+            {
+                return popState(e);
+            }
+            else if(atEnd && s.loopBack(index).nextChar(back, bi)
+                    && wordTrie[back])
+            {
+                return popState(e);
+            }
+            else if(s.loopBack(index).nextChar(back, bi))
+            {
+                bool af = wordTrie[front];
+                bool ab = wordTrie[back]  != 0;
+                if(af ^ ab)
+                {
+                    return popState(e);
+                }
+            }
+            t.pc += IRL!(IR.Notwordboundary);
+        }
+        return true;
+    }
+
+    static bool op(IR code:IR.Bol)(E* e, S* state)
+    {
+        with(e) with(state)
+        {
+            dchar back;
+            DataIndex bi;
+            if(atStart
+                ||( (re.flags & RegexOption.multiline)
+                && s.loopBack(index).nextChar(back,bi)
+                && startOfLine(back, front == '\n')))
+            {
+                t.pc += IRL!(IR.Bol);
+                return true;
+            }
+            else
+            {
+                return popState(e);
+            }
+        }
+    }
+
+    static bool op(IR code:IR.Eol)(E* e, S* state)
+    {
+        with(e) with(state)
+        {
+            debug(std_regex_matcher) writefln("EOL (front 0x%x) %s",  front, s[index..s.lastIndex]);
+            dchar back;
+            DataIndex bi;
+            //no matching inside \r\n
+            if(atEnd || ((re.flags & RegexOption.multiline)
+                && endOfLine(front, s.loopBack(index).nextChar(back, bi)
+                    && back == '\r')))
+            {
+                t.pc += IRL!(IR.Eol);
+                return true;
+            }
+            else
+            {
+                return popState(e);
+            }
+
+        }
+    }
+
+    static bool op(IR code:IR.InfiniteStart)(E* e, S* state)
+    {
+        with(e) with(state)
+            t.pc += re.ir[t.pc].data + IRL!(IR.InfiniteStart);
+        return op!(IR.InfiniteEnd)(e,state);
+    }
+
+    static bool op(IR code:IR.InfiniteQStart)(E* e, S* state)
+    {
+        with(e) with(state)
+            t.pc += re.ir[t.pc].data + IRL!(IR.InfiniteQStart);
+        return op!(IR.InfiniteQEnd)(e,state);
+    }
+
+    static bool op(IR code:IR.RepeatStart)(E* e, S* state)
+    {
+        with(e) with(state)
+            t.pc += re.ir[t.pc].data + IRL!(IR.RepeatStart);
+        return op!(IR.RepeatEnd)(e,state);
+    }
+
+    static bool op(IR code:IR.RepeatQStart)(E* e, S* state)
+    {
+        with(e) with(state)
+            t.pc += re.ir[t.pc].data + IRL!(IR.RepeatQStart);
+        return op!(IR.RepeatQEnd)(e,state);
+    }
+
+    static bool op(IR code)(E* e, S* state)
+        if(code == IR.RepeatEnd || code == IR.RepeatQEnd)
+    {
+        with(e) with(state)
+        {
+            //len, step, min, max
+                uint len = re.ir[t.pc].data;
+                uint step =  re.ir[t.pc+2].raw;
+                uint min = re.ir[t.pc+3].raw;
+                if(t.counter < min)
+                {
+                    t.counter += step;
+                    t.pc -= len;
+                    return true;
+                }
+                if(merge[re.ir[t.pc + 1].raw+t.counter] < genCounter)
+                {
+                    debug(std_regex_matcher) writefln("A thread(pc=%s) passed there : %s ; GenCounter=%s mergetab=%s",
+                                    t.pc, index, genCounter, merge[re.ir[t.pc + 1].raw+t.counter] );
+                    merge[re.ir[t.pc + 1].raw+t.counter] = genCounter;
+                }
+                else
+                {
+                    debug(std_regex_matcher) writefln("A thread(pc=%s) got merged there : %s ; GenCounter=%s mergetab=%s",
+                                    t.pc, index, genCounter, merge[re.ir[t.pc + 1].raw+t.counter] );
+                    return popState(e);
+                }
+                uint max = re.ir[t.pc+4].raw;
+                if(t.counter < max)
+                {
+                    if(re.ir[t.pc].code == IR.RepeatEnd)
+                    {
+                        //queue out-of-loop thread
+                        worklist.insertFront(fork(t, t.pc + IRL!(IR.RepeatEnd),  t.counter % step));
+                        t.counter += step;
+                        t.pc -= len;
+                    }
+                    else
+                    {
+                        //queue into-loop thread
+                        worklist.insertFront(fork(t, t.pc - len,  t.counter + step));
+                        t.counter %= step;
+                        t.pc += IRL!(IR.RepeatEnd);
+                    }
+                }
+                else
+                {
+                    t.counter %= step;
+                    t.pc += IRL!(IR.RepeatEnd);
+                }
+                return true;
+        }
+    }
+
+    static bool op(IR code)(E* e, S* state)
+        if(code == IR.InfiniteEnd || code == IR.InfiniteQEnd)
+    {
+        with(e) with(state)
+        {
+            if(merge[re.ir[t.pc + 1].raw+t.counter] < genCounter)
+            {
+                debug(std_regex_matcher) writefln("A thread(pc=%s) passed there : %s ; GenCounter=%s mergetab=%s",
+                                t.pc, index, genCounter, merge[re.ir[t.pc + 1].raw+t.counter] );
+                merge[re.ir[t.pc + 1].raw+t.counter] = genCounter;
+            }
+            else
+            {
+                debug(std_regex_matcher) writefln("A thread(pc=%s) got merged there : %s ; GenCounter=%s mergetab=%s",
+                                t.pc, index, genCounter, merge[re.ir[t.pc + 1].raw+t.counter] );
+                return popState(e);
+            }
+            uint len = re.ir[t.pc].data;
+            uint pc1, pc2; //branches to take in priority order
+            if(re.ir[t.pc].code == IR.InfiniteEnd)
+            {
+                pc1 = t.pc - len;
+                pc2 = t.pc + IRL!(IR.InfiniteEnd);
+            }
+            else
+            {
+                pc1 = t.pc + IRL!(IR.InfiniteEnd);
+                pc2 = t.pc - len;
+            }
+            worklist.insertFront(fork(t, pc2, t.counter));
+            t.pc = pc1;
+            return true;
+        }
+    }
+
+    static bool op(IR code:IR.OrEnd)(E* e, S* state)
+    {
+        with(e) with(state)
+        {
+            if(merge[re.ir[t.pc + 1].raw+t.counter] < genCounter)
+            {
+                debug(std_regex_matcher) writefln("A thread(pc=%s) passed there : %s ; GenCounter=%s mergetab=%s",
+                                t.pc, s[index .. s.lastIndex], genCounter, merge[re.ir[t.pc + 1].raw + t.counter] );
+                merge[re.ir[t.pc + 1].raw+t.counter] = genCounter;
+                t.pc += IRL!(IR.OrEnd);
+            }
+            else
+            {
+                debug(std_regex_matcher) writefln("A thread(pc=%s) got merged there : %s ; GenCounter=%s mergetab=%s",
+                                t.pc, s[index .. s.lastIndex], genCounter, merge[re.ir[t.pc + 1].raw + t.counter] );
+                return popState(e);
+            }
+            return true;
+        }
+    }
+
+    static bool op(IR code:IR.OrStart)(E* e, S* state)
+    {
+        with(e) with(state)
+        {
+            t.pc += IRL!(IR.OrStart);
+            return op!(IR.Option)(e,state);
+        }
+    }
+
+    static bool op(IR code:IR.Option)(E* e, S* state)
+    {
+        with(e) with(state)
+        {
+            uint next = t.pc + re.ir[t.pc].data + IRL!(IR.Option);
+            //queue next Option
+            if(re.ir[next].code == IR.Option)
+            {
+                worklist.insertFront(fork(t, next, t.counter));
+            }
+            t.pc += IRL!(IR.Option);
+            return true;
+        }
+    }
+
+    static bool op(IR code:IR.GotoEndOr)(E* e, S* state)
+    {
+        with(e) with(state)
+        {
+            t.pc = t.pc + re.ir[t.pc].data + IRL!(IR.GotoEndOr);
+            return op!(IR.OrEnd)(e, state);
+        }
+    }
+
+    static bool op(IR code:IR.GroupStart)(E* e, S* state)
+    {
+        with(e) with(state)
+        {
+            uint n = re.ir[t.pc].data;
+            t.matches.ptr[n].begin = index;
+            t.pc += IRL!(IR.GroupStart);
+            return true;
+        }
+    }
+    static bool op(IR code:IR.GroupEnd)(E* e, S* state)
+    {
+        with(e) with(state)
+        {
+            uint n = re.ir[t.pc].data;
+            t.matches.ptr[n].end = index;
+            t.pc += IRL!(IR.GroupEnd);
+            return true;
+        }
+    }
+    
+    static bool op(IR code:IR.Backref)(E* e, S* state)
+    {
+        with(e) with(state)
+        {
+            uint n = re.ir[t.pc].data;
+            Group!DataIndex* source = re.ir[t.pc].localRef ? t.matches.ptr : backrefed.ptr;
+            assert(source);
+            if(source[n].begin == source[n].end)//zero-width Backref!
+            {
+                t.pc += IRL!(IR.Backref);
+                return true;
+            }
+            else
+            {
+                size_t idx = source[n].begin + t.uopCounter;
+                size_t end = source[n].end;
+                if(s[idx..end].front == front)
+                {
+                    import std.utf : stride;
+
+                    t.uopCounter += stride(s[idx..end], 0);
+                    if(t.uopCounter + source[n].begin == source[n].end)
+                    {//last codepoint
+                        t.pc += IRL!(IR.Backref);
+                        t.uopCounter = 0;
+                    }
+                    nlist.insertBack(t);
+                }
+                else
+                    recycle(t);
+                t = worklist.fetch();
+                return t != null;
+            }
+        }
+    }
+
+
+    static bool op(IR code)(E* e, S* state)
+        if(code == IR.LookbehindStart || code == IR.NeglookbehindStart)
+    {
+        with(e) with(state)
+        {
+            uint len = re.ir[t.pc].data;
+            uint ms = re.ir[t.pc + 1].raw, me = re.ir[t.pc + 2].raw;
+            uint end = t.pc + len + IRL!(IR.LookbehindEnd) + IRL!(IR.LookbehindStart);
+            bool positive = re.ir[t.pc].code == IR.LookbehindStart;
+            static if(Stream.isLoopback)
+                auto matcher = fwdMatcher(re.ir[t.pc .. end], subCounters.get(t.pc, 0));
+            else
+                auto matcher = bwdMatcher(re.ir[t.pc .. end], subCounters.get(t.pc, 0));
+            matcher.re.ngroup = me - ms;
+            matcher.backrefed = backrefed.empty ? t.matches : backrefed;
+            //backMatch
+            auto mRes = matcher.matchOneShot(t.matches.ptr[ms .. me], IRL!(IR.LookbehindStart));
+            freelist = matcher.freelist;
+            subCounters[t.pc] = matcher.genCounter;
+            if((mRes == MatchResult.Match) ^ positive)
+            {
+                return popState(e);
+            }
+            t.pc = end;
+            return true;
+        }
+    }
+
+    static bool op(IR code)(E* e, S* state)
+        if(code == IR.LookaheadStart || code == IR.NeglookaheadStart)
+    {
+        with(e) with(state)
+        {
+            auto save = index;
+            uint len = re.ir[t.pc].data;
+            uint ms = re.ir[t.pc+1].raw, me = re.ir[t.pc+2].raw;
+            uint end = t.pc+len+IRL!(IR.LookaheadEnd)+IRL!(IR.LookaheadStart);
+            bool positive = re.ir[t.pc].code == IR.LookaheadStart;
+            static if(Stream.isLoopback)
+                auto matcher = bwdMatcher(re.ir[t.pc .. end], subCounters.get(t.pc, 0));
+            else
+                auto matcher = fwdMatcher(re.ir[t.pc .. end], subCounters.get(t.pc, 0));
+            matcher.re.ngroup = me - ms;
+            matcher.backrefed = backrefed.empty ? t.matches : backrefed;
+            auto mRes = matcher.matchOneShot(t.matches.ptr[ms .. me], IRL!(IR.LookaheadStart));
+            freelist = matcher.freelist;
+            subCounters[t.pc] = matcher.genCounter;
+            s.reset(index);
+            next();
+            if((mRes == MatchResult.Match) ^ positive)
+            {
+                return popState(e);
+            }
+            t.pc = end;
+            return true;
+        }
+    }
+
+    static bool op(IR code)(E* e, S* state)
+        if(code == IR.LookaheadEnd || code == IR.NeglookaheadEnd ||
+            code == IR.LookbehindEnd || code == IR.NeglookbehindEnd)
+    {
+        with(e) with(state)
+        {
+                finish(t, matches.ptr[0 .. re.ngroup]);
+                recycle(t);
+                //cut off low priority threads
+                recycle(clist);
+                recycle(worklist);
+                return false; // no more state
+        }
+    }
+
+    static bool op(IR code:IR.Nop)(E* e, S* state)
+    {
+        with(state) t.pc += IRL!(IR.Nop);
+        return true;
+    }
+
+    static bool op(IR code:IR.OrChar)(E* e, S* state)
+    {
+        with(e) with(state)
+        {
+            uint len = re.ir[t.pc].sequence;
+            uint end = t.pc + len;
+            static assert(IRL!(IR.OrChar) == 1);
+            for(; t.pc < end; t.pc++)
+                if(re.ir[t.pc].data == front)
+                    break;
+            if(t.pc != end)
+            {
+                t.pc = end;
+                nlist.insertBack(t);
+            }
+            else
+                recycle(t);
+            t = worklist.fetch();
+            return t != null;
+        }
+    }
+
+    static bool op(IR code:IR.Char)(E* e, S* state)
+    {
+        with(e) with(state)
+        {
+            if(front == re.ir[t.pc].data)
+            {
+                t.pc += IRL!(IR.Char);
+                nlist.insertBack(t);
+            }
+            else
+                recycle(t);
+            t = worklist.fetch();
+            return t != null;
+        }
+    }
+
+    static bool op(IR code:IR.Any)(E* e, S* state)
+    {
+        with(e) with(state)
+        {
+            t.pc += IRL!(IR.Any);
+            if(!(re.flags & RegexOption.singleline)
+                  && (front == '\r' || front == '\n'))
+              recycle(t);
+            else
+              nlist.insertBack(t);
+            t = worklist.fetch();
+            return t != null;
+        }
+    }
+
+    static bool op(IR code:IR.CodepointSet)(E* e, S* state)
+    {
+        with(e) with(state)
+        {
+            if(re.charsets[re.ir[t.pc].data].scanFor(front))
+            {
+                t.pc += IRL!(IR.CodepointSet);
+                nlist.insertBack(t);
+            }
+            else
+            {
+                recycle(t);
+            }
+            t = worklist.fetch();
+            return t != null;
+        }
+    }
+
+    static bool op(IR code:IR.Trie)(E* e, S* state)
+    {
+        with(e) with(state)
+        {
+            if(re.tries[re.ir[t.pc].data][front])
+            {
+                t.pc += IRL!(IR.Trie);
+                nlist.insertBack(t);
+            }
+            else
+            {
+                recycle(t);
+            }
+            t = worklist.fetch();
+            return t != null;
+        }
+    }
+
+}
+
+template ThompsonOps(E,S, bool withInput:false)
+{
+    // can't match these without input
+    static bool op(IR code)(E* e, S* state)
+        if (code == IR.Char || code == IR.OrChar || code == IR.CodepointSet
+        || code == IR.Trie || code == IR.Char || code == IR.Any)
+    {
+        return state.popState(e);
+    }
+
+    // special case of zero-width backref
+    static bool op(IR code:IR.Backref)(E* e, S* state)
+    {
+        with(e) with(state)
+        {
+            uint n = re.ir[t.pc].data;
+            Group!DataIndex* source = re.ir[t.pc].localRef ? t.matches.ptr : backrefed.ptr;
+            assert(source);
+            if(source[n].begin == source[n].end)//zero-width Backref!
+            {
+                t.pc += IRL!(IR.Backref);
+                return true;
+            }
+            else
+                return popState(e);
+        }
+    }
+
+    // forward all control flow to normal versions
+    static bool op(IR code)(E* e, S* state)
+        if (code != IR.Char && code != IR.OrChar && code != IR.CodepointSet
+        && code != IR.Trie && code != IR.Char && code != IR.Any && code != IR.Backref)
+    {
+        return ThompsonOps!(E,S,true).op!code(e,state);
+    }
+}
+
 /+
    Thomspon matcher does all matching in lockstep,
    never looking at the same char twice
 +/
-@trusted struct ThompsonMatcher(Char, Stream = Input!Char)
+@trusted struct ThompsonMatcher(Char, StreamType = Input!Char)
     if(is(Char : dchar))
 {
     alias DataIndex = Stream.DataIndex;
+    alias Stream = StreamType;
     Thread!DataIndex* freelist;
     ThreadList!DataIndex clist, nlist;
     DataIndex[] merge;
@@ -107,6 +668,24 @@ struct ThreadList(DataIndex)
     size_t threadSize;
     bool matched;
     bool exhausted;
+
+    static struct State
+    {
+        Thread!DataIndex* t;
+        ThreadList!DataIndex worklist;
+        Group!DataIndex[] matches;
+
+        bool popState(ThompsonMatcher* e)
+        {
+        	with(e)
+        	{
+        		recycle(t);
+        		t = worklist.fetch();
+        		return t != null;
+        	}
+        }
+    }
+
     static if(__traits(hasMember,Stream, "search"))
     {
         enum kicked = true;
@@ -304,12 +883,15 @@ struct ThreadList(DataIndex)
         genCounter++; //increment also on each end
         debug(std_regex_matcher) writefln("Threaded matching threads at end");
         //try out all zero-width posibilities
-        for(Thread!DataIndex* t = clist.fetch(); t; t = clist.fetch())
+        for(state.t = clist.fetch(); state.t; state.t = clist.fetch())
         {
-            eval!false(t, matches);
+            eval!false(&state);
         }
         if(!matched)
-            eval!false(createStart(index), matches);//new thread starting at end of input
+        {
+        	state.t = createStart(index);
+            eval!false(&state);//new thread starting at end of input
+        }
         if(matched)
         {//in case NFA found match along the way
          //and last possible longer alternative ultimately failed
@@ -342,14 +924,17 @@ struct ThreadList(DataIndex)
         matched = true;
     }
 
+    alias Ops(bool withInput) =  ThompsonOps!(ThompsonMatcher, State, withInput);
+
     /+
         match thread against codepoint, cutting trough all 0-width instructions
         and taking care of control flow, then add it to nlist
     +/
-    void eval(bool withInput)(Thread!DataIndex* t, Group!DataIndex[] matches)
+    void eval(bool withInput)(State* state)
     {
         ThreadList!DataIndex worklist;
         debug(std_regex_matcher) writeln("---- Evaluating thread");
+    L_Eval:
         for(;;)
         {
             debug(std_regex_matcher)
@@ -359,492 +944,20 @@ struct ThreadList(DataIndex)
                     writef(" %s ", x.pc);
                 writeln("]");
             }
-            switch(re.ir[t.pc].code)
+            
+    L_dispatch:
+            switch(re.ir[state.t.pc].code)
             {
-            case IR.End:
-                finish(t, matches);
-                matches[0].end = index; //fix endpoint of the whole match
-                recycle(t);
-                //cut off low priority threads
-                recycle(clist);
-                recycle(worklist);
-                debug(std_regex_matcher) writeln("Finished thread ", matches);
-                return;
-            case IR.Wordboundary:
-                dchar back;
-                DataIndex bi;
-                //at start & end of input
-                if(atStart && wordTrie[front])
+                foreach(e; __traits(allMembers, IR))
                 {
-                    t.pc += IRL!(IR.Wordboundary);
-                    break;
+            mixin(`case IR.`~e~`: 
+                if(!Ops!withInput.op!(IR.`~e~`)(&this, state))
+                    break L_Eval;
+                break L_dispatch;
+                `);
                 }
-                else if(atEnd && s.loopBack(index).nextChar(back, bi)
-                        && wordTrie[back])
-                {
-                    t.pc += IRL!(IR.Wordboundary);
-                    break;
-                }
-                else if(s.loopBack(index).nextChar(back, bi))
-                {
-                    bool af = wordTrie[front];
-                    bool ab = wordTrie[back];
-                    if(af ^ ab)
-                    {
-                        t.pc += IRL!(IR.Wordboundary);
-                        break;
-                    }
-                }
-                recycle(t);
-                t = worklist.fetch();
-                if(!t)
-                    return;
-                break;
-            case IR.Notwordboundary:
-                dchar back;
-                DataIndex bi;
-                //at start & end of input
-                if(atStart && wordTrie[front])
-                {
-                    recycle(t);
-                    t = worklist.fetch();
-                    if(!t)
-                        return;
-                    break;
-                }
-                else if(atEnd && s.loopBack(index).nextChar(back, bi)
-                        && wordTrie[back])
-                {
-                    recycle(t);
-                    t = worklist.fetch();
-                    if(!t)
-                        return;
-                    break;
-                }
-                else if(s.loopBack(index).nextChar(back, bi))
-                {
-                    bool af = wordTrie[front];
-                    bool ab = wordTrie[back]  != 0;
-                    if(af ^ ab)
-                    {
-                        recycle(t);
-                        t = worklist.fetch();
-                        if(!t)
-                            return;
-                        break;
-                    }
-                }
-                t.pc += IRL!(IR.Wordboundary);
-                break;
-            case IR.Bol:
-                dchar back;
-                DataIndex bi;
-                if(atStart
-                    ||( (re.flags & RegexOption.multiline)
-                    && s.loopBack(index).nextChar(back,bi)
-                    && startOfLine(back, front == '\n')))
-                {
-                    t.pc += IRL!(IR.Bol);
-                }
-                else
-                {
-                    recycle(t);
-                    t = worklist.fetch();
-                    if(!t)
-                        return;
-                }
-                break;
-            case IR.Eol:
-                debug(std_regex_matcher) writefln("EOL (front 0x%x) %s",  front, s[index..s.lastIndex]);
-                dchar back;
-                DataIndex bi;
-                //no matching inside \r\n
-                if(atEnd || ((re.flags & RegexOption.multiline)
-                    && endOfLine(front, s.loopBack(index).nextChar(back, bi)
-                        && back == '\r')))
-                {
-                    t.pc += IRL!(IR.Eol);
-                }
-                else
-                {
-                    recycle(t);
-                    t = worklist.fetch();
-                    if(!t)
-                        return;
-                }
-                break;
-            case IR.InfiniteStart, IR.InfiniteQStart:
-                t.pc += re.ir[t.pc].data + IRL!(IR.InfiniteStart);
-                goto case IR.InfiniteEnd; //both Q and non-Q
-            case IR.InfiniteBloomStart:
-                t.pc += re.ir[t.pc].data + IRL!(IR.InfiniteBloomStart);
-                goto case IR.InfiniteBloomEnd;
-            case IR.RepeatStart, IR.RepeatQStart:
-                t.pc += re.ir[t.pc].data + IRL!(IR.RepeatStart);
-                goto case IR.RepeatEnd; //both Q and non-Q
-            case IR.RepeatEnd:
-            case IR.RepeatQEnd:
-                //len, step, min, max
-                uint len = re.ir[t.pc].data;
-                uint step =  re.ir[t.pc+2].raw;
-                uint min = re.ir[t.pc+3].raw;
-                if(t.counter < min)
-                {
-                    t.counter += step;
-                    t.pc -= len;
-                    break;
-                }
-                if(merge[re.ir[t.pc + 1].raw+t.counter] < genCounter)
-                {
-                    debug(std_regex_matcher) writefln("A thread(pc=%s) passed there : %s ; GenCounter=%s mergetab=%s",
-                                    t.pc, index, genCounter, merge[re.ir[t.pc + 1].raw+t.counter] );
-                    merge[re.ir[t.pc + 1].raw+t.counter] = genCounter;
-                }
-                else
-                {
-                    debug(std_regex_matcher) writefln("A thread(pc=%s) got merged there : %s ; GenCounter=%s mergetab=%s",
-                                    t.pc, index, genCounter, merge[re.ir[t.pc + 1].raw+t.counter] );
-                    recycle(t);
-                    t = worklist.fetch();
-                    if(!t)
-                        return;
-                    break;
-                }
-                uint max = re.ir[t.pc+4].raw;
-                if(t.counter < max)
-                {
-                    if(re.ir[t.pc].code == IR.RepeatEnd)
-                    {
-                        //queue out-of-loop thread
-                        worklist.insertFront(fork(t, t.pc + IRL!(IR.RepeatEnd),  t.counter % step));
-                        t.counter += step;
-                        t.pc -= len;
-                    }
-                    else
-                    {
-                        //queue into-loop thread
-                        worklist.insertFront(fork(t, t.pc - len,  t.counter + step));
-                        t.counter %= step;
-                        t.pc += IRL!(IR.RepeatEnd);
-                    }
-                }
-                else
-                {
-                    t.counter %= step;
-                    t.pc += IRL!(IR.RepeatEnd);
-                }
-                break;
-            case IR.InfiniteEnd:
-            case IR.InfiniteQEnd:
-                if(merge[re.ir[t.pc + 1].raw+t.counter] < genCounter)
-                {
-                    debug(std_regex_matcher) writefln("A thread(pc=%s) passed there : %s ; GenCounter=%s mergetab=%s",
-                                    t.pc, index, genCounter, merge[re.ir[t.pc + 1].raw+t.counter] );
-                    merge[re.ir[t.pc + 1].raw+t.counter] = genCounter;
-                }
-                else
-                {
-                    debug(std_regex_matcher) writefln("A thread(pc=%s) got merged there : %s ; GenCounter=%s mergetab=%s",
-                                    t.pc, index, genCounter, merge[re.ir[t.pc + 1].raw+t.counter] );
-                    recycle(t);
-                    t = worklist.fetch();
-                    if(!t)
-                        return;
-                    break;
-                }
-                uint len = re.ir[t.pc].data;
-                uint pc1, pc2; //branches to take in priority order
-                if(re.ir[t.pc].code == IR.InfiniteEnd)
-                {
-                    pc1 = t.pc - len;
-                    pc2 = t.pc + IRL!(IR.InfiniteEnd);
-                }
-                else
-                {
-                    pc1 = t.pc + IRL!(IR.InfiniteEnd);
-                    pc2 = t.pc - len;
-                }
-                static if(withInput)
-                {
-                    worklist.insertFront(fork(t, pc2, t.counter));
-                    t.pc = pc1;
-                }
-                else
-                {
-                    worklist.insertFront(fork(t, pc2, t.counter));
-                    t.pc = pc1;
-                }
-                break;
-            case IR.InfiniteBloomEnd:
-                if(merge[re.ir[t.pc + 1].raw+t.counter] < genCounter)
-                {
-                    debug(std_regex_matcher) writefln("A thread(pc=%s) passed there : %s ; GenCounter=%s mergetab=%s",
-                                    t.pc, index, genCounter, merge[re.ir[t.pc + 1].raw+t.counter] );
-                    merge[re.ir[t.pc + 1].raw+t.counter] = genCounter;
-                }
-                else
-                {
-                    debug(std_regex_matcher) writefln("A thread(pc=%s) got merged there : %s ; GenCounter=%s mergetab=%s",
-                                    t.pc, index, genCounter, merge[re.ir[t.pc + 1].raw+t.counter] );
-                    recycle(t);
-                    t = worklist.fetch();
-                    if(!t)
-                        return;
-                    break;
-                }
-                uint len = re.ir[t.pc].data;
-                uint pc1, pc2; //branches to take in priority order
-                pc1 = t.pc - len;
-                pc2 = t.pc + IRL!(IR.InfiniteBloomEnd);
-                static if(withInput)
-                {
-                    uint filterIdx = re.ir[t.pc+2].raw;
-                    if(re.filters[filterIdx][front])
-                        worklist.insertFront(fork(t, pc2, t.counter));
-                    t.pc = pc1;
-                }
-                else
-                {
-                    // Since it has filter then going out of loop needs a char
-                    // thus only go inside of loop
-                    t.pc = pc1;
-                }
-                break;
-            case IR.OrEnd:
-                if(merge[re.ir[t.pc + 1].raw+t.counter] < genCounter)
-                {
-                    debug(std_regex_matcher) writefln("A thread(pc=%s) passed there : %s ; GenCounter=%s mergetab=%s",
-                                    t.pc, s[index .. s.lastIndex], genCounter, merge[re.ir[t.pc + 1].raw + t.counter] );
-                    merge[re.ir[t.pc + 1].raw+t.counter] = genCounter;
-                    t.pc += IRL!(IR.OrEnd);
-                }
-                else
-                {
-                    debug(std_regex_matcher) writefln("A thread(pc=%s) got merged there : %s ; GenCounter=%s mergetab=%s",
-                                    t.pc, s[index .. s.lastIndex], genCounter, merge[re.ir[t.pc + 1].raw + t.counter] );
-                    recycle(t);
-                    t = worklist.fetch();
-                    if(!t)
-                        return;
-                }
-                break;
-            case IR.OrStart:
-                t.pc += IRL!(IR.OrStart);
-                goto case;
-            case IR.Option:
-                uint next = t.pc + re.ir[t.pc].data + IRL!(IR.Option);
-                //queue next Option
-                if(re.ir[next].code == IR.Option)
-                {
-                    worklist.insertFront(fork(t, next, t.counter));
-                }
-                t.pc += IRL!(IR.Option);
-                break;
-            case IR.GotoEndOr:
-                t.pc = t.pc + re.ir[t.pc].data + IRL!(IR.GotoEndOr);
-                goto case IR.OrEnd;
-            case IR.GroupStart:
-                uint n = re.ir[t.pc].data;
-                t.matches.ptr[n].begin = index;
-                t.pc += IRL!(IR.GroupStart);
-                break;
-            case IR.GroupEnd:
-                uint n = re.ir[t.pc].data;
-                t.matches.ptr[n].end = index;
-                t.pc += IRL!(IR.GroupEnd);
-                break;
-            case IR.Backref:
-                uint n = re.ir[t.pc].data;
-                Group!DataIndex* source = re.ir[t.pc].localRef ? t.matches.ptr : backrefed.ptr;
-                assert(source);
-                if(source[n].begin == source[n].end)//zero-width Backref!
-                {
-                    t.pc += IRL!(IR.Backref);
-                }
-                else static if(withInput)
-                {
-                    size_t idx = source[n].begin + t.uopCounter;
-                    size_t end = source[n].end;
-                    if(s[idx..end].front == front)
-                    {
-                        import std.utf : stride;
-
-                        t.uopCounter += stride(s[idx..end], 0);
-                        if(t.uopCounter + source[n].begin == source[n].end)
-                        {//last codepoint
-                            t.pc += IRL!(IR.Backref);
-                            t.uopCounter = 0;
-                        }
-                        nlist.insertBack(t);
-                    }
-                    else
-                        recycle(t);
-                    t = worklist.fetch();
-                    if(!t)
-                        return;
-                    break;
-                }
-                else
-                {
-                    recycle(t);
-                    t = worklist.fetch();
-                    if(!t)
-                        return;
-                    break;
-                }
-                break;
-            case IR.LookbehindStart:
-            case IR.NeglookbehindStart:
-                uint len = re.ir[t.pc].data;
-                uint ms = re.ir[t.pc + 1].raw, me = re.ir[t.pc + 2].raw;
-                uint end = t.pc + len + IRL!(IR.LookbehindEnd) + IRL!(IR.LookbehindStart);
-                bool positive = re.ir[t.pc].code == IR.LookbehindStart;
-                static if(Stream.isLoopback)
-                    auto matcher = fwdMatcher(re.ir[t.pc .. end], subCounters.get(t.pc, 0));
-                else
-                    auto matcher = bwdMatcher(re.ir[t.pc .. end], subCounters.get(t.pc, 0));
-                matcher.re.ngroup = me - ms;
-                matcher.backrefed = backrefed.empty ? t.matches : backrefed;
-                //backMatch
-                auto mRes = matcher.matchOneShot(t.matches.ptr[ms .. me], IRL!(IR.LookbehindStart));
-                freelist = matcher.freelist;
-                subCounters[t.pc] = matcher.genCounter;
-                if((mRes == MatchResult.Match) ^ positive)
-                {
-                    recycle(t);
-                    t = worklist.fetch();
-                    if(!t)
-                        return;
-                    break;
-                }
-                else
-                    t.pc = end;
-                break;
-            case IR.LookaheadStart:
-            case IR.NeglookaheadStart:
-                auto save = index;
-                uint len = re.ir[t.pc].data;
-                uint ms = re.ir[t.pc+1].raw, me = re.ir[t.pc+2].raw;
-                uint end = t.pc+len+IRL!(IR.LookaheadEnd)+IRL!(IR.LookaheadStart);
-                bool positive = re.ir[t.pc].code == IR.LookaheadStart;
-                static if(Stream.isLoopback)
-                    auto matcher = bwdMatcher(re.ir[t.pc .. end], subCounters.get(t.pc, 0));
-                else
-                    auto matcher = fwdMatcher(re.ir[t.pc .. end], subCounters.get(t.pc, 0));
-                matcher.re.ngroup = me - ms;
-                matcher.backrefed = backrefed.empty ? t.matches : backrefed;
-                auto mRes = matcher.matchOneShot(t.matches.ptr[ms .. me], IRL!(IR.LookaheadStart));
-                freelist = matcher.freelist;
-                subCounters[t.pc] = matcher.genCounter;
-                s.reset(index);
-                next();
-                if((mRes == MatchResult.Match) ^ positive)
-                {
-                    recycle(t);
-                    t = worklist.fetch();
-                    if(!t)
-                        return;
-                    break;
-                }
-                else
-                    t.pc = end;
-                break;
-            case IR.LookaheadEnd:
-            case IR.NeglookaheadEnd:
-            case IR.LookbehindEnd:
-            case IR.NeglookbehindEnd:
-                finish(t, matches.ptr[0 .. re.ngroup]);
-                recycle(t);
-                //cut off low priority threads
-                recycle(clist);
-                recycle(worklist);
-                return;
-            case IR.Nop:
-                t.pc += IRL!(IR.Nop);
-                break;
-
-                static if(withInput)
-                {
-            case IR.OrChar:
-                      uint len = re.ir[t.pc].sequence;
-                      uint end = t.pc + len;
-                      static assert(IRL!(IR.OrChar) == 1);
-                      for(; t.pc < end; t.pc++)
-                          if(re.ir[t.pc].data == front)
-                              break;
-                      if(t.pc != end)
-                      {
-                          t.pc = end;
-                          nlist.insertBack(t);
-                      }
-                      else
-                          recycle(t);
-                      t = worklist.fetch();
-                      if(!t)
-                          return;
-                      break;
-            case IR.Char:
-                      if(front == re.ir[t.pc].data)
-                      {
-                          t.pc += IRL!(IR.Char);
-                          nlist.insertBack(t);
-                      }
-                      else
-                          recycle(t);
-                      t = worklist.fetch();
-                      if(!t)
-                          return;
-                      break;
-            case IR.Any:
-                      t.pc += IRL!(IR.Any);
-                      if(!(re.flags & RegexOption.singleline)
-                              && (front == '\r' || front == '\n'))
-                          recycle(t);
-                      else
-                          nlist.insertBack(t);
-                      t = worklist.fetch();
-                      if(!t)
-                          return;
-                      break;
-            case IR.CodepointSet:
-                      if(re.charsets[re.ir[t.pc].data].scanFor(front))
-                      {
-                          t.pc += IRL!(IR.CodepointSet);
-                          nlist.insertBack(t);
-                      }
-                      else
-                      {
-                          recycle(t);
-                      }
-                      t = worklist.fetch();
-                      if(!t)
-                          return;
-                      break;
-            case IR.Trie:
-                      if(re.tries[re.ir[t.pc].data][front])
-                      {
-                          t.pc += IRL!(IR.Trie);
-                          nlist.insertBack(t);
-                      }
-                      else
-                      {
-                          recycle(t);
-                      }
-                      t = worklist.fetch();
-                      if(!t)
-                          return;
-                      break;
-                  default:
-                      assert(0, "Unrecognized instruction " ~ re.ir[t.pc].mnemonic);
-                }
-                else
-                {
-                    default:
-                        recycle(t);
-                        t = worklist.fetch();
-                        if(!t)
-                            return;
-                }
+            default:
+                assert(0, "Unrecognized instruction "~re.ir[state.t.pc].mnemonic);
             }
         }
 
@@ -860,6 +973,8 @@ struct ThreadList(DataIndex)
         alias evalFn = eval;
         assert(clist == (ThreadList!DataIndex).init || startPc == RestartPc); // incorrect after a partial match
         assert(nlist == (ThreadList!DataIndex).init || startPc == RestartPc);
+        State state;
+        state.matches = matches;
         if(!atEnd)//if no char
         {
             debug(std_regex_matcher)
@@ -868,9 +983,9 @@ struct ThreadList(DataIndex)
             }
             if(startPc!=RestartPc)
             {
-                auto startT = createStart(index, startPc);
+                state.t = createStart(index, startPc);
                 genCounter++;
-                evalFn!true(startT, matches);
+                evalFn!true(&state);
             }
             for(;;)
             {
@@ -883,9 +998,9 @@ struct ThreadList(DataIndex)
                         assert(t);
                     }
                 }
-                for(Thread!DataIndex* t = clist.fetch(); t; t = clist.fetch())
+                for(state.t = clist.fetch(); state.t; state.t = clist.fetch())
                 {
-                    evalFn!true(t, matches);
+                    evalFn!true(&state);
                 }
                 if(nlist.empty)
                 {
@@ -905,12 +1020,15 @@ struct ThreadList(DataIndex)
         genCounter++; //increment also on each end
         debug(std_regex_matcher) writefln("-- Matching threads at end");
         //try out all zero-width posibilities
-        for(Thread!DataIndex* t = clist.fetch(); t; t = clist.fetch())
+        for(state.t = clist.fetch(); state.t; state.t = clist.fetch())
         {
-            evalFn!false(t, matches);
+            evalFn!false(&state);
         }
         if(!matched)
-            evalFn!false(createStart(index, startPc), matches);
+        {
+        	state.t = createStart(index, startPc);
+            evalFn!false(&state);
+        }
 
         return (matched?MatchResult.Match:MatchResult.NoMatch);
     }

--- a/std/regex/internal/thompson.d
+++ b/std/regex/internal/thompson.d
@@ -112,21 +112,21 @@ template ThompsonOps(E, S, bool withInput:true)
             dchar back;
             DataIndex bi;
             //at start & end of input
-            if(atStart && wordTrie[front])
+            if(atStart && wordMatcher[front])
             {
                 t.pc += IRL!(IR.Wordboundary);
                 return true;
             }
             else if(atEnd && s.loopBack(index).nextChar(back, bi)
-                    && wordTrie[back])
+                    && wordMatcher[back])
             {
                 t.pc += IRL!(IR.Wordboundary);
                 return true;
             }
             else if(s.loopBack(index).nextChar(back, bi))
             {
-                bool af = wordTrie[front];
-                bool ab = wordTrie[back];
+                bool af = wordMatcher[front];
+                bool ab = wordMatcher[back];
                 if(af ^ ab)
                 {
                     t.pc += IRL!(IR.Wordboundary);
@@ -144,19 +144,19 @@ template ThompsonOps(E, S, bool withInput:true)
             dchar back;
             DataIndex bi;
             //at start & end of input
-            if(atStart && wordTrie[front])
+            if(atStart && wordMatcher[front])
             {
                 return popState(e);
             }
             else if(atEnd && s.loopBack(index).nextChar(back, bi)
-                    && wordTrie[back])
+                    && wordMatcher[back])
             {
                 return popState(e);
             }
             else if(s.loopBack(index).nextChar(back, bi))
             {
-                bool af = wordTrie[front];
-                bool ab = wordTrie[back]  != 0;
+                bool af = wordMatcher[front];
+                bool ab = wordMatcher[back]  != 0;
                 if(af ^ ab)
                 {
                     return popState(e);
@@ -630,7 +630,7 @@ template ThompsonOps(E, S, bool withInput:true)
     {
         with(e) with(state)
         {
-            if(re.tries[re.ir[t.pc].data][front])
+            if(re.matchers[re.ir[t.pc].data][front])
             {
                 t.pc += IRL!(IR.Trie);
                 nlist.insertBack(t);

--- a/std/regex/internal/thompson.d
+++ b/std/regex/internal/thompson.d
@@ -986,7 +986,7 @@ template ThompsonOps(E,S, bool withInput:false)
         }
         if(!matched)
         {
-        	state.t = createStart(index);
+            state.t = createStart(index);
             eval!false(&state);//new thread starting at end of input
         }
         if(matched)


### PR DESCRIPTION
Profiler strikes back, most of the time was actually spent inside of lookup tables.
![screenshot-7](https://cloud.githubusercontent.com/assets/281770/14066673/ec08cdf6-f460-11e5-9154-630a5e68485e.png)
