### PR TITLE
Fix issue 12367 - std.regex: Recognize (?# ... ) comment syntax

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -10,6 +10,7 @@ $(BUGSTITLE Library Changes,
     $(LI $(XREF range, padLeft) and $(XREF range, padRight) were added.)
     $(LI $(XREF uni, isAlphaNum), which is analogous to $(XREF ascii, isAlphaNum)
         was added.)
+    $(LI $(XREF regex, regex) now supports inline comments with (?#...) syntax.
 )
 
 $(BUGSTITLE Library Changes,

--- a/std/regex/internal/parser.d
+++ b/std/regex/internal/parser.d
@@ -432,6 +432,20 @@ struct Parser(R)
                     next();
                     switch(current)
                     {
+                    case '#':
+                        nesting--;
+                        fixupStack.pop();
+                        for(;;)
+                        {
+                            if(!next())
+                                error("Unexpected end of pattern");
+                            if(current == ')')
+                            {
+                                next();
+                                break;
+                            }
+                        }
+                        break;
                     case ':':
                         put(Bytecode(IR.Nop, 0));
                         next();

--- a/std/regex/internal/tests.d
+++ b/std/regex/internal/tests.d
@@ -1003,3 +1003,10 @@ unittest
     auto rx = regex("[c d]", "x");
     assert("a b".matchFirst(rx));
 }
+
+unittest
+{
+    auto r = regex("(?# comment)abc(?# comment2)");
+    assert("abc".matchFirst(r));
+    assertThrown(regex("(?#..."));
+}

--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -128,6 +128,7 @@
     $(REG_TITLE Other, Subexpressions $(AMP) alternations )
     $(REG_ROW (regex),  Matches subexpression regex,
       saving matched portion of text for later retrieval. )
+    $(REG_ROW (?#comment), An inline comment that is ignored while matching.)
     $(REG_ROW (?:regex), Matches subexpression regex,
       $(U not) saving matched portion of text. Useful to speed up matching. )
     $(REG_ROW A|B, Matches subexpression A, or failing that, matches B. )


### PR DESCRIPTION
Adds hackish comment syntax that's supported by a lot of regex engines.