### PR TITLE
document std.algorithm.mutation: swapAt

### DIFF
--- a/std/algorithm/mutation.d
+++ b/std/algorithm/mutation.d
@@ -1926,7 +1926,7 @@ if (isRandomAccessRange!Range && hasLength!Range)
     immutable steps = r.length/2;
     for (size_t i = 0; i < steps; i++)
     {
-        swapAt(r, i, last-i);
+        r.swapAt(i, last-i);
     }
 }
 

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -897,21 +897,21 @@ private size_t getPivot(alias less, Range)(Range r)
 
     switch(result) {
         case 0b001:
-            swapAt(r, 0, len - 1);
-            swapAt(r, 0, mid);
+            r.swapAt(0, len - 1);
+            r.swapAt(0, mid);
             break;
         case 0b110:
-            swapAt(r, mid, len - 1);
+            r.swapAt(mid, len - 1);
             break;
         case 0b011:
-            swapAt(r, 0, mid);
+            r.swapAt(0, mid);
             break;
         case 0b100:
-            swapAt(r, mid, len - 1);
-            swapAt(r, 0, mid);
+            r.swapAt(mid, len - 1);
+            r.swapAt(0, mid);
             break;
         case 0b000:
-            swapAt(r, 0, len - 1);
+            r.swapAt(0, len - 1);
             break;
         case 0b111:
             break;
@@ -952,7 +952,7 @@ private void optimisticInsertionSort(alias less, Range)(Range r)
         {
             for (; j < maxJ && pred(r[j + 1], r[j]); ++j)
             {
-                swapAt(r, j, j + 1);
+                r.swapAt(j, j + 1);
             }
         }
     }
@@ -1225,7 +1225,7 @@ private void quickSortImpl(alias less, Range)(Range r, size_t depth)
         alias pred = binaryFun!(less);
 
         // partition
-        swapAt(r, pivotIdx, r.length - 1);
+        r.swapAt(pivotIdx, r.length - 1);
         size_t lessI = size_t.max, greaterI = r.length - 1;
 
         while (true)
@@ -1237,10 +1237,10 @@ private void quickSortImpl(alias less, Range)(Range r, size_t depth)
             {
                 break;
             }
-            swapAt(r, lessI, greaterI);
+            r.swapAt(lessI, greaterI);
         }
 
-        swapAt(r, r.length - 1, lessI);
+        r.swapAt(r.length - 1, lessI);
         auto right = r[lessI + 1 .. r.length];
 
         auto left = r[0 .. min(lessI, greaterI + 1)];

--- a/std/container/binaryheap.d
+++ b/std/container/binaryheap.d
@@ -277,7 +277,7 @@ and $(D length == capacity), throws an exception.
             auto parentIdx = (n - 1) / 2;
             if (!comp(_store[parentIdx], _store[n])) break; // done!
             // must swap and continue
-            swapAt(_store, parentIdx, n);
+            _store.swapAt(parentIdx, n);
             n = parentIdx;
         }
         ++_length;

--- a/std/random.d
+++ b/std/random.d
@@ -1876,7 +1876,7 @@ void partialShuffle(Range, RandomGen)(Range r, in size_t n, ref RandomGen gen)
     enforce(n <= r.length, "n must be <= r.length for partialShuffle.");
     foreach (i; 0 .. n)
     {
-        swapAt(r, i, uniform(i, r.length, gen));
+        r.swapAt(i, uniform(i, r.length, gen));
     }
 }
 


### PR DESCRIPTION
Hey I have seen that `swapAt` is used quite often even though it's undocumented.

In phobos `swapAt` is used 19 times in other modules and [other people](https://github.com/DlangScience/mir/pull/29) seem to know about it too.

Imho it looks nicer to write `myArray.swapAt(0, i)` than `swap(myArray[0], myArray[i])`.
I couldn't find a unittest for the  `else` in the `static if` - maybe @quickfur?

If you don't like to expose `swapAt` I would suggest we remove it entirely from Phobos.

```
algorithm/sorting.d:            swapAt(r, 0, len - 1);
algorithm/sorting.d:            swapAt(r, 0, mid);
algorithm/sorting.d:            swapAt(r, mid, len - 1);
algorithm/sorting.d:            swapAt(r, 0, mid);
algorithm/sorting.d:            swapAt(r, mid, len - 1);
algorithm/sorting.d:            swapAt(r, 0, mid);
algorithm/sorting.d:            swapAt(r, 0, len - 1);
algorithm/sorting.d:                swapAt(r, j, j + 1);
algorithm/sorting.d:        swapAt(r, pivotIdx, r.length - 1);
algorithm/sorting.d:            swapAt(r, lessI, greaterI);
algorithm/sorting.d:        swapAt(r, r.length - 1, lessI);
algorithm/sorting.d:            r.swapAt(0, i);
algorithm/sorting.d:                    r.swapAt(parent, child);
algorithm/sorting.d:            r.swapAt(parent, child);
algorithm/sorting.d:                    r.swapAt(parent, child);
algorithm/sorting.d:            r.swapAt(parent, child);
algorithm/sorting.d:            r.swapAt(parent, child);
container/binaryheap.d:            swapAt(_store, parentIdx, n);
random.d:        swapAt(r, i, uniform(i, r.length, gen));
```