### PR TITLE
fix Issue 15872

### DIFF
--- a/std/experimental/ndslice/iteration.d
+++ b/std/experimental/ndslice/iteration.d
@@ -93,6 +93,7 @@ T4=$(TR $(TDNW $(LREF $1)) $(TD $2) $(TD $3) $(TD $4))
 module std.experimental.ndslice.iteration;
 
 import std.traits;
+import std.meta;
 
 import std.experimental.ndslice.internal;
 import std.experimental.ndslice.slice; //: Slice;
@@ -664,7 +665,7 @@ Returns:
 template strided(Dimensions...)
     if (Dimensions.length)
 {
-    auto strided(size_t N, Range)(Slice!(N, Range) slice, Repeat!(size_t, Dimensions.length) factors)
+    auto strided(size_t N, Range)(Slice!(N, Range) slice, Repeat!(Dimensions.length, size_t) factors)
     body
     {
         foreach (i, dimension; Dimensions)
@@ -1027,7 +1028,7 @@ Returns:
 template dropExactly(Dimensions...)
     if (Dimensions.length)
 {
-    Slice!(N, Range) dropExactly(size_t N, Range)(Slice!(N, Range) slice, Repeat!(size_t, Dimensions.length) ns)
+    Slice!(N, Range) dropExactly(size_t N, Range)(Slice!(N, Range) slice, Repeat!(Dimensions.length, size_t) ns)
     body
     {
         foreach (i, dimension; Dimensions)
@@ -1055,7 +1056,7 @@ body
 template dropBackExactly(Dimensions...)
     if (Dimensions.length)
 {
-    Slice!(N, Range) dropBackExactly(size_t N, Range)(Slice!(N, Range) slice, Repeat!(size_t, Dimensions.length) ns)
+    Slice!(N, Range) dropBackExactly(size_t N, Range)(Slice!(N, Range) slice, Repeat!(Dimensions.length, size_t) ns)
     body
     {
         foreach (i, dimension; Dimensions)
@@ -1116,7 +1117,7 @@ Returns:
 template drop(Dimensions...)
     if (Dimensions.length)
 {
-    Slice!(N, Range) drop(size_t N, Range)(Slice!(N, Range) slice, Repeat!(size_t, Dimensions.length) ns)
+    Slice!(N, Range) drop(size_t N, Range)(Slice!(N, Range) slice, Repeat!(Dimensions.length, size_t) ns)
     body
     {
         foreach (i, dimension; Dimensions)
@@ -1144,7 +1145,7 @@ body
 template dropBack(Dimensions...)
     if (Dimensions.length)
 {
-    Slice!(N, Range) dropBack(size_t N, Range)(Slice!(N, Range) slice, Repeat!(size_t, Dimensions.length) ns)
+    Slice!(N, Range) dropBack(size_t N, Range)(Slice!(N, Range) slice, Repeat!(Dimensions.length, size_t) ns)
     body
     {
         foreach (i, dimension; Dimensions)

--- a/std/experimental/ndslice/slice.d
+++ b/std/experimental/ndslice/slice.d
@@ -844,26 +844,17 @@ struct Slice(size_t _N, _Range)
         __traits(compiles, { auto a = &(_ptr[0]); } );
 
     enum PureIndexLength(Slices...) = Filter!(isIndex, Slices).length;
-    template isFullPureIndex(Indexes...)
-    {
-        static if (allSatisfy!(isIndex, Indexes))
-            enum isFullPureIndex  = Indexes.length == N;
-        else
-        static if (Indexes.length == 1 && isStaticArray!(Indexes[0]))
-            enum isFullPureIndex = Indexes[0].length == N && isIndex!(ForeachType!(Indexes[0]));
-        else
-            enum isFullPureIndex = false;
-    }
+
     enum isPureSlice(Slices...) =
            Slices.length <= N
         && PureIndexLength!Slices < N
-        && Filter!(isStaticArray, Slices).length == 0;
+        && allSatisfy!(templateOr!(isIndex, is_Slice), Slices);
 
     enum isFullPureSlice(Slices...) =
            Slices.length == 0
         || Slices.length == N
         && PureIndexLength!Slices < N
-        && Filter!(isStaticArray, Slices).length == 0;
+        && allSatisfy!(templateOr!(isIndex, is_Slice), Slices);
 
     size_t[PureN] _lengths;
     sizediff_t[PureN] _strides;
@@ -878,54 +869,25 @@ struct Slice(size_t _N, _Range)
         return _strides[dimension] * (_lengths[dimension] - 1);
     }
 
-    size_t indexStride(Indexes...)(Indexes _indexes)
-        if (isFullPureIndex!Indexes)
+    size_t indexStride(Indexes...)(Indexes _indexes) const
+        if (allSatisfy!(isIndex, Indexes))
     {
-        static if (isStaticArray!(Indexes[0]))
-        {
-            size_t stride;
-            foreach (i; Iota!(0, N)) //static
-            {
-                assert(_indexes[0][i] < _lengths[i], indexStrideAssertMsg!(i, N) ~ tailErrorMessage!());
-                stride += _strides[i] * _indexes[0][i];
-            }
-            return stride;
-        }
-        else
-        {
-            size_t stride;
-            foreach (i, index; _indexes) //static
-            {
-                assert(index < _lengths[i], indexStrideAssertMsg!(i, N) ~ tailErrorMessage!());
-                stride += _strides[i] * index;
-            }
-            return stride;
-        }
+        mixin(indexStrideCode);
     }
 
-    size_t mathIndexStride(Indexes...)(Indexes _indexes)
-        if (isFullPureIndex!Indexes)
+    size_t indexStride(size_t[N] _indexes) const
     {
-        static if (isStaticArray!(Indexes[0]))
-        {
-            size_t stride;
-            foreach_reverse (i; Iota!(0, N)) //static
-            {
-                assert(_indexes[0][i] < _lengths[N - 1 - i], indexStrideAssertMsg!(i, N) ~ tailErrorMessage!());
-                stride += _strides[N - 1 - i] * _indexes[0][i];
-            }
-            return stride;
-        }
-        else
-        {
-            size_t stride;
-            foreach_reverse (i, index; _indexes) //static
-            {
-                assert(index < _lengths[N - 1 - i], indexStrideAssertMsg!(i, N) ~ tailErrorMessage!());
-                stride += _strides[N - 1 - i] * index;
-            }
-            return stride;
-        }
+        mixin(indexStrideCode);
+    }
+
+    size_t mathIndexStride(Indexes...)(Indexes _indexes) const
+    {
+        mixin(mathIndexStrideCode);
+    }
+
+    size_t mathIndexStride(size_t[N] _indexes) const
+    {
+        mixin(mathIndexStrideCode);
     }
 
     this(ref in size_t[PureN] lengths, ref in sizediff_t[PureN] strides, PureRange range)
@@ -1461,8 +1423,7 @@ struct Slice(size_t _N, _Range)
     /++
     $(BLUE Fully defined index).
     +/
-    auto ref opIndex(Indexes...)(Indexes _indexes)
-        if (isFullPureIndex!Indexes)
+    auto ref opIndex(Repeat!(N, size_t) _indexes)
     {
         static if (PureN == N)
             return _ptr[indexStride(_indexes)];
@@ -1471,8 +1432,25 @@ struct Slice(size_t _N, _Range)
     }
 
     ///ditto
-    auto ref opCall(Indexes...)(Indexes _indexes)
-        if (isFullPureIndex!Indexes)
+    auto ref opIndex(size_t[N] _indexes)
+    {
+        static if (PureN == N)
+            return _ptr[indexStride(_indexes)];
+        else
+            return DeepElemType(_lengths[N .. $], _strides[N .. $], _ptr + indexStride(_indexes));
+    }
+
+    ///ditto
+    auto ref opCall(Repeat!(N, size_t) _indexes)
+    {
+        static if (PureN == N)
+            return _ptr[mathIndexStride(_indexes)];
+        else
+            return DeepElemType(_lengths[N .. $], _strides[N .. $], _ptr + mathIndexStride(_indexes));
+    }
+
+    ///ditto
+    auto ref opCall(size_t[N] _indexes)
     {
         static if (PureN == N)
             return _ptr[mathIndexStride(_indexes)];
@@ -1816,8 +1794,13 @@ struct Slice(size_t _N, _Range)
         /++
         Assignment of a value (e.g. a number) to a $(BLUE fully defined index).
         +/
-        auto ref opIndexAssign(T, Indexes...)(T value, Indexes _indexes)
-            if (isFullPureIndex!Indexes)
+        auto ref opIndexAssign(T)(T value, Repeat!(N, size_t) _indexes)
+        {
+            return _ptr[indexStride(_indexes)] = value;
+        }
+
+        /// ditto
+        auto ref opIndexAssign(T)(T value, size_t[N] _indexes)
         {
             return _ptr[indexStride(_indexes)] = value;
         }
@@ -1841,11 +1824,34 @@ struct Slice(size_t _N, _Range)
             assert(a[1, 2] == 3);
         }
 
+        static if (doUnittest)
+        pure nothrow unittest
+        {
+            auto a = new int[6].sliced(2, 3);
+
+            a[[1, 2]] = 3;
+            assert(a[[1, 2]] == 3);
+        }
+
+        static if (doUnittest)
+        pure nothrow unittest
+        {
+            auto a = new int[6].sliced!(No.replaceArrayWithPointer)(2, 3);
+
+            a[[1, 2]] = 3;
+            assert(a[[1, 2]] == 3);
+        }
+
         /++
         Op Assignment `op=` of a value (e.g. a number) to a $(BLUE fully defined index).
         +/
-        auto ref opIndexOpAssign(string op, T, Indexes...)(T value, Indexes _indexes)
-            if (isFullPureIndex!Indexes)
+        auto ref opIndexOpAssign(string op, T)(T value, Repeat!(N, size_t) _indexes)
+        {
+            mixin (`return _ptr[indexStride(_indexes)] ` ~ op ~ `= value;`);
+        }
+
+        /// ditto
+        auto ref opIndexOpAssign(string op, T)(T value, size_t[N] _indexes)
         {
             mixin (`return _ptr[indexStride(_indexes)] ` ~ op ~ `= value;`);
         }
@@ -1863,10 +1869,28 @@ struct Slice(size_t _N, _Range)
         static if (doUnittest)
         pure nothrow unittest
         {
+            auto a = new int[6].sliced(2, 3);
+
+            a[[1, 2]] += 3;
+            assert(a[[1, 2]] == 3);
+        }
+
+        static if (doUnittest)
+        pure nothrow unittest
+        {
             auto a = new int[6].sliced!(No.replaceArrayWithPointer)(2, 3);
 
             a[1, 2] += 3;
             assert(a[1, 2] == 3);
+        }
+
+        static if (doUnittest)
+        pure nothrow unittest
+        {
+            auto a = new int[6].sliced!(No.replaceArrayWithPointer)(2, 3);
+
+            a[[1, 2]] += 3;
+            assert(a[[1, 2]] == 3);
         }
 
         /++
@@ -2011,8 +2035,15 @@ struct Slice(size_t _N, _Range)
         /++
         Increment `++` and Decrement `--` operators for a $(BLUE fully defined index).
         +/
-        auto ref opIndexUnary(string op, Indexes...)(Indexes _indexes)
-            if (isFullPureIndex!Indexes && (op == `++` || op == `--`))
+        auto ref opIndexUnary(string op)(Repeat!(N, size_t) _indexes)
+            if (op == `++` || op == `--`)
+        {
+            mixin (`return ` ~ op ~ `_ptr[indexStride(_indexes)];`);
+        }
+
+        ///ditto
+        auto ref opIndexUnary(string op)(size_t[N] _indexes)
+            if (op == `++` || op == `--`)
         {
             mixin (`return ` ~ op ~ `_ptr[indexStride(_indexes)];`);
         }
@@ -2034,6 +2065,24 @@ struct Slice(size_t _N, _Range)
 
             ++a[1, 2];
             assert(a[1, 2] == 1);
+        }
+
+        static if (doUnittest)
+        pure nothrow unittest
+        {
+            auto a = new int[6].sliced(2, 3);
+
+            ++a[[1, 2]];
+            assert(a[[1, 2]] == 1);
+        }
+
+        static if (doUnittest)
+        pure nothrow unittest
+        {
+            auto a = new int[6].sliced!(No.replaceArrayWithPointer)(2, 3);
+
+            ++a[[1, 2]];
+            assert(a[[1, 2]] == 1);
         }
 
         /++
@@ -2085,7 +2134,6 @@ struct Slice(size_t _N, _Range)
         }
     }
 }
-
 
 /++
 Slicing, indexing, and arithmetic operations.


### PR DESCRIPTION
Description:
Slices accept static array type of `size_t[N]` as multidimensional index. So this PR fix it for cases like `slice[[1, 2, 3]]`, so it allows automatic type conversion for `[1, 2, 3]` to type `size_t[3]`.