### PR TITLE
Small std.math fixes for ARM

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -5460,7 +5460,7 @@ real NaN(ulong payload) @trusted pure nothrow @nogc
     }
 }
 
-@safe pure nothrow @nogc unittest
+pure nothrow @nogc unittest
 {
     static if (floatTraits!(real).realFormat == RealFormat.ieeeDouble)
     {


### PR DESCRIPTION
* The SoftFloat floating point emulation doesn't support the IEEE flags.
* The unittest isn't `@safe` (taking address of a local variable + pointer cast)

Ping @kinke @redstar does LDC support the IEEE flags with floating point emulation?