### PR TITLE
Suggest bracket-free template syntax in the doc of std.algorithm

### DIFF
--- a/std/algorithm/package.d
+++ b/std/algorithm/package.d
@@ -155,9 +155,9 @@ static bool greater(int a, int b)
 {
     return a > b;
 }
-sort!(greater)(a);         // predicate as alias
+sort!greater(a);           // predicate as alias
 sort!((a, b) => a > b)(a); // predicate as a lambda.
-sort!("a > b")(a);         // predicate as string
+sort!"a > b"(a);           // predicate as string
                            // (no ambiguity with array name)
 sort(a);                   // no predicate, "a < b" is implicit
 ----


### PR DESCRIPTION
AFAIK brackets for one argument were long a limitation of the compiler. While this doesn't hurt in the code base, it might be a nice idea to update the documentation, so that future code/users know about this feature ;-)