### PR TITLE
Fix issue 12227 - Allow matching multiple patterns in one go with std.regex

### DIFF
--- a/std/regex/internal/ir.d
+++ b/std/regex/internal/ir.d
@@ -15,6 +15,8 @@ debug(std_regex_parser) import std.stdio;
 // just a common trait, may be moved elsewhere
 alias BasicElementOf(Range) = Unqual!(ElementEncodingType!Range);
 
+enum privateUseStart = '\U000F0000', privateUseEnd ='\U000FFFFD';
+
 // heuristic value determines maximum CodepointSet length suitable for linear search
 enum maxCharsetUsed = 6;
 


### PR DESCRIPTION
A long awaited feature is in. The helpers for matchFirst/matchAll etc. are not provided but regex can now be constructed with a array of patterns more or less following the API outlined.