### PR TITLE
std.uni.isNumber: significant performance increase for ASCII

### DIFF
--- a/std/uni.d
+++ b/std/uni.d
@@ -9108,7 +9108,15 @@ bool isMark(dchar c)
 @safe pure nothrow @nogc
 bool isNumber(dchar c)
 {
-    return numberTrie[c];
+    // optimization
+    if (c < 0xAA)
+    {
+        return c >= 48 && c <= 57;
+    }
+    else
+    {
+        return numberTrie[c];
+    }
 }
 
 @safe unittest


### PR DESCRIPTION
When testing the old version vs this version on `dchar a = '7';`, I got the following results for 1 million calls:

```
isNumber		85 ms, 914 μs, and 3 hnsecs
isNumber2		4 ms and 368 μs
```