### PR TITLE
Link from CONTRIBUTING.md to the new wiki contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,16 @@
 Guidelines for Contributing
 ===========================
 
-Welcome to the D community and thanks for your interest in contributing! To get started, please read the [Starting as a Contributor](http://wiki.dlang.org/Starting_as_a_Contributor) article on the D Wiki.
+Welcome to the D community and thanks for your interest in contributing!
+If this is your first pull request, please read [Contributing to Phobos](https://wiki.dlang.org/Contributing_to_Phobos).
+Have a look at [Starting as a Contributor](http://wiki.dlang.org/Starting_as_a_Contributor#Building_D) for build instructions.
 
 More Links
 ----------
 
 * Fork [on Github](https://github.com/D-Programming-Language/phobos)
 * Use our [Bugzilla bug tracker](http://d.puremagic.com/issues/)
-* Follow the [Styleguide](http://dlang.org/dstyle.html)
+* Follow the [D style](http://dlang.org/dstyle.html)
 * Participate in [our forum](http://forum.dlang.org/)
+* Ask questions on our `#d` IRC channel on freenode.org ([web interface](https://kiwiirc.com/client/irc.freenode.net/d))
 * Review Phobos additions in the [Review Queue](http://wiki.dlang.org/Review_Queue).


### PR DESCRIPTION
In reference to #4128, I propose to add a link to the new contribution guide.

It also fixes the typo of Styleguide and adds a link to the IRC channel.