### PR TITLE
Add Redirect.none to std.process

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -1887,6 +1887,9 @@ Use bitwise OR to combine flags.
 */
 enum Redirect
 {
+    /// Redirect nothing.
+    none = 0,
+
     /// Redirect the standard input, output or error streams, respectively.
     stdin = 1,
     stdout = 2,                             /// ditto


### PR DESCRIPTION
While this use-case is satisfied by spawnProcess, this is useful for consistency reasons (ensuring the spectrum of redirection is covered) and making user refactoring easy (switching between pipeProcess and spawnProcess changes return type).