### PR TITLE
Added staticSubset template

### DIFF
--- a/std/json.d
+++ b/std/json.d
@@ -808,7 +808,7 @@ if(isInputRange!T)
         }
     }
 
-    void parseValue(out JSONValue value)
+    void parseValue(ref JSONValue value)
     {
         depth++;
 

--- a/std/math.d
+++ b/std/math.d
@@ -6849,6 +6849,34 @@ private real polyImpl(real x, in real[] A) @trusted pure nothrow @nogc
                 ;
             }
         }
+        else version (Solaris)
+        {
+            asm pure nothrow @nogc // assembler by W. Bright
+            {
+                // EDX = (A.length - 1) * real.sizeof
+                mov     ECX,A[EBP]              ; // ECX = A.length
+                dec     ECX                     ;
+                lea     EDX,[ECX*8]             ;
+                lea     EDX,[EDX][ECX*4]        ;
+                add     EDX,A+4[EBP]            ;
+                fld     real ptr [EDX]          ; // ST0 = coeff[ECX]
+                jecxz   return_ST               ;
+                fld     x[EBP]                  ; // ST0 = x
+                fxch    ST(1)                   ; // ST1 = x, ST0 = r
+                align   4                       ;
+        L2:     fmul    ST,ST(1)                ; // r *= x
+                fld     real ptr -12[EDX]       ;
+                sub     EDX,12                  ; // deg--
+                faddp   ST(1),ST                ;
+                dec     ECX                     ;
+                jne     L2                      ;
+                fxch    ST(1)                   ; // ST1 = r, ST0 = x
+                fstp    ST(0)                   ; // dump x
+                align   4                       ;
+        return_ST:                              ;
+                ;
+            }
+        }
         else
         {
             static assert(0);

--- a/std/meta.d
+++ b/std/meta.d
@@ -1326,7 +1326,6 @@ private template staticMerge(alias cmp, int half, Seq...)
  */
 template staticSubset(alias range, T...)
 {
-	import std.range : isInputRange;
 	import std.traits : isArray, isNarrowString;
 
 	alias ArrT = typeof(range);
@@ -1341,14 +1340,18 @@ template staticSubset(alias range, T...)
 			alias staticSubset = AliasSeq!(T[range[0]], staticSubset!(range[1 .. $], T));
 		}
 	}
-	else static if (isInputRange!ArrT)
-	{
-		import std.array : array;
-		alias staticSubset = staticSubset!(array(range));
-	}
 	else
 	{
-		static assert(false, "Cannot transform " ~ range.stringof ~ " of type " ~ ArrT.stringof ~ " into a AliasSeq.");
+        import std.range.primitives : isInputRange;
+        static if(isInputRange!ArrT)
+        {
+            import std.array : array;
+            alias staticSubset = staticSubset!(array(range));
+        }
+        else
+        {
+            static assert(false, "Cannot index range of type " ~ ArrT.stringof ~ ".");
+        }
 	}
 }
 
@@ -1356,7 +1359,7 @@ template staticSubset(alias range, T...)
 unittest
 {
 	alias T1 = staticSubset!([0, 2, 1, 1, 2, 0], int, char, double);
-	static assert(is (T1 == AliasSeq!(int)));
+	static assert(is (T1 == AliasSeq!(int, double, char, char, double, int)));
 
 	alias T2 = staticSubset!([0, 2], int, char, double);
 	static assert(is (T2 == AliasSeq!(int, double)));

--- a/std/meta.d
+++ b/std/meta.d
@@ -1309,6 +1309,62 @@ private template staticMerge(alias cmp, int half, Seq...)
     }
 }
 
+/**
+ * Allows subsetting of alias sequence that are not
+ * necessarily adjacent to each other, i.e. cannot be sliced.
+ *
+ * Parameters:
+ *	range = a range object preferably an unsigned array to index T
+ *  T = a set of types to be indexed
+ *
+ * Returns: alias sequence of selected types
+ *
+ * Evaluates to `AliasSeq!(T[range[0]], T[range[1]], ..., T[range[n]])`.
+ *
+ * How:
+ * 		alias T1 = staticSubset!([0, 2, 1, 1, 2, 0], int, char, double);
+ */
+template staticSubset(alias range, T...)
+{
+	import std.range : isInputRange;
+	import std.traits : isArray, isNarrowString;
+
+	alias ArrT = typeof(range);
+	static if (isArray!ArrT && !isNarrowString!ArrT)
+	{
+		static if (range.length == 0)
+		{
+			alias staticSubset = AliasSeq!();
+		}
+		else
+		{
+			alias staticSubset = AliasSeq!(T[range[0]], staticSubset!(range[1 .. $], T));
+		}
+	}
+	else static if (isInputRange!ArrT)
+	{
+		import std.array : array;
+		alias staticSubset = staticSubset!(array(range));
+	}
+	else
+	{
+		static assert(false, "Cannot transform " ~ range.stringof ~ " of type " ~ ArrT.stringof ~ " into a AliasSeq.");
+	}
+}
+
+///
+unittest
+{
+	alias T1 = staticSubset!([0, 2, 1, 1, 2, 0], int, char, double);
+	static assert(is (T1 == AliasSeq!(int)));
+
+	alias T2 = staticSubset!([0, 2], int, char, double);
+	static assert(is (T2 == AliasSeq!(int, double)));
+
+	alias T3 = staticSubset!([1, 3, 5], int, char, double, string, ulong, dchar, size_t);
+	static assert(is (T3 == AliasSeq!(char, string, dchar)));
+}
+
 // : : : : : : : : : : : : : : : : : : : : : : : : : : : : : : : : : //
 private:
 

--- a/std/uni.d
+++ b/std/uni.d
@@ -9108,7 +9108,15 @@ bool isMark(dchar c)
 @safe pure nothrow @nogc
 bool isNumber(dchar c)
 {
-    return numberTrie[c];
+    // optimization
+    if (c < 0xAA)
+    {
+        return c >= 48 && c <= 57;
+    }
+    else
+    {
+        return numberTrie[c];
+    }
 }
 
 @safe unittest


### PR DESCRIPTION
The staticSubset template allows the subsetting of types for multiple indexes that are not necessarily contiguous