### PR TITLE
Fix issue 15773 - D's treatment of whitespace in character classes in…

### DIFF
--- a/std/regex/internal/parser.d
+++ b/std/regex/internal/parser.d
@@ -1082,6 +1082,14 @@ struct Parser(R)
     //parse and store IR for CodepointSet
     void parseCharset()
     {
+        auto save = re_flags;
+        re_flags &= ~RegexOption.freeform; // stop ignoring whitespace if we did
+        parseCharsetImpl();
+        re_flags = save;
+    }
+
+    void parseCharsetImpl()
+    {
         ValStack vstack;
         OpStack opstack;
         import std.functional : unaryFun;

--- a/std/regex/internal/tests.d
+++ b/std/regex/internal/tests.d
@@ -997,3 +997,9 @@ unittest
     assert(sink.data == "Hello, world!Hello, world!");
 }
 
+// bugzilla 15573
+unittest
+{
+    auto rx = regex("[c d]", "x");
+    assert("a b".matchFirst(rx));
+}


### PR DESCRIPTION
… free-form regexes is not the same as Perl's.