### PR TITLE
Remove deprecated `std.concurrency.MessageBox.isClosed() const`.

### DIFF
--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -1804,20 +1804,6 @@ private
             }
         }
 
-    // @@@DEPRECATED_2016-03@@@
-    /++
-        $(RED Deprecated. isClosed can't be used with a const MessageBox.
-              It will be removed in March 2016).
-      +/
-        deprecated("isClosed can't be used with a const MessageBox")
-        final @property bool isClosed() const
-        {
-            synchronized( m_lock )
-            {
-                return m_closed;
-            }
-        }
-
         ///
         final @property bool isClosed()
         {


### PR DESCRIPTION
Within Phobos, this appears to be the only occurrence of synchronizing on an immutable object. Removal of this deprecated function allows us to resolve Issue 14251. The removal is needed for DMD PR https://github.com/D-Programming-Language/dmd/pull/5564 .

Ping @yebblies and @MartinNowak because you have marked this method as deprecated.
